### PR TITLE
Fail active HTTP/2 streams when the connection closes

### DIFF
--- a/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
@@ -34,7 +34,7 @@ public class ConnectionFlowControl {
     private final BiConsumer<Integer, Http2WindowUpdate> windowUpdateWriter;
     private final Duration timeout;
     private final WindowSize.Inbound inboundConnectionWindowSize;
-    private final WindowSize.Outbound outboundConnectionWindowSize;
+    private final WindowSizeImpl.Outbound outboundConnectionWindowSize;
 
     private volatile int maxFrameSize = WindowSize.DEFAULT_MAX_FRAME_SIZE;
     private volatile int initialWindowSize = WindowSize.DEFAULT_WIN_SIZE;
@@ -53,8 +53,7 @@ public class ConnectionFlowControl {
                                          initialWindowSize,
                                          maxFrameSize,
                                          windowUpdateWriter);
-        outboundConnectionWindowSize =
-                WindowSize.createOutbound(type, 0, this);
+        outboundConnectionWindowSize = new WindowSizeImpl.Outbound(type, 0, this);
     }
 
     /**
@@ -161,6 +160,10 @@ public class ConnectionFlowControl {
      */
     public WindowSize.Outbound outbound() {
         return outboundConnectionWindowSize;
+    }
+
+    void connectionClosed() {
+        outboundConnectionWindowSize.connectionClosed();
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
@@ -100,6 +100,14 @@ public interface FlowControl {
         void blockTillUpdate();
 
         /**
+         * Notify flow control that the connection has closed.
+         * <p>
+         * Releases threads blocked waiting for a window update.
+         */
+        default void connectionClosed() {
+        }
+
+        /**
          * MAX_FRAME_SIZE setting last received from the other side or default.
          * @return MAX_FRAME_SIZE
          */

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
@@ -135,7 +135,7 @@ abstract class FlowControlImpl implements FlowControl {
 
         private final ConnectionFlowControl.Type type;
         private final ConnectionFlowControl connectionFlowControl;
-        private final WindowSize.Outbound streamWindowSize;
+        private final WindowSizeImpl.Outbound streamWindowSize;
 
         Outbound(ConnectionFlowControl.Type type,
                  int streamId,
@@ -143,7 +143,7 @@ abstract class FlowControlImpl implements FlowControl {
             super(streamId);
             this.type = type;
             this.connectionFlowControl = connectionFlowControl;
-            this.streamWindowSize = WindowSize.createOutbound(type, streamId, connectionFlowControl);
+            this.streamWindowSize = new WindowSizeImpl.Outbound(type, streamId, connectionFlowControl);
         }
 
         @Override
@@ -188,6 +188,12 @@ abstract class FlowControlImpl implements FlowControl {
         public void blockTillUpdate() {
             connectionFlowControl.outbound().blockTillUpdate();
             streamWindowSize.blockTillUpdate();
+        }
+
+        @Override
+        public void connectionClosed() {
+            connectionFlowControl.connectionClosed();
+            streamWindowSize.connectionClosed();
         }
 
         @Override

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -134,6 +134,7 @@ abstract class WindowSizeImpl implements WindowSize {
         private final ConnectionFlowControl.Type type;
         private final int streamId;
         private final long timeoutMillis;
+        private boolean connectionClosed;
 
         Outbound(ConnectionFlowControl.Type type, int streamId, ConnectionFlowControl connectionFlowControl) {
             super(type, streamId, connectionFlowControl.initialWindowSize());
@@ -185,6 +186,16 @@ abstract class WindowSizeImpl implements WindowSize {
             }
         }
 
+        void connectionClosed() {
+            updateLock.lock();
+            try {
+                connectionClosed = true;
+                updated.signalAll();
+            } finally {
+                updateLock.unlock();
+            }
+        }
+
         @Override
         public void blockTillUpdate() {
             var startTime = System.nanoTime();
@@ -195,6 +206,10 @@ abstract class WindowSizeImpl implements WindowSize {
                     boolean waiting;
                     updateLock.lock();
                     try {
+                        if (connectionClosed) {
+                            throw new Http2Exception(Http2ErrorCode.CANCEL,
+                                                     "Connection closed while waiting for a flow control update.");
+                        }
                         // Updates acquire this lock, so the predicate check and await enrollment are atomic.
                         int remainingWindowSize = getRemainingWindowSize();
                         long elapsedNanos = System.nanoTime() - startTime;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -582,7 +582,8 @@ public class Http2ClientConnection {
             try {
                 closeTransport();
             } finally {
-                failedStreams.forEach(stream -> stream.completeTrailersFailure(actualFailure));
+                failedStreams.forEach(stream ->
+                        Thread.startVirtualThread(() -> stream.completeTrailersFailure(actualFailure)));
             }
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -516,7 +516,10 @@ public class Http2ClientConnection {
             closeConnection(failure);
             return;
         }
-        closeOrderingLock.lock();
+        if (!closeOrderingLock.tryLock()) {
+            closeConnection(failure);
+            return;
+        }
         try {
             closeFailure.compareAndSet(null, failure);
             Http2ErrorCode errorCode = failure instanceof Http2Exception http2Exception

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -108,6 +108,7 @@ public class Http2ClientConnection {
     private final ReentrantLock reservedStreamsLock = new ReentrantLock();
     private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
+    private final AtomicReference<RuntimeException> closeFailure = new AtomicReference<>();
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
     private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
@@ -275,6 +276,13 @@ public class Http2ClientConnection {
                 .writeInt64(pingId);
     }
 
+    private static RuntimeException connectionFailure(Throwable failure) {
+        if (failure instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return new IllegalStateException("HTTP/2 connection failed", failure);
+    }
+
     Http2ConnectionWriter writer() {
         return writer;
     }
@@ -362,12 +370,25 @@ public class Http2ClientConnection {
      * @param stream the stream
      */
     public void addStream(int streamId, Http2ClientStream stream) {
+        RuntimeException failure = null;
         Lock lock = streamsLock.writeLock();
         lock.lock();
         try {
-            this.streams.put(streamId, stream);
+            State currentState = state.get();
+            if (currentState == State.CLOSED || currentState == State.GO_AWAY) {
+                failure = closeFailure.get();
+                if (failure == null) {
+                    failure = new IllegalStateException("HTTP/2 connection is closed");
+                }
+            } else {
+                this.streams.put(streamId, stream);
+            }
         } finally {
             lock.unlock();
+        }
+        if (failure != null) {
+            stream.connectionClosed(failure);
+            throw failure;
         }
     }
 
@@ -459,23 +480,13 @@ public class Http2ClientConnection {
      * Closes this connection.
      */
     public void close() {
-        initialSettingsLatch.countDown();
-        if (!clientPrefaceSent) {
-            closeConnection();
-            return;
-        }
-        try {
-            this.goAway(0, Http2ErrorCode.NO_ERROR, "Closing connection");
-        } catch (Throwable e) {
-            ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY before closing connection.", e);
-        }
-        closeConnection();
+        close(new IllegalStateException("HTTP/2 connection is closed"));
     }
 
     void retire() {
         initialSettingsLatch.countDown();
         if (!clientPrefaceSent) {
-            closeConnection();
+            closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
             return;
         }
         reservedStreamsLock.lock();
@@ -494,24 +505,68 @@ public class Http2ClientConnection {
      */
     @Api.Internal
     public void closeNow() {
-        initialSettingsLatch.countDown();
-        closeConnection();
+        closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
     }
 
-    private void closeConnection() {
-        if (state.getAndSet(State.CLOSED) != State.CLOSED) {
-            try {
-                if (handleTask != null) {
-                    handleTask.cancel(true);
-                }
-                ctx.log(LOGGER, TRACE, "Closing connection");
-                connection.closeResource();
-            } catch (Throwable e) {
-                ctx.log(LOGGER, TRACE, "Failed to close HTTP/2 connection.", e);
-            } finally {
-                closeListener.accept(this);
-            }
+    private void close(RuntimeException failure) {
+        initialSettingsLatch.countDown();
+        if (!clientPrefaceSent) {
+            closeConnection(failure);
+            return;
         }
+        try {
+            Http2ErrorCode errorCode = failure instanceof Http2Exception http2Exception
+                    ? http2Exception.code()
+                    : Http2ErrorCode.NO_ERROR;
+            // A protocol error must put GOAWAY on the wire before a failed request can make its caller exit.
+            this.goAway(0, errorCode, failure.getMessage());
+        } catch (Throwable e) {
+            ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY before closing connection.", e);
+        } finally {
+            closeConnection(failure);
+        }
+    }
+
+    private void closeConnection(RuntimeException failure) {
+        if (beginClose(failure)) {
+            closeTransport();
+        }
+    }
+
+    private boolean beginClose(RuntimeException failure) {
+        initialSettingsLatch.countDown();
+        closeFailure.compareAndSet(null, failure);
+        if (state.getAndSet(State.CLOSED) == State.CLOSED) {
+            return false;
+        }
+        failActiveStreams(closeFailure.get());
+        return true;
+    }
+
+    private void closeTransport() {
+        try {
+            if (handleTask != null) {
+                handleTask.cancel(true);
+            }
+            ctx.log(LOGGER, TRACE, "Closing connection");
+            connection.closeResource();
+        } catch (Throwable e) {
+            ctx.log(LOGGER, TRACE, "Failed to close HTTP/2 connection.", e);
+        } finally {
+            closeListener.accept(this);
+        }
+    }
+
+    private void failActiveStreams(RuntimeException failure) {
+        List<Http2ClientStream> activeStreams;
+        Lock lock = streamsLock.readLock();
+        lock.lock();
+        try {
+            activeStreams = List.copyOf(streams.values());
+        } finally {
+            lock.unlock();
+        }
+        activeStreams.forEach(stream -> stream.connectionClosed(failure));
     }
 
     private void finishRetirement() {
@@ -527,7 +582,7 @@ public class Http2ClientConnection {
         } catch (Throwable e) {
             ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY while retiring connection.", e);
         } finally {
-            closeConnection();
+            closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
         }
     }
 
@@ -602,14 +657,19 @@ public class Http2ClientConnection {
             try {
                 while (!Thread.interrupted()) {
                     if (!handle()) {
-                        this.close();
+                        closeConnection(new IllegalStateException("HTTP/2 connection closed while reading a response"));
                         ctx.log(LOGGER, TRACE, "Connection closed");
                         return;
                     }
                 }
                 ctx.log(LOGGER, TRACE, "Client listener interrupted");
             } catch (Throwable t) {
-                this.close();
+                RuntimeException failure = connectionFailure(t);
+                if (failure instanceof Http2Exception) {
+                    close(failure);
+                } else {
+                    closeConnection(failure);
+                }
                 ctx.log(LOGGER, DEBUG, "Failed to handle HTTP/2 client connection", t);
             }
         });
@@ -825,7 +885,8 @@ public class Http2ClientConnection {
         Http2GoAway http2GoAway = Http2GoAway.create(data);
         recvListener.frameHeader(ctx, streamId, frameHeader);
         recvListener.frame(ctx, streamId, http2GoAway);
-        this.close();
+        closeConnection(new Http2Exception(http2GoAway.errorCode(),
+                                           "Connection closed by remote peer, last stream: " + http2GoAway.lastStreamId()));
         ctx.log(LOGGER, TRACE, "Connection closed by remote peer, error code: %s, last stream: %d",
                 http2GoAway.errorCode(),
                 http2GoAway.lastStreamId());

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -525,9 +525,8 @@ public class Http2ClientConnection {
             Http2ErrorCode errorCode = failure instanceof Http2Exception http2Exception
                     ? http2Exception.code()
                     : Http2ErrorCode.NO_ERROR;
-            // A normal close must reach the transport to break an in-flight retirement GOAWAY write.
-            if (errorCode == Http2ErrorCode.NO_ERROR
-                    && state.get() == State.RETIREMENT_GO_AWAY
+            // Closing must reach the transport to break an in-flight retirement GOAWAY write.
+            if (state.get() == State.RETIREMENT_GO_AWAY
                     && goAwayWriteComplete.getCount() != 0) {
                 return;
             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -785,6 +785,9 @@ public class Http2ClientConnection {
     }
 
     private void writeWindowsUpdate(int streamId, Http2WindowUpdate windowUpdateFrame) {
+        if (state.get() == State.CLOSED) {
+            return;
+        }
         if (streamId == 0) {
             writer.write(windowUpdateFrame.toFrameData(serverSettings, streamId, Http2Flag.NoFlags.create()));
             return;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -528,6 +528,7 @@ public class Http2ClientConnection {
             // A normal close must reach the transport to break an in-flight retirement GOAWAY write.
             if (errorCode == Http2ErrorCode.NO_ERROR
                     && state.get() == State.GO_AWAY
+                    && goAwayErrorCode.get() == Http2ErrorCode.NO_ERROR
                     && goAwayWriteComplete.getCount() != 0) {
                 return;
             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -386,10 +386,10 @@ public class Http2ClientConnection {
             lock.unlock();
         }
         if (failure != null) {
-            if (awaitGoAway) {
-                awaitGoAwayWrite(failure);
+            if (awaitGoAway && !awaitGoAwayWrite(failure, stream.readTimeout())) {
+                closeNow();
             }
-            stream.connectionClosed(failure);
+            stream.connectionClosedBeforeRegistration(failure);
             throw failure;
         }
     }
@@ -535,12 +535,21 @@ public class Http2ClientConnection {
         }
     }
 
-    private void awaitGoAwayWrite(RuntimeException failure) {
+    private boolean awaitGoAwayWrite(RuntimeException failure, Duration timeout) {
         CountDownLatch writeComplete = failure instanceof Http2Exception http2Exception
                 && http2Exception.code() != Http2ErrorCode.NO_ERROR
                 ? errorGoAwayWriteComplete
                 : goAwayWriteComplete;
-        await(writeComplete);
+        try {
+            if (timeout.isZero() || timeout.isNegative()) {
+                writeComplete.await();
+                return true;
+            }
+            return writeComplete.await(timeout.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     private void await(CountDownLatch latch) {
@@ -1129,7 +1138,6 @@ public class Http2ClientConnection {
         try {
             headerStream.inboundHeaders(headers, endOfStream);
         } catch (Http2Exception e) {
-            headerStream.close();
             headerStream.reset(e.code());
             throw e;
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -373,8 +373,8 @@ public class Http2ClientConnection {
         lock.lock();
         try {
             State currentState = state.get();
-            if (currentState == State.CLOSED || currentState == State.GO_AWAY) {
-                awaitGoAway = currentState == State.GO_AWAY;
+            if (currentState == State.CLOSED || currentState.goAway()) {
+                awaitGoAway = currentState.goAway();
                 failure = closeFailure.get();
                 if (failure == null) {
                     failure = new IllegalStateException("HTTP/2 connection is closed");
@@ -527,8 +527,7 @@ public class Http2ClientConnection {
                     : Http2ErrorCode.NO_ERROR;
             // A normal close must reach the transport to break an in-flight retirement GOAWAY write.
             if (errorCode == Http2ErrorCode.NO_ERROR
-                    && state.get() == State.GO_AWAY
-                    && goAwayErrorCode.get() == Http2ErrorCode.NO_ERROR
+                    && state.get() == State.RETIREMENT_GO_AWAY
                     && goAwayWriteComplete.getCount() != 0) {
                 return;
             }
@@ -627,7 +626,7 @@ public class Http2ClientConnection {
     }
 
     private void finishRetirement() {
-        if (!state.compareAndSet(State.RETIRING, State.GO_AWAY)) {
+        if (!state.compareAndSet(State.RETIRING, State.RETIREMENT_GO_AWAY)) {
             return;
         }
         goAwayErrorCode.compareAndSet(null, Http2ErrorCode.NO_ERROR);
@@ -1201,7 +1200,7 @@ public class Http2ClientConnection {
                     errorGoAwayWriteComplete.countDown();
                 }
             }
-        } else if (state.get() == State.GO_AWAY) {
+        } else if (state.get().goAway()) {
             await(goAwayWriteComplete);
             if (errorCode != Http2ErrorCode.NO_ERROR) {
                 if (goAwayErrorCode.compareAndSet(Http2ErrorCode.NO_ERROR, errorCode)) {
@@ -1226,6 +1225,7 @@ public class Http2ClientConnection {
     private enum State {
         CLOSED(true),
         GO_AWAY(true),
+        RETIREMENT_GO_AWAY(true),
         RETIRING(true),
         OPEN(false);
 
@@ -1237,6 +1237,10 @@ public class Http2ClientConnection {
 
         boolean closed() {
             return closed;
+        }
+
+        boolean goAway() {
+            return this == GO_AWAY || this == RETIREMENT_GO_AWAY;
         }
     }
 

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -106,9 +106,13 @@ public class Http2ClientConnection {
     private final Http2ClientConfig clientConfig;
     private final boolean clearReadTimeoutAfterInitialSettings;
     private final ReentrantLock reservedStreamsLock = new ReentrantLock();
+    private final ReentrantLock closeOrderingLock = new ReentrantLock();
     private final CountDownLatch initialSettingsLatch = new CountDownLatch(1);
+    private final CountDownLatch goAwayWriteComplete = new CountDownLatch(1);
+    private final CountDownLatch errorGoAwayWriteComplete = new CountDownLatch(1);
     private final AtomicReference<State> state = new AtomicReference<>(State.OPEN);
     private final AtomicReference<RuntimeException> closeFailure = new AtomicReference<>();
+    private final AtomicReference<Http2ErrorCode> goAwayErrorCode = new AtomicReference<>();
     private volatile int lastStreamId;
     private volatile long expectedPingAck = NO_PING_ACK;
     private volatile long peerMaxConcurrentStreams = Http2Setting.MAX_CONCURRENT_STREAMS.defaultValue();
@@ -276,13 +280,6 @@ public class Http2ClientConnection {
                 .writeInt64(pingId);
     }
 
-    private static RuntimeException connectionFailure(Throwable failure) {
-        if (failure instanceof RuntimeException runtimeException) {
-            return runtimeException;
-        }
-        return new IllegalStateException("HTTP/2 connection failed", failure);
-    }
-
     Http2ConnectionWriter writer() {
         return writer;
     }
@@ -371,11 +368,13 @@ public class Http2ClientConnection {
      */
     public void addStream(int streamId, Http2ClientStream stream) {
         RuntimeException failure = null;
+        boolean awaitGoAway = false;
         Lock lock = streamsLock.writeLock();
         lock.lock();
         try {
             State currentState = state.get();
             if (currentState == State.CLOSED || currentState == State.GO_AWAY) {
+                awaitGoAway = currentState == State.GO_AWAY;
                 failure = closeFailure.get();
                 if (failure == null) {
                     failure = new IllegalStateException("HTTP/2 connection is closed");
@@ -387,6 +386,9 @@ public class Http2ClientConnection {
             lock.unlock();
         }
         if (failure != null) {
+            if (awaitGoAway) {
+                awaitGoAwayWrite(failure);
+            }
             stream.connectionClosed(failure);
             throw failure;
         }
@@ -514,7 +516,9 @@ public class Http2ClientConnection {
             closeConnection(failure);
             return;
         }
+        closeOrderingLock.lock();
         try {
+            closeFailure.compareAndSet(null, failure);
             Http2ErrorCode errorCode = failure instanceof Http2Exception http2Exception
                     ? http2Exception.code()
                     : Http2ErrorCode.NO_ERROR;
@@ -523,24 +527,55 @@ public class Http2ClientConnection {
         } catch (Throwable e) {
             ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY before closing connection.", e);
         } finally {
-            closeConnection(failure);
+            try {
+                closeConnection(failure);
+            } finally {
+                closeOrderingLock.unlock();
+            }
+        }
+    }
+
+    private void awaitGoAwayWrite(RuntimeException failure) {
+        CountDownLatch writeComplete = failure instanceof Http2Exception http2Exception
+                && http2Exception.code() != Http2ErrorCode.NO_ERROR
+                ? errorGoAwayWriteComplete
+                : goAwayWriteComplete;
+        await(writeComplete);
+    }
+
+    private void await(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (latch.getCount() != 0) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 
     private void closeConnection(RuntimeException failure) {
-        if (beginClose(failure)) {
-            closeTransport();
+        List<Http2ClientStream> failedStreams = beginClose(failure);
+        if (failedStreams != null) {
+            RuntimeException actualFailure = closeFailure.get();
+            try {
+                closeTransport();
+            } finally {
+                failedStreams.forEach(stream -> stream.completeTrailersFailure(actualFailure));
+            }
         }
     }
 
-    private boolean beginClose(RuntimeException failure) {
+    private List<Http2ClientStream> beginClose(RuntimeException failure) {
         initialSettingsLatch.countDown();
         closeFailure.compareAndSet(null, failure);
         if (state.getAndSet(State.CLOSED) == State.CLOSED) {
-            return false;
+            return null;
         }
-        failActiveStreams(closeFailure.get());
-        return true;
+        return failActiveStreams(closeFailure.get());
     }
 
     private void closeTransport() {
@@ -557,7 +592,7 @@ public class Http2ClientConnection {
         }
     }
 
-    private void failActiveStreams(RuntimeException failure) {
+    private List<Http2ClientStream> failActiveStreams(RuntimeException failure) {
         List<Http2ClientStream> activeStreams;
         Lock lock = streamsLock.readLock();
         lock.lock();
@@ -566,23 +601,28 @@ public class Http2ClientConnection {
         } finally {
             lock.unlock();
         }
+        activeStreams.forEach(stream -> stream.recordConnectionFailure(failure));
         activeStreams.forEach(stream -> stream.connectionClosed(failure));
+        return activeStreams;
     }
 
     private void finishRetirement() {
         if (!state.compareAndSet(State.RETIRING, State.GO_AWAY)) {
             return;
         }
+        goAwayErrorCode.compareAndSet(null, Http2ErrorCode.NO_ERROR);
         try {
-            Http2Settings http2Settings = Http2Settings.create();
-            Http2GoAway frame = new Http2GoAway(0,
-                                                Http2ErrorCode.NO_ERROR,
-                                                "Connection target retired");
-            writer.write(frame.toFrameData(http2Settings, 0, Http2Flag.NoFlags.create()));
+            writeGoAway(0, Http2ErrorCode.NO_ERROR, "Connection target retired");
         } catch (Throwable e) {
             ctx.log(LOGGER, TRACE, "Failed to send HTTP/2 GOAWAY while retiring connection.", e);
         } finally {
-            closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
+            goAwayWriteComplete.countDown();
+            closeOrderingLock.lock();
+            try {
+                closeConnection(new IllegalStateException("HTTP/2 connection is closed"));
+            } finally {
+                closeOrderingLock.unlock();
+            }
         }
     }
 
@@ -664,11 +704,18 @@ public class Http2ClientConnection {
                 }
                 ctx.log(LOGGER, TRACE, "Client listener interrupted");
             } catch (Throwable t) {
-                RuntimeException failure = connectionFailure(t);
-                if (failure instanceof Http2Exception) {
-                    close(failure);
-                } else {
+                RuntimeException failure = t instanceof RuntimeException runtimeException
+                        ? runtimeException
+                        : new IllegalStateException("HTTP/2 connection failed", t);
+                if (failure instanceof DataReader.InsufficientDataAvailableException
+                        || failure instanceof UncheckedIOException) {
                     closeConnection(failure);
+                } else {
+                    close(failure instanceof Http2Exception
+                                  ? failure
+                                  : new Http2Exception(Http2ErrorCode.INTERNAL,
+                                                       "HTTP/2 connection failed while processing a peer frame",
+                                                       failure));
                 }
                 ctx.log(LOGGER, DEBUG, "Failed to handle HTTP/2 client connection", t);
             }
@@ -885,8 +932,8 @@ public class Http2ClientConnection {
         Http2GoAway http2GoAway = Http2GoAway.create(data);
         recvListener.frameHeader(ctx, streamId, frameHeader);
         recvListener.frame(ctx, streamId, http2GoAway);
-        closeConnection(new Http2Exception(http2GoAway.errorCode(),
-                                           "Connection closed by remote peer, last stream: " + http2GoAway.lastStreamId()));
+        close(new Http2Exception(http2GoAway.errorCode(),
+                                 "Connection closed by remote peer, last stream: " + http2GoAway.lastStreamId()));
         ctx.log(LOGGER, TRACE, "Connection closed by remote peer, error code: %s, last stream: %d",
                 http2GoAway.errorCode(),
                 http2GoAway.lastStreamId());
@@ -1121,11 +1168,37 @@ public class Http2ClientConnection {
     }
 
     private void goAway(int streamId, Http2ErrorCode errorCode, String msg) {
-        if (state.compareAndSet(State.OPEN, State.GO_AWAY)) {
-            Http2Settings http2Settings = Http2Settings.create();
-            Http2GoAway frame = new Http2GoAway(streamId, errorCode, msg);
-            writer.write(frame.toFrameData(http2Settings, 0, Http2Flag.NoFlags.create()));
+        if (state.compareAndSet(State.OPEN, State.GO_AWAY)
+                || state.compareAndSet(State.RETIRING, State.GO_AWAY)) {
+            goAwayErrorCode.compareAndSet(null, errorCode);
+            try {
+                writeGoAway(streamId, errorCode, msg);
+            } finally {
+                goAwayWriteComplete.countDown();
+                if (errorCode != Http2ErrorCode.NO_ERROR) {
+                    errorGoAwayWriteComplete.countDown();
+                }
+            }
+        } else if (state.get() == State.GO_AWAY) {
+            await(goAwayWriteComplete);
+            if (errorCode != Http2ErrorCode.NO_ERROR) {
+                if (goAwayErrorCode.compareAndSet(Http2ErrorCode.NO_ERROR, errorCode)) {
+                    try {
+                        writeGoAway(streamId, errorCode, msg);
+                    } finally {
+                        errorGoAwayWriteComplete.countDown();
+                    }
+                } else {
+                    await(errorGoAwayWriteComplete);
+                }
+            }
         }
+    }
+
+    private void writeGoAway(int streamId, Http2ErrorCode errorCode, String msg) {
+        Http2Settings http2Settings = Http2Settings.create();
+        Http2GoAway frame = new Http2GoAway(streamId, errorCode, msg);
+        writer.write(frame.toFrameData(http2Settings, 0, Http2Flag.NoFlags.create()));
     }
 
     private enum State {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -525,6 +525,12 @@ public class Http2ClientConnection {
             Http2ErrorCode errorCode = failure instanceof Http2Exception http2Exception
                     ? http2Exception.code()
                     : Http2ErrorCode.NO_ERROR;
+            // A normal close must reach the transport to break an in-flight retirement GOAWAY write.
+            if (errorCode == Http2ErrorCode.NO_ERROR
+                    && state.get() == State.GO_AWAY
+                    && goAwayWriteComplete.getCount() != 0) {
+                return;
+            }
             // A protocol error must put GOAWAY on the wire before a failed request can make its caller exit.
             this.goAway(0, errorCode, failure.getMessage());
         } catch (Throwable e) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -81,6 +81,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private volatile ReadState readState = ReadState.INIT;
     private Http2Headers currentHeaders;
     private RuntimeException inboundFailure;
+    private volatile RuntimeException connectionFailure;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
     private boolean hasEntity;
@@ -243,26 +244,60 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     void connectionClosed(RuntimeException failure) {
+        recordConnectionFailure(failure);
         RuntimeException actualFailure;
         StreamBuffer streamBuffer;
+        boolean inboundComplete;
         inboundStateLock.lock();
         try {
-            if (readState == ReadState.END || inboundEndQueued) {
-                return;
+            actualFailure = connectionFailure;
+            inboundComplete = readState == ReadState.END || inboundEndQueued;
+            if (inboundComplete) {
+                streamBuffer = null;
+            } else {
+                if (inboundFailure == null) {
+                    inboundFailure = actualFailure;
+                }
+                streamBuffer = buffer;
+                inboundStateChanged.signalAll();
             }
-            if (inboundFailure == null) {
-                inboundFailure = failure;
-            }
-            actualFailure = inboundFailure;
-            streamBuffer = buffer;
-            inboundStateChanged.signalAll();
         } finally {
             inboundStateLock.unlock();
+        }
+        StreamFlowControl streamFlowControl = flowControl;
+        if (streamFlowControl != null) {
+            streamFlowControl.outbound().connectionClosed();
+        }
+        if (inboundComplete) {
+            return;
         }
         if (streamBuffer != null) {
             streamBuffer.fail(actualFailure);
         }
         close();
+    }
+
+    void completeTrailersFailure(RuntimeException failure) {
+        inboundStateLock.lock();
+        try {
+            if (inboundFailure == null) {
+                return;
+            }
+        } finally {
+            inboundStateLock.unlock();
+        }
+        trailers.completeExceptionally(failure);
+    }
+
+    void recordConnectionFailure(RuntimeException failure) {
+        inboundStateLock.lock();
+        try {
+            if (connectionFailure == null) {
+                connectionFailure = failure;
+            }
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     void trailers(Http2Headers headers, boolean endOfStream) {
@@ -742,7 +777,8 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 }
             }
             case DATA, TRAILERS -> pushTrailers(headers, endOfStream);
-            default -> throw new IllegalStateException("Client is in wrong read state " + readState.name());
+            default -> throw new Http2Exception(Http2ErrorCode.STREAM_CLOSED,
+                                                "Received HEADERS in invalid response read state " + readState);
             }
             inboundStateChanged.signalAll();
         } finally {
@@ -874,8 +910,18 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                                                       true,
                                                       endOfStream,
                                                       false));
-        connection.writer().writeData(frameData,
-                                      flowControl().outbound());
+        try {
+            connection.writer().writeData(frameData,
+                                          flowControl().outbound());
+        } catch (Http2Exception e) {
+            if (e.code() == Http2ErrorCode.CANCEL) {
+                RuntimeException failure = connectionFailure;
+                if (failure != null) {
+                    throw failure;
+                }
+            }
+            throw e;
+        }
     }
 
     private void updateState(Http2StreamState newState) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -242,6 +242,29 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         close();
     }
 
+    void connectionClosed(RuntimeException failure) {
+        RuntimeException actualFailure;
+        StreamBuffer streamBuffer;
+        inboundStateLock.lock();
+        try {
+            if (readState == ReadState.END || inboundEndQueued) {
+                return;
+            }
+            if (inboundFailure == null) {
+                inboundFailure = failure;
+            }
+            actualFailure = inboundFailure;
+            streamBuffer = buffer;
+            inboundStateChanged.signalAll();
+        } finally {
+            inboundStateLock.unlock();
+        }
+        if (streamBuffer != null) {
+            streamBuffer.fail(actualFailure);
+        }
+        close();
+    }
+
     void trailers(Http2Headers headers, boolean endOfStream) {
         inboundStateLock.lock();
         try {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -244,37 +244,11 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     void connectionClosed(RuntimeException failure) {
-        recordConnectionFailure(failure);
-        RuntimeException actualFailure;
-        StreamBuffer streamBuffer;
-        boolean inboundComplete;
-        inboundStateLock.lock();
-        try {
-            actualFailure = connectionFailure;
-            inboundComplete = readState == ReadState.END || inboundEndQueued;
-            if (inboundComplete) {
-                streamBuffer = null;
-            } else {
-                if (inboundFailure == null) {
-                    inboundFailure = actualFailure;
-                }
-                streamBuffer = buffer;
-                inboundStateChanged.signalAll();
-            }
-        } finally {
-            inboundStateLock.unlock();
-        }
-        StreamFlowControl streamFlowControl = flowControl;
-        if (streamFlowControl != null) {
-            streamFlowControl.outbound().connectionClosed();
-        }
-        if (inboundComplete) {
-            return;
-        }
-        if (streamBuffer != null) {
-            streamBuffer.fail(actualFailure);
-        }
-        close();
+        connectionClosed(failure, true);
+    }
+
+    void connectionClosedBeforeRegistration(RuntimeException failure) {
+        connectionClosed(failure, false);
     }
 
     void completeTrailersFailure(RuntimeException failure) {
@@ -683,6 +657,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         return http2ClientConfig.protocolConfig();
     }
 
+    Duration readTimeout() {
+        return timeout;
+    }
+
     /**
      * Reads an HTTP2 frame from the stream.
      *
@@ -784,6 +762,40 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         } finally {
             inboundStateLock.unlock();
         }
+    }
+
+    private void connectionClosed(RuntimeException failure, boolean notifyConnectionFlowControl) {
+        recordConnectionFailure(failure);
+        RuntimeException actualFailure;
+        StreamBuffer streamBuffer;
+        boolean inboundComplete;
+        inboundStateLock.lock();
+        try {
+            actualFailure = connectionFailure;
+            inboundComplete = readState == ReadState.END || inboundEndQueued;
+            if (inboundComplete) {
+                streamBuffer = null;
+            } else {
+                if (inboundFailure == null) {
+                    inboundFailure = actualFailure;
+                }
+                streamBuffer = buffer;
+                inboundStateChanged.signalAll();
+            }
+        } finally {
+            inboundStateLock.unlock();
+        }
+        StreamFlowControl streamFlowControl = flowControl;
+        if (notifyConnectionFlowControl && streamFlowControl != null) {
+            streamFlowControl.outbound().connectionClosed();
+        }
+        if (inboundComplete) {
+            return;
+        }
+        if (streamBuffer != null) {
+            streamBuffer.fail(actualFailure);
+        }
+        close();
     }
 
     /**

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -371,6 +372,120 @@ class Http2ClientConnectionTest {
 
             assertThrows(IllegalStateException.class, () -> test.createConnection(false));
             test.assertConnectionClosed();
+        }
+    }
+
+    @Test
+    void connectionLossFailsStreamWaitingForResponseHeaders() throws InterruptedException {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            firstStream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(firstStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+            assertThat(firstStream.readHeaders().status(), is(Status.OK_200));
+            firstStream.close();
+
+            Http2ClientStream redirectedStream = connection.createStream(STREAM_CONFIG);
+            redirectedStream.writeHeaders(requestHeaders(), true);
+            CountDownLatch responseReadStarted = new CountDownLatch(1);
+            CompletableFuture<Http2Headers> response = CompletableFuture.supplyAsync(() -> {
+                responseReadStarted.countDown();
+                return redirectedStream.readHeaders();
+            });
+
+            try {
+                assertTrue(responseReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException exception = assertThrows(ExecutionException.class,
+                                                              () -> response.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                 TimeUnit.MILLISECONDS));
+                assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                redirectedStream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    void connectionLossPreservesCompletedResponse() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+            test.closeInbound();
+            test.assertConnectionClosed();
+
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void connectionLossPreservesQueuedResponseEntity() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            byte[] expectedEntity = "done".getBytes(StandardCharsets.UTF_8);
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman),
+                              dataFrame(stream.streamId(), expectedEntity, true));
+            test.closeInbound();
+            test.assertConnectionClosed();
+
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+            BufferData entity = stream.read();
+            byte[] actualEntity = new byte[entity.available()];
+            entity.read(actualEntity);
+            assertThat(actualEntity, is(expectedEntity));
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void connectionLossFailsStreamRegisteredAfterClosure() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+
+            test.closeInbound();
+            test.assertConnectionClosed();
+
+            assertThrows(DataReader.InsufficientDataAvailableException.class,
+                         () -> stream.writeHeaders(requestHeaders(), true));
+            stream.close();
+            connection.close();
         }
     }
 
@@ -932,6 +1047,31 @@ class Http2ClientConnectionTest {
             assertNotNull(recoveredStream);
             recoveredStream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void retiredConnectionAllowsReservedStreamToComplete() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream reservedStream = connection.createStream(STREAM_CONFIG);
+
+            connection.retire();
+            reservedStream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(reservedStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+            assertThat(reservedStream.readHeaders().status(), is(Status.OK_200));
+            reservedStream.close();
+
+            test.assertConnectionClosed();
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -989,7 +989,7 @@ class Http2ClientConnectionTest {
                                         "invalid".getBytes(StandardCharsets.UTF_8),
                                         false));
 
-            test.assertConnectionClosed();
+            verify(test.clientConnection, timeout(1_000)).closeResource();
             drained.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         }
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1231,6 +1231,33 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void closeWaitsForBlockedErrorGoAway() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            assertThat(test.initialWriteNowCallsCompleted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(true));
+
+            Http2Settings invalidSettings = Http2Settings.builder()
+                    .add(Http2Setting.INITIAL_WINDOW_SIZE, WindowSize.MAX_WIN_SIZE + 1L)
+                    .build();
+            MockedConnectionTestContext.BlockedWrite blockedErrorGoAway = test.blockNextWriteNow();
+            test.offerInbound(invalidSettings.toFrameData(null, 0, Http2Flag.SettingsFlags.create(0)));
+            assertThat(blockedErrorGoAway.awaitEntered(), is(true));
+
+            CompletableFuture<Void> closed = CompletableFuture.runAsync(connection::close);
+            try {
+                assertThrows(TimeoutException.class, () -> closed.get(200, TimeUnit.MILLISECONDS));
+                verify(test.clientConnection, never()).closeResource();
+            } finally {
+                blockedErrorGoAway.release();
+            }
+            closed.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            test.assertConnectionClosed();
+        }
+    }
+
+    @Test
     void closeBeforePrefaceDoesNotSendGoAway() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             AtomicReference<Http2ClientConnection> connectionRef = new AtomicReference<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -67,7 +67,6 @@ import org.mockito.InOrder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1168,13 +1167,9 @@ class Http2ClientConnectionTest {
             CompletableFuture<Void> cancel = CompletableFuture.runAsync(stream::cancel);
 
             assertTrue(blockedWrite.awaitEntered());
-            try {
-                connection.closeNow();
-                test.assertConnectionClosed();
-                assertFalse(cancel.isDone());
-            } finally {
-                blockedWrite.release();
-            }
+            CompletableFuture<Void> closed = CompletableFuture.runAsync(connection::closeNow);
+            closed.get(1, TimeUnit.SECONDS);
+            test.assertConnectionClosed();
             cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             stream.close();
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -585,6 +585,48 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void unregisteredStreamFailureDoesNotWakeConnectionWindowWaiter() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream waitingStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream unregisteredStream = connection.createStream(STREAM_CONFIG);
+            firstStream.writeHeaders(requestHeaders(), false);
+            waitingStream.writeHeaders(requestHeaders(), false);
+            unregisteredStream.writeHeaders(requestHeaders(), false);
+            connection.removeStream(unregisteredStream.streamId());
+            firstStream.writeData(BufferData.create(new byte[WindowSize.DEFAULT_WIN_SIZE]), false);
+
+            CountDownLatch writerStarted = new CountDownLatch(1);
+            CompletableFuture<Void> waitingWrite = CompletableFuture.runAsync(() -> {
+                writerStarted.countDown();
+                waitingStream.writeData(BufferData.create(new byte[] {1}), true);
+            });
+
+            try {
+                assertThat(writerStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> waitingWrite.get(200, TimeUnit.MILLISECONDS));
+                unregisteredStream.connectionClosedBeforeRegistration(
+                        new Http2Exception(Http2ErrorCode.PROTOCOL, "expected test connection failure"));
+                assertThrows(TimeoutException.class, () -> waitingWrite.get(200, TimeUnit.MILLISECONDS));
+
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException failure = assertThrows(ExecutionException.class,
+                                                            () -> waitingWrite.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                   TimeUnit.MILLISECONDS));
+                assertThat(failure.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                firstStream.close();
+                waitingStream.close();
+                unregisteredStream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
     void connectionLossFailsPendingTrailers() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));
@@ -723,6 +765,56 @@ class Http2ClientConnectionTest {
             assertThat(exception.getCause(), instanceOf(Http2Exception.class));
             assertThat(((Http2Exception) exception.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
             test.assertConnectionClosed();
+            activeStream.close();
+            lateStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void interruptedLateStreamDoesNotWaitForBlockedGoAwayWrite() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream activeStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream lateStream = connection.createStream(STREAM_CONFIG);
+            activeStream.writeHeaders(requestHeaders(), false);
+
+            MockedConnectionTestContext.BlockedWrite blockedGoAway = test.blockNextWriteNow();
+            test.offerInbound(dataFrame(activeStream.streamId(), "invalid".getBytes(StandardCharsets.UTF_8), false));
+            assertThat(blockedGoAway.awaitEntered(), is(true));
+
+            CountDownLatch lateWriteStarted = new CountDownLatch(1);
+            AtomicBoolean interruptPreserved = new AtomicBoolean();
+            CompletableFuture<Throwable> lateWriteResult = new CompletableFuture<>();
+            Thread lateWriteThread = Thread.ofPlatform().start(() -> {
+                Throwable result;
+                try {
+                    lateWriteStarted.countDown();
+                    lateStream.writeHeaders(requestHeaders(), true);
+                    result = new AssertionError("Late stream write unexpectedly completed");
+                } catch (Throwable t) {
+                    result = t;
+                }
+                interruptPreserved.set(Thread.currentThread().isInterrupted());
+                lateWriteResult.complete(result);
+            });
+
+            try {
+                assertThat(lateWriteStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> lateWriteResult.get(200, TimeUnit.MILLISECONDS));
+                lateWriteThread.interrupt();
+                Throwable failure = lateWriteResult.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                assertThat(failure, instanceOf(Http2Exception.class));
+                assertThat(((Http2Exception) failure).code(), is(Http2ErrorCode.PROTOCOL));
+                assertThat(interruptPreserved.get(), is(true));
+                test.assertConnectionClosed();
+            } finally {
+                lateWriteThread.interrupt();
+                blockedGoAway.release();
+            }
+            lateWriteThread.join(TEST_WAIT_TIMEOUT.toMillis());
+            assertThat(lateWriteThread.isAlive(), is(false));
             activeStream.close();
             lateStream.close();
             connection.close();
@@ -1418,6 +1510,56 @@ class Http2ClientConnectionTest {
 
             stream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void invalidTrailersFailEntityAndTrailersWaiters() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            CountDownLatch entityReadStarted = new CountDownLatch(1);
+            CompletableFuture<BufferData> entity = CompletableFuture.supplyAsync(() -> {
+                entityReadStarted.countDown();
+                return stream.read();
+            });
+            try {
+                assertThat(entityReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> entity.get(200, TimeUnit.MILLISECONDS));
+                test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                     encodedTrailers(),
+                                                     inboundTable,
+                                                     huffman,
+                                                     false));
+                test.assertConnectionClosed();
+
+                ExecutionException entityFailure = assertThrows(
+                        ExecutionException.class,
+                        () -> entity.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThat(entityFailure.getCause(), instanceOf(Http2Exception.class));
+                assertThat(((Http2Exception) entityFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+
+                ExecutionException trailersFailure = assertThrows(
+                        ExecutionException.class,
+                        () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThat(trailersFailure.getCause(), instanceOf(Http2Exception.class));
+                assertThat(((Http2Exception) trailersFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+            } finally {
+                stream.close();
+                connection.close();
+            }
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1124,6 +1124,41 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void secondCloseBreaksBlockedConnectionWriter() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+
+            MockedConnectionTestContext.BlockedWrite blockedWrite = test.blockNextWriteNow();
+            CompletableFuture<Void> write = CompletableFuture.runAsync(
+                    () -> connection.writer().write(dataFrame(stream.streamId(), new byte[] {1}, false)));
+            assertThat(blockedWrite.awaitEntered(), is(true));
+
+            Http2ClientProtocolConfig noPing = Http2ClientProtocolConfig.builder()
+                    .ping(false)
+                    .buildPrototype();
+            CompletableFuture<Void> firstClose = CompletableFuture.runAsync(connection::close);
+            long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+            while (!connection.closed(noPing) && System.nanoTime() < deadline) {
+                Thread.onSpinWait();
+            }
+            assertThat(connection.closed(noPing), is(true));
+
+            CompletableFuture<Void> secondClose = CompletableFuture.runAsync(connection::close);
+            secondClose.get(1, TimeUnit.SECONDS);
+            test.assertConnectionClosed();
+            firstClose.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            ExecutionException writeFailure = assertThrows(ExecutionException.class,
+                                                            () -> write.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                            TimeUnit.MILLISECONDS));
+            assertThat(writeFailure.getCause(), instanceOf(UncheckedIOException.class));
+            stream.close();
+        }
+    }
+
+    @Test
     void closeBeforePrefaceDoesNotSendGoAway() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             AtomicReference<Http2ClientConnection> connectionRef = new AtomicReference<>();
@@ -1750,6 +1785,7 @@ class Http2ClientConnectionTest {
         private final AtomicBoolean failWrites = new AtomicBoolean();
         private final AtomicBoolean transportClosed = new AtomicBoolean();
         private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
+        private final AtomicReference<BlockedWrite> activeBlockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
         private final io.helidon.common.socket.HelidonSocket socket = mock(io.helidon.common.socket.HelidonSocket.class);
         private final Http2ClientConfig clientConfig;
@@ -1802,6 +1838,7 @@ class Http2ClientConnectionTest {
             when(clientConnection.helidonSocket()).thenReturn(socket);
             doAnswer(_ -> {
                 transportClosed.set(true);
+                failBlockedWrite();
                 return null;
             }).when(clientConnection).closeResource();
             when(socket.socketId()).thenReturn("test-socket");
@@ -1864,7 +1901,23 @@ class Http2ClientConnectionTest {
         private void maybeBlockWriteNow() {
             BlockedWrite block = blockedWrite.getAndSet(null);
             if (block != null) {
-                block.block();
+                activeBlockedWrite.set(block);
+                try {
+                    block.block();
+                } finally {
+                    activeBlockedWrite.compareAndSet(block, null);
+                }
+            }
+        }
+
+        private void failBlockedWrite() {
+            BlockedWrite block = blockedWrite.get();
+            if (block != null) {
+                block.releaseAndFail();
+            }
+            block = activeBlockedWrite.get();
+            if (block != null) {
+                block.releaseAndFail();
             }
         }
 
@@ -1883,16 +1936,17 @@ class Http2ClientConnectionTest {
 
         @Override
         public void close() {
+            failBlockedWrite();
             connectionExecutor.shutdownNow();
         }
 
         private static final class BlockedWrite {
             private final CountDownLatch entered = new CountDownLatch(1);
             private final CountDownLatch released = new CountDownLatch(1);
-            private final boolean failAfterRelease;
+            private final AtomicBoolean failAfterRelease;
 
             private BlockedWrite(boolean failAfterRelease) {
-                this.failAfterRelease = failAfterRelease;
+                this.failAfterRelease = new AtomicBoolean(failAfterRelease);
             }
 
             private boolean awaitEntered() throws InterruptedException {
@@ -1903,13 +1957,18 @@ class Http2ClientConnectionTest {
                 released.countDown();
             }
 
+            private void releaseAndFail() {
+                failAfterRelease.set(true);
+                release();
+            }
+
             private void block() {
                 entered.countDown();
                 try {
                     if (!released.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
                         throw new IllegalStateException("Timed out waiting for test to release blocked write");
                     }
-                    if (failAfterRelease) {
+                    if (failAfterRelease.get()) {
                         throw new UncheckedIOException(new IOException("expected blocked test write failure"));
                     }
                 } catch (InterruptedException e) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -684,11 +684,12 @@ class Http2ClientConnectionTest {
             CompletableFuture<Headers> firstTrailers = firstStream.trailers();
             CompletableFuture<Headers> secondTrailers = secondStream.trailers();
             AtomicBoolean callbackClaimed = new AtomicBoolean();
-            CountDownLatch callbackEntered = new CountDownLatch(1);
+            CountDownLatch callbacksEntered = new CountDownLatch(2);
             CountDownLatch releaseCallback = new CountDownLatch(1);
             Runnable blockFirstCallback = () -> {
-                if (callbackClaimed.compareAndSet(false, true)) {
-                    callbackEntered.countDown();
+                boolean block = callbackClaimed.compareAndSet(false, true);
+                callbacksEntered.countDown();
+                if (block) {
                     try {
                         if (!releaseCallback.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
                             throw new IllegalStateException("Timed out waiting to release trailers callback");
@@ -705,7 +706,7 @@ class Http2ClientConnectionTest {
             try {
                 test.closeInbound();
                 test.assertConnectionClosed();
-                assertThat(callbackEntered.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThat(callbacksEntered.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
                 assertThat(firstTrailers.isCompletedExceptionally(), is(true));
                 assertThat(secondTrailers.isCompletedExceptionally(), is(true));
             } finally {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1159,6 +1159,26 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void closeBreaksBlockedRetirementGoAway() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+
+            connection.retire();
+            MockedConnectionTestContext.BlockedWrite blockedRetirement = test.blockNextWriteNow();
+            CompletableFuture<Void> drained = CompletableFuture.runAsync(stream::close);
+            assertThat(blockedRetirement.awaitEntered(), is(true));
+
+            CompletableFuture<Void> closed = CompletableFuture.runAsync(connection::close);
+            closed.get(1, TimeUnit.SECONDS);
+            test.assertConnectionClosed();
+            drained.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Test
     void closeBeforePrefaceDoesNotSendGoAway() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             AtomicReference<Http2ClientConnection> connectionRef = new AtomicReference<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -662,6 +662,63 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void connectionLossFailsSiblingTrailersDespiteBlockingCallback() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+            firstStream.writeHeaders(requestHeaders(), true);
+            secondStream.writeHeaders(requestHeaders(), true);
+
+            WritableHeaders<?> responseHeaders = WritableHeaders.create();
+            responseHeaders.set(HeaderNames.TRAILER, "grpc-status");
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers response = Http2Headers.create(responseHeaders).status(Status.OK_200);
+            test.offerInbound(encodedHeaderFrame(firstStream.streamId(), response, inboundTable, huffman),
+                              encodedHeaderFrame(secondStream.streamId(), response, inboundTable, huffman));
+            assertThat(firstStream.readHeaders().status(), is(Status.OK_200));
+            assertThat(secondStream.readHeaders().status(), is(Status.OK_200));
+
+            CompletableFuture<Headers> firstTrailers = firstStream.trailers();
+            CompletableFuture<Headers> secondTrailers = secondStream.trailers();
+            AtomicBoolean callbackClaimed = new AtomicBoolean();
+            CountDownLatch callbackEntered = new CountDownLatch(1);
+            CountDownLatch releaseCallback = new CountDownLatch(1);
+            Runnable blockFirstCallback = () -> {
+                if (callbackClaimed.compareAndSet(false, true)) {
+                    callbackEntered.countDown();
+                    try {
+                        if (!releaseCallback.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                            throw new IllegalStateException("Timed out waiting to release trailers callback");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Interrupted while blocking trailers callback", e);
+                    }
+                }
+            };
+            firstTrailers.whenComplete((_, _) -> blockFirstCallback.run());
+            secondTrailers.whenComplete((_, _) -> blockFirstCallback.run());
+
+            try {
+                test.closeInbound();
+                test.assertConnectionClosed();
+                assertThat(callbackEntered.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThat(firstTrailers.isCompletedExceptionally(), is(true));
+                assertThat(secondTrailers.isCompletedExceptionally(), is(true));
+            } finally {
+                releaseCallback.countDown();
+                firstStream.close();
+                secondStream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
     void connectionLossPreservesCompletedResponse() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -36,11 +36,13 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
@@ -54,11 +56,13 @@ import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
 import io.helidon.http.http2.Http2WindowUpdate;
+import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClient;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -71,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -403,7 +408,7 @@ class Http2ClientConnectionTest {
             });
 
             try {
-                assertTrue(responseReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThat(responseReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
                 test.closeInbound();
                 test.assertConnectionClosed();
                 ExecutionException exception = assertThrows(ExecutionException.class,
@@ -414,6 +419,203 @@ class Http2ClientConnectionTest {
                 redirectedStream.close();
                 connection.close();
             }
+        }
+    }
+
+    @Test
+    void connectionLossFailsStreamWaitingFor100Continue() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            WritableHeaders<?> headers = WritableHeaders.create();
+            headers.set(HeaderValues.EXPECT_100);
+            Http2Headers requestHeaders = Http2Headers.create(headers)
+                    .method(Method.POST)
+                    .scheme("http")
+                    .path("/")
+                    .authority("www.example.com");
+            stream.writeHeaders(requestHeaders, false);
+
+            CountDownLatch continueWaitStarted = new CountDownLatch(1);
+            CompletableFuture<Status> continueStatus = CompletableFuture.supplyAsync(() -> {
+                continueWaitStarted.countDown();
+                return stream.waitFor100Continue(Duration.ofSeconds(30));
+            });
+
+            try {
+                assertThat(continueWaitStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> continueStatus.get(200, TimeUnit.MILLISECONDS));
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException exception = assertThrows(ExecutionException.class,
+                                                              () -> continueStatus.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                       TimeUnit.MILLISECONDS));
+                assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                stream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    void connectionLossFailsStreamWaitingForResponseEntity() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            CountDownLatch entityReadStarted = new CountDownLatch(1);
+            CompletableFuture<BufferData> entity = CompletableFuture.supplyAsync(() -> {
+                entityReadStarted.countDown();
+                return stream.read();
+            });
+
+            try {
+                assertThat(entityReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> entity.get(200, TimeUnit.MILLISECONDS));
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException exception = assertThrows(ExecutionException.class,
+                                                              () -> entity.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                               TimeUnit.MILLISECONDS));
+                assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                stream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    void connectionLossFailsStreamWaitingForOutboundWindowUpdate() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            Http2Settings settings = Http2Settings.builder()
+                    .add(Http2Setting.MAX_CONCURRENT_STREAMS, 10L)
+                    .add(Http2Setting.INITIAL_WINDOW_SIZE, 0L)
+                    .build();
+            test.offerInbound(settings.toFrameData(null, 0, Http2Flag.SettingsFlags.create(0)));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            CompletableFuture<Void> write = CompletableFuture.runAsync(
+                    () -> stream.writeData(BufferData.create(new byte[] {1}), true));
+
+            try {
+                assertThrows(TimeoutException.class, () -> write.get(200, TimeUnit.MILLISECONDS));
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException exception = assertThrows(ExecutionException.class,
+                                                              () -> write.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                              TimeUnit.MILLISECONDS));
+                assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                stream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    void connectionLossPreservesFailureForAllConnectionWindowWaiters() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream thirdStream = connection.createStream(STREAM_CONFIG);
+            firstStream.writeHeaders(requestHeaders(), false);
+            secondStream.writeHeaders(requestHeaders(), false);
+            thirdStream.writeHeaders(requestHeaders(), false);
+            firstStream.writeData(BufferData.create(new byte[WindowSize.DEFAULT_WIN_SIZE]), false);
+
+            CountDownLatch writersStarted = new CountDownLatch(2);
+            CompletableFuture<Void> secondWrite = CompletableFuture.runAsync(() -> {
+                writersStarted.countDown();
+                secondStream.writeData(BufferData.create(new byte[] {1}), true);
+            });
+            CompletableFuture<Void> thirdWrite = CompletableFuture.runAsync(() -> {
+                writersStarted.countDown();
+                thirdStream.writeData(BufferData.create(new byte[] {1}), true);
+            });
+
+            try {
+                assertThat(writersStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> secondWrite.get(200, TimeUnit.MILLISECONDS));
+                assertThrows(TimeoutException.class, () -> thirdWrite.get(200, TimeUnit.MILLISECONDS));
+                test.closeInbound();
+                test.assertConnectionClosed();
+                ExecutionException secondFailure = assertThrows(ExecutionException.class,
+                                                                  () -> secondWrite.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                        TimeUnit.MILLISECONDS));
+                ExecutionException thirdFailure = assertThrows(ExecutionException.class,
+                                                                 () -> thirdWrite.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                      TimeUnit.MILLISECONDS));
+                assertThat(secondFailure.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+                assertThat(thirdFailure.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            } finally {
+                firstStream.close();
+                secondStream.close();
+                thirdStream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    void connectionLossFailsPendingTrailers() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            WritableHeaders<?> responseHeaders = WritableHeaders.create();
+            responseHeaders.set(HeaderNames.TRAILER, "grpc-status");
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 Http2Headers.create(responseHeaders).status(Status.OK_200),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            CompletableFuture<Boolean> trailersCompletedAfterTransportClose = stream.trailers()
+                    .handle((_, _) -> test.transportClosed.get());
+            test.closeInbound();
+            test.assertConnectionClosed();
+
+            ExecutionException exception = assertThrows(ExecutionException.class,
+                                                          () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                                      TimeUnit.MILLISECONDS));
+            assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+            assertThat(trailersCompletedAfterTransportClose.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(true));
+            stream.close();
+            connection.close();
         }
     }
 
@@ -484,6 +686,234 @@ class Http2ClientConnectionTest {
 
             assertThrows(DataReader.InsufficientDataAvailableException.class,
                          () -> stream.writeHeaders(requestHeaders(), true));
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void protocolFailureWritesGoAwayBeforeFailingLateStream() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream activeStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream lateStream = connection.createStream(STREAM_CONFIG);
+            activeStream.writeHeaders(requestHeaders(), false);
+
+            MockedConnectionTestContext.BlockedWrite blockedGoAway = test.blockNextWriteNow();
+            test.offerInbound(dataFrame(activeStream.streamId(), "invalid".getBytes(StandardCharsets.UTF_8), false));
+            assertThat(blockedGoAway.awaitEntered(), is(true));
+
+            CompletableFuture<Void> lateWrite;
+            try {
+                CountDownLatch lateWriteStarted = new CountDownLatch(1);
+                lateWrite = CompletableFuture.runAsync(() -> {
+                    lateWriteStarted.countDown();
+                    lateStream.writeHeaders(requestHeaders(), true);
+                });
+                assertThat(lateWriteStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThrows(TimeoutException.class, () -> lateWrite.get(200, TimeUnit.MILLISECONDS));
+            } finally {
+                blockedGoAway.release();
+            }
+
+            ExecutionException exception = assertThrows(ExecutionException.class,
+                                                          () -> lateWrite.get(TEST_WAIT_TIMEOUT.toMillis(),
+                                                                              TimeUnit.MILLISECONDS));
+            assertThat(exception.getCause(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) exception.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+            test.assertConnectionClosed();
+            activeStream.close();
+            lateStream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void goAwayWriteDoesNotDeadlockWriterFailureClose() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+
+            MockedConnectionTestContext.BlockedWrite blockedReset = test.blockAndFailNextWriteNow();
+            CompletableFuture<Void> cancel = CompletableFuture.runAsync(stream::cancel);
+            assertThat(blockedReset.awaitEntered(), is(true));
+
+            try {
+                test.offerInbound(dataFrame(stream.streamId(), "invalid".getBytes(StandardCharsets.UTF_8), false));
+                Http2ClientProtocolConfig noPing = Http2ClientProtocolConfig.builder()
+                        .ping(false)
+                        .buildPrototype();
+                long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+                while (!connection.closed(noPing) && System.nanoTime() < deadline) {
+                    Thread.onSpinWait();
+                }
+                assertThat(connection.closed(noPing), is(true));
+            } finally {
+                blockedReset.release();
+            }
+            cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            test.assertConnectionClosed();
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void peerGoAwayWritesReciprocalGoAwayBeforeClosing() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            assertThat(test.initialWriteNowCallsCompleted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(true));
+            clearInvocations(test.dataWriter, test.clientConnection);
+
+            Http2GoAway peerGoAway = new Http2GoAway(1, Http2ErrorCode.PROTOCOL, "peer protocol failure");
+            test.offerInbound(peerGoAway.toFrameData(Http2Settings.create(), 0, Http2Flag.NoFlags.create()));
+
+            ArgumentCaptor<BufferData> reciprocalGoAway = ArgumentCaptor.forClass(BufferData.class);
+            InOrder closeOrder = inOrder(test.dataWriter, test.clientConnection);
+            closeOrder.verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis())).writeNow(reciprocalGoAway.capture());
+            closeOrder.verify(test.clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
+
+            BufferData frameData = reciprocalGoAway.getValue();
+            byte[] headerBytes = new byte[Http2FrameHeader.LENGTH];
+            frameData.read(headerBytes);
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(headerBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.GO_AWAY));
+            byte[] payloadBytes = new byte[frameHeader.length()];
+            frameData.read(payloadBytes);
+            assertThat(Http2GoAway.create(BufferData.create(payloadBytes)).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            connection.close();
+        }
+    }
+
+    @Test
+    void protocolFailureOnRetiringConnectionWritesGoAwayBeforeClosing() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+            verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(3)).writeNow(any(BufferData.class));
+            clearInvocations(test.dataWriter, test.clientConnection);
+
+            connection.retire();
+            test.offerInbound(dataFrame(stream.streamId(), "invalid".getBytes(StandardCharsets.UTF_8), false));
+
+            ArgumentCaptor<BufferData> errorGoAway = ArgumentCaptor.forClass(BufferData.class);
+            InOrder closeOrder = inOrder(test.dataWriter, test.clientConnection);
+            closeOrder.verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis())).writeNow(errorGoAway.capture());
+            closeOrder.verify(test.clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
+
+            BufferData frameData = errorGoAway.getValue();
+            byte[] headerBytes = new byte[Http2FrameHeader.LENGTH];
+            frameData.read(headerBytes);
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(headerBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.GO_AWAY));
+            byte[] payloadBytes = new byte[frameHeader.length()];
+            frameData.read(payloadBytes);
+            assertThat(Http2GoAway.create(BufferData.create(payloadBytes)).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    void protocolFailureUpgradesInFlightRetirementGoAway() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), false);
+            verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(3)).writeNow(any(BufferData.class));
+            clearInvocations(test.dataWriter, test.clientConnection);
+
+            connection.retire();
+            MockedConnectionTestContext.BlockedWrite blockedRetirement = test.blockNextWriteNow();
+            CompletableFuture<Void> drained = CompletableFuture.runAsync(stream::close);
+            assertThat(blockedRetirement.awaitEntered(), is(true));
+
+            try {
+                test.offerInbound(dataFrame(stream.streamId() + 2,
+                                            "invalid".getBytes(StandardCharsets.UTF_8),
+                                            false));
+                assertThrows(TimeoutException.class, () -> drained.get(200, TimeUnit.MILLISECONDS));
+            } finally {
+                blockedRetirement.release();
+            }
+            drained.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+            ArgumentCaptor<BufferData> goAwayFrames = ArgumentCaptor.forClass(BufferData.class);
+            InOrder closeOrder = inOrder(test.dataWriter, test.clientConnection);
+            closeOrder.verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(2))
+                    .writeNow(goAwayFrames.capture());
+            closeOrder.verify(test.clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
+
+            List<BufferData> frames = goAwayFrames.getAllValues();
+            BufferData retirementFrame = frames.get(0);
+            byte[] retirementHeaderBytes = new byte[Http2FrameHeader.LENGTH];
+            retirementFrame.read(retirementHeaderBytes);
+            Http2FrameHeader retirementHeader = Http2FrameHeader.create(BufferData.create(retirementHeaderBytes));
+            byte[] retirementPayloadBytes = new byte[retirementHeader.length()];
+            retirementFrame.read(retirementPayloadBytes);
+            assertThat(Http2GoAway.create(BufferData.create(retirementPayloadBytes)).errorCode(),
+                       is(Http2ErrorCode.NO_ERROR));
+
+            BufferData errorFrame = frames.get(1);
+            byte[] errorHeaderBytes = new byte[Http2FrameHeader.LENGTH];
+            errorFrame.read(errorHeaderBytes);
+            Http2FrameHeader errorHeader = Http2FrameHeader.create(BufferData.create(errorHeaderBytes));
+            byte[] errorPayloadBytes = new byte[errorHeader.length()];
+            errorFrame.read(errorPayloadBytes);
+            assertThat(Http2GoAway.create(BufferData.create(errorPayloadBytes)).errorCode(),
+                       is(Http2ErrorCode.PROTOCOL));
+            connection.close();
+        }
+    }
+
+    @Test
+    void lateHeadersWriteStreamClosedGoAwayBeforeClosing() {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+            verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(3)).writeNow(any(BufferData.class));
+            clearInvocations(test.dataWriter, test.clientConnection);
+
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman,
+                                                 true));
+
+            ArgumentCaptor<BufferData> errorGoAway = ArgumentCaptor.forClass(BufferData.class);
+            InOrder closeOrder = inOrder(test.dataWriter, test.clientConnection);
+            closeOrder.verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis())).writeNow(errorGoAway.capture());
+            closeOrder.verify(test.clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
+
+            BufferData frameData = errorGoAway.getValue();
+            byte[] headerBytes = new byte[Http2FrameHeader.LENGTH];
+            frameData.read(headerBytes);
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(headerBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.GO_AWAY));
+            byte[] payloadBytes = new byte[frameHeader.length()];
+            frameData.read(payloadBytes);
+            assertThat(Http2GoAway.create(BufferData.create(payloadBytes)).errorCode(),
+                       is(Http2ErrorCode.STREAM_CLOSED));
             stream.close();
             connection.close();
         }
@@ -1176,6 +1606,7 @@ class Http2ClientConnectionTest {
         // The client preface is the first writeNow call; the initial SETTINGS ACK is the second.
         private final CountDownLatch initialWriteNowCallsCompleted = new CountDownLatch(2);
         private final AtomicBoolean failWrites = new AtomicBoolean();
+        private final AtomicBoolean transportClosed = new AtomicBoolean();
         private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
         private final io.helidon.common.socket.HelidonSocket socket = mock(io.helidon.common.socket.HelidonSocket.class);
@@ -1227,6 +1658,10 @@ class Http2ClientConnectionTest {
             when(clientConnection.reader()).thenReturn(DataReader.create(this::nextInboundFrame));
             when(clientConnection.writer()).thenReturn(dataWriter);
             when(clientConnection.helidonSocket()).thenReturn(socket);
+            doAnswer(_ -> {
+                transportClosed.set(true);
+                return null;
+            }).when(clientConnection).closeResource();
             when(socket.socketId()).thenReturn("test-socket");
             when(socket.childSocketId()).thenReturn("0");
         }
@@ -1263,7 +1698,15 @@ class Http2ClientConnectionTest {
         }
 
         private BlockedWrite blockNextWriteNow() {
-            BlockedWrite result = new BlockedWrite();
+            return blockNextWriteNow(false);
+        }
+
+        private BlockedWrite blockAndFailNextWriteNow() {
+            return blockNextWriteNow(true);
+        }
+
+        private BlockedWrite blockNextWriteNow(boolean failAfterRelease) {
+            BlockedWrite result = new BlockedWrite(failAfterRelease);
             if (!blockedWrite.compareAndSet(null, result)) {
                 throw new IllegalStateException("A write is already blocked");
             }
@@ -1304,6 +1747,11 @@ class Http2ClientConnectionTest {
         private static final class BlockedWrite {
             private final CountDownLatch entered = new CountDownLatch(1);
             private final CountDownLatch released = new CountDownLatch(1);
+            private final boolean failAfterRelease;
+
+            private BlockedWrite(boolean failAfterRelease) {
+                this.failAfterRelease = failAfterRelease;
+            }
 
             private boolean awaitEntered() throws InterruptedException {
                 return entered.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -1318,6 +1766,9 @@ class Http2ClientConnectionTest {
                 try {
                     if (!released.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
                         throw new IllegalStateException("Timed out waiting for test to release blocked write");
+                    }
+                    if (failAfterRelease) {
+                        throw new UncheckedIOException(new IOException("expected blocked test write failure"));
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1893,7 +1893,7 @@ class Http2ClientConnectionTest {
         }
 
         private void maybeFailWrites() {
-            if (failWrites.get()) {
+            if (failWrites.get() || transportClosed.get()) {
                 throw new UncheckedIOException(new IOException("expected test write failure"));
             }
         }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -971,7 +971,7 @@ class Http2ClientConnectionTest {
     }
 
     @Test
-    void protocolFailureUpgradesInFlightRetirementGoAway() throws Exception {
+    void protocolFailureBreaksBlockedRetirementGoAway() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));
             Http2ClientConnection connection = test.createConnection(false);
@@ -985,41 +985,12 @@ class Http2ClientConnectionTest {
             CompletableFuture<Void> drained = CompletableFuture.runAsync(stream::close);
             assertThat(blockedRetirement.awaitEntered(), is(true));
 
-            try {
-                test.offerInbound(dataFrame(stream.streamId() + 2,
-                                            "invalid".getBytes(StandardCharsets.UTF_8),
-                                            false));
-                assertThrows(TimeoutException.class, () -> drained.get(200, TimeUnit.MILLISECONDS));
-            } finally {
-                blockedRetirement.release();
-            }
+            test.offerInbound(dataFrame(stream.streamId() + 2,
+                                        "invalid".getBytes(StandardCharsets.UTF_8),
+                                        false));
+
+            test.assertConnectionClosed();
             drained.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-
-            ArgumentCaptor<BufferData> goAwayFrames = ArgumentCaptor.forClass(BufferData.class);
-            InOrder closeOrder = inOrder(test.dataWriter, test.clientConnection);
-            closeOrder.verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(2))
-                    .writeNow(goAwayFrames.capture());
-            closeOrder.verify(test.clientConnection, timeout(TEST_WAIT_TIMEOUT.toMillis())).closeResource();
-
-            List<BufferData> frames = goAwayFrames.getAllValues();
-            BufferData retirementFrame = frames.get(0);
-            byte[] retirementHeaderBytes = new byte[Http2FrameHeader.LENGTH];
-            retirementFrame.read(retirementHeaderBytes);
-            Http2FrameHeader retirementHeader = Http2FrameHeader.create(BufferData.create(retirementHeaderBytes));
-            byte[] retirementPayloadBytes = new byte[retirementHeader.length()];
-            retirementFrame.read(retirementPayloadBytes);
-            assertThat(Http2GoAway.create(BufferData.create(retirementPayloadBytes)).errorCode(),
-                       is(Http2ErrorCode.NO_ERROR));
-
-            BufferData errorFrame = frames.get(1);
-            byte[] errorHeaderBytes = new byte[Http2FrameHeader.LENGTH];
-            errorFrame.read(errorHeaderBytes);
-            Http2FrameHeader errorHeader = Http2FrameHeader.create(BufferData.create(errorHeaderBytes));
-            byte[] errorPayloadBytes = new byte[errorHeader.length()];
-            errorFrame.read(errorPayloadBytes);
-            assertThat(Http2GoAway.create(BufferData.create(errorPayloadBytes)).errorCode(),
-                       is(Http2ErrorCode.PROTOCOL));
-            connection.close();
         }
     }
 


### PR DESCRIPTION
Resolves #12345

Propagates unexpected HTTP/2 connection failures to active stream waiters and unblocks outbound flow control. Preserves completed responses and writes ordered GOAWAY frames before closing when the transport remains usable.
