### PR TITLE
Reject missing declarative request entities (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -65,6 +65,7 @@ import io.helidon.service.codegen.spi.RegistryCodegenExtension;
 
 import static io.helidon.codegen.CodegenUtil.toConstantName;
 import static io.helidon.declarative.codegen.DeclarativeTypes.SINGLETON_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.BAD_REQUEST_EXCEPTION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_CONSUMES_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
@@ -496,8 +497,22 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                                     RestMethod restMethod,
                                     Map<String, String> headerProducers,
                                     int methodIndex) {
-        validateBodyParameters(restMethod);
-        if (methodUsesFormParams(restMethod)) {
+        BodyParameters bodyParameters = bodyParameters(restMethod);
+        validateBodyParameters(restMethod, bodyParameters);
+        bodyParameters.entityName()
+                .ifPresent(entity -> method.addContent("if (!")
+                        .addContent(REQUEST_PARAM_NAME)
+                        .addContentLine(".content().hasEntity()) {")
+                        .increaseContentPadding()
+                        .addContent("throw new ")
+                        .addContent(BAD_REQUEST_EXCEPTION)
+                        .addContent("(\"Entity ")
+                        .addContent(entity)
+                        .addContentLine(" is not present in the request.\");")
+                        .decreaseContentPadding()
+                        .addContentLine("}"));
+
+        if (bodyParameters.formCount() > 0) {
             method.addContent("var ")
                     .addContent(ParamProviderHttpForm.FORM_PARAMS)
                     .addContent(" = ")
@@ -708,8 +723,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         }
     }
 
-    private void validateBodyParameters(RestMethod restMethod) {
-        BodyParameters bodyParameters = bodyParameters(restMethod);
+    private void validateBodyParameters(RestMethod restMethod, BodyParameters bodyParameters) {
         if (bodyParameters.entityCount() > 1) {
             throw new CodegenException("Only one @Http.Entity parameter is supported on declarative server method "
                                                + restMethod.type().typeName().fqName() + "." + restMethod.name() + "().",
@@ -722,18 +736,16 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         }
     }
 
-    private boolean methodUsesFormParams(RestMethod restMethod) {
-        return bodyParameters(restMethod).formCount() > 0;
-    }
-
     private BodyParameters bodyParameters(RestMethod restMethod) {
         int entityCount = 0;
         int formCount = 0;
+        Optional<String> entityName = Optional.empty();
         Object firstOriginatingElement = restMethod.method().originatingElementValue();
 
         for (RestMethodParameter parameter : restMethod.parameters()) {
             if (HttpCodegenValidation.hasAnnotation(parameter.annotations(), HTTP_ENTITY_ANNOTATION)) {
                 entityCount++;
+                entityName = Optional.of(parameter.name());
                 firstOriginatingElement = parameter.parameter().originatingElementValue();
             }
             if (HttpCodegenValidation.hasAnnotation(parameter.annotations(), HTTP_FORM_PARAM_ANNOTATION)) {
@@ -749,6 +761,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                 for (TypedElementInfo component : HttpCodegenValidation.requestParamsComponents(requestParamsType)) {
                     if (HttpCodegenValidation.hasAnnotation(component.annotations(), HTTP_ENTITY_ANNOTATION)) {
                         entityCount++;
+                        entityName = Optional.of(component.elementName());
                         firstOriginatingElement = component.originatingElementValue();
                     }
                     if (HttpCodegenValidation.hasAnnotation(component.annotations(), HTTP_FORM_PARAM_ANNOTATION)) {
@@ -759,7 +772,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
             }
         }
 
-        return new BodyParameters(entityCount, formCount, firstOriginatingElement);
+        return new BodyParameters(entityCount, formCount, entityName, firstOriginatingElement);
     }
 
     private void addSimpleRoute(FieldHandler fieldHandler, Method.Builder routing, RestMethod restMethod) {
@@ -847,6 +860,7 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
 
     private record BodyParameters(int entityCount,
                                   int formCount,
+                                  Optional<String> entityName,
                                   Object firstOriginatingElement) {
     }
 }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/EntityGenericTypeCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/EntityGenericTypeCodegenTest.java
@@ -135,6 +135,9 @@ class EntityGenericTypeCodegenTest {
         }
 
         String generated = generatedContent.toString();
+        assertThat(generated, containsString("if (!req.content().hasEntity())"));
+        assertThat(generated,
+                   containsString("throw new BadRequestException(\"Entity entity is not present in the request.\");"));
         assertThat(generated, containsString(".content().as(GTYPE"));
         assertThat(generated, not(containsString("List<String>.class")));
     }

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -328,6 +328,14 @@ class GreetServiceEndpoint implements GreetService {
         return greet.get();
     }
 
+    @Http.POST
+    @Http.Path("/input-stream")
+    String inputStreamEntity(@Http.Entity InputStream inputStream) throws IOException {
+        try (inputStream) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
     private JsonObject response(String name) {
         return JsonObject.builder()
                 .set("message", stringResponse(name))

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -307,6 +307,18 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testRequestParamsMissingEntity() {
+        var response = client.post("/request-params/grouped")
+                .header(HeaderValues.create(HeaderNames.create("X-CUSTOM"), "Expected-header"))
+                .header(HeaderValues.create(HeaderNames.COOKIE, "myCookie=Expected-cookie"))
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Entity entity is not present in the request."));
+    }
+
+    @Test
     void testRequestParamsPath() {
         var response = client.get("/request-params/path/Expected-path")
                 .request(String.class);
@@ -787,5 +799,23 @@ class DeclarativeHttpTest {
         IllegalStateException exception = assertThrows(IllegalStateException.class,
                                                        typedClient::optionalMessageNotFoundHandled);
         assertThat(exception.getMessage(), is("optional 404 handled"));
+    }
+
+    @Test
+    void testInputStreamEntityEcho() {
+        var response = client.post("/greet/input-stream")
+                .submit("hello", String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("hello"));
+    }
+
+    @Test
+    void testInputStreamEntityEmptyContentLengthFailure() {
+        var response = client.post("/greet/input-stream")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        assertThat(response.entity(), is("Entity inputStream is not present in the request."));
     }
 }


### PR DESCRIPTION
Resolves #12149

Carries forward the missing declarative request entity handling from #12148 to `main`. Missing required `@Http.Entity` request bodies now return HTTP 400; the narrow target-line adaptation applies the same check to `@Http.RequestParams` entity components supported on `main`.

This is a source-faithful carry-forward with only the adaptation required for the target line. It is not an attempt to resolve inherited findings in the source change.
