### PR TITLE
Defer IDCS metadata loading until first use (27.x)

### DIFF
--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
@@ -72,7 +72,8 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
     private final TokenHandler idcsAppNameTokenHandler;
     private final EvictableCache<MtCacheKey, List<Grant>> cache;
     private final MultitenancyEndpoints multitenantEndpoints;
-    private final ConcurrentHashMap<String, AppToken> tokenCache = new ConcurrentHashMap<>();
+    private final RetryableLazyValue<WebClient> appWebClient;
+    private final ConcurrentHashMap<String, RetryableLazyValue<AppToken>> tokenCache = new ConcurrentHashMap<>();
 
     /**
      * Configure instance from any descendant of
@@ -86,6 +87,7 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
         this.idcsTenantTokenHandler = builder.idcsTenantTokenHandler;
         this.idcsAppNameTokenHandler = builder.idcsAppNameTokenHandler;
         this.cache = builder.cache;
+        this.appWebClient = new RetryableLazyValue<>(builder.oidcConfig()::appWebClient);
         if (null == builder.multitentantEndpoints) {
             this.multitenantEndpoints = new DefaultMultitenancyEndpoints(builder.oidcConfig());
         } else {
@@ -276,22 +278,26 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
      */
     protected Optional<String> getAppToken(String idcsTenantId, RoleMapTracing tracing) {
         // if cached and valid, use the cached token
-        return tokenCache.computeIfAbsent(idcsTenantId, key -> {
-            URI tokenEndpoint = multitenantEndpoints.tokenEndpoint(key);
-            OidcConfig oidcConfig = oidcConfig();
+        RetryableLazyValue<AppToken> appToken = tokenCache.computeIfAbsent(
+                idcsTenantId,
+                key -> new RetryableLazyValue<>(() -> createAppToken(key)));
+        return appToken.get().getToken(tracing);
+    }
 
-            if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC
-                    && multitenantEndpoints.useClientCredentials(key, tokenEndpoint)) {
-                return new AppToken(oidcConfig.appWebClient(),
-                                    tokenEndpoint,
-                                    oidcConfig.tokenRefreshSkew(),
-                                    oidcConfig.clientId(),
-                                    oidcConfig.clientSecret());
-            }
+    private AppToken createAppToken(String idcsTenantId) {
+        URI tokenEndpoint = multitenantEndpoints.tokenEndpoint(idcsTenantId);
+        OidcConfig oidcConfig = oidcConfig();
 
-            return new AppToken(oidcConfig.generalWebClient(), tokenEndpoint, oidcConfig.tokenRefreshSkew());
-        })
-                .getToken(tracing);
+        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC
+                && multitenantEndpoints.useClientCredentials(idcsTenantId, tokenEndpoint)) {
+            return new AppToken(appWebClient.get(),
+                                tokenEndpoint,
+                                oidcConfig.tokenRefreshSkew(),
+                                oidcConfig.clientId(),
+                                oidcConfig.clientSecret());
+        }
+
+        return new AppToken(oidcConfig.generalWebClient(), tokenEndpoint, oidcConfig.tokenRefreshSkew());
     }
 
     /**
@@ -459,8 +465,6 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
         private final String urlPrefix;
         private final String assertUrlSuffix;
         private final String tokenUrlSuffix;
-        private final WebClient appClient;
-        private final WebClient generalClient;
 
         // we want to cache endpoints for each tenant
         private final ConcurrentHashMap<String, URI> assertEndpointCache = new ConcurrentHashMap<>();
@@ -490,8 +494,6 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
             urlPrefix = config.identityUri().getScheme() + "://";
             this.assertUrlSuffix = "/admin/v1/Asserter";
             this.tokenUrlSuffix = "/oauth2/v1/token?IDCS_CLIENT_TENANT=";
-            this.generalClient = config.generalWebClient();
-            this.appClient = config.appWebClient();
         }
 
         @Override

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -48,10 +48,9 @@ import io.helidon.webclient.api.HttpClientRequest;
 public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implements SubjectMappingProvider {
     private final EvictableCache<String, List<Grant>> roleCache;
     private final String asserterUri;
-    private final URI tokenEndpointUri;
 
     // caching application token (as that can be re-used for group requests)
-    private final AppToken appToken;
+    private final RetryableLazyValue<AppToken> appToken;
 
     /**
      * Constructor that accepts any {@link IdcsRoleMapperProvider.Builder} descendant.
@@ -65,17 +64,7 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
         OidcConfig oidcConfig = builder.oidcConfig();
 
         this.asserterUri = oidcConfig.identityUri() + "/admin/v1/Asserter";
-        this.tokenEndpointUri = oidcConfig.tokenEndpointUri();
-
-        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC) {
-            this.appToken = new AppToken(oidcConfig.appWebClient(),
-                                         tokenEndpointUri,
-                                         oidcConfig.tokenRefreshSkew(),
-                                         oidcConfig.clientId(),
-                                         oidcConfig.clientSecret());
-        } else {
-            this.appToken = new AppToken(oidcConfig.appWebClient(), tokenEndpointUri, oidcConfig.tokenRefreshSkew());
-        }
+        this.appToken = new RetryableLazyValue<>(() -> createAppToken(oidcConfig));
     }
 
     /**
@@ -176,7 +165,19 @@ public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implement
 
     // Added for testing purposes
     Optional<String> getAppToken(RoleMapTracing tracing) {
-        return appToken.getToken(tracing);
+        return appToken.get().getToken(tracing);
+    }
+
+    private static AppToken createAppToken(OidcConfig oidcConfig) {
+        URI tokenEndpointUri = oidcConfig.tokenEndpointUri();
+        if (oidcConfig.tokenEndpointAuthentication() == OidcConfig.ClientAuthentication.CLIENT_SECRET_BASIC) {
+            return new AppToken(oidcConfig.appWebClient(),
+                                tokenEndpointUri,
+                                oidcConfig.tokenRefreshSkew(),
+                                oidcConfig.clientId(),
+                                oidcConfig.clientSecret());
+        }
+        return new AppToken(oidcConfig.appWebClient(), tokenEndpointUri, oidcConfig.tokenRefreshSkew());
     }
 
     private List<? extends Grant> obtainGrantsFromServer(String subjectName,

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderBase.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.context.Context;
@@ -101,7 +103,6 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
      */
     protected IdcsRoleMapperProviderBase(Builder<?> builder) {
         this.oidcConfig = builder.oidcConfig;
-        this.oidcConfig.tokenEndpointUri(); //Remove once IDCS is rewritten to be lazily loaded
         this.defaultIdcsSubjectType = builder.defaultIdcsSubjectType;
         if (builder.supportedTypes.isEmpty()) {
             this.supportedTypes.add(SubjectType.USER);
@@ -545,6 +546,47 @@ public abstract class IdcsRoleMapperProviderBase implements SubjectMappingProvid
                            e);
             }
             return new AppTokenData();
+        }
+    }
+
+    /**
+     * Shares each initialization attempt with concurrent callers. A successful value remains cached, while a failed
+     * attempt is shared by its callers and replaced so a later call can retry.
+     *
+     * @param <T> type of the initialized value
+     */
+    static final class RetryableLazyValue<T> {
+        private final Supplier<T> supplier;
+        private final AtomicReference<LazyValue<Outcome<T>>> attempt;
+
+        RetryableLazyValue(Supplier<T> supplier) {
+            this.supplier = Objects.requireNonNull(supplier);
+            this.attempt = new AtomicReference<>(newAttempt());
+        }
+
+        T get() {
+            LazyValue<Outcome<T>> currentAttempt = attempt.get();
+            Outcome<T> outcome = currentAttempt.get();
+            RuntimeException failure = outcome.failure();
+            if (failure == null) {
+                return outcome.value();
+            }
+
+            attempt.compareAndSet(currentAttempt, newAttempt());
+            throw failure;
+        }
+
+        private LazyValue<Outcome<T>> newAttempt() {
+            return LazyValue.create(() -> {
+                try {
+                    return new Outcome<>(supplier.get(), null);
+                } catch (RuntimeException e) {
+                    return new Outcome<>(null, e);
+                }
+            });
+        }
+
+        private record Outcome<T>(T value, RuntimeException failure) {
         }
     }
 

--- a/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
+++ b/security/providers/idcs-mapper/src/test/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProviderTest.java
@@ -22,12 +22,21 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
 
+import io.helidon.common.Errors;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -62,8 +71,10 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableWithSize.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class IdcsRoleMapperProviderTest {
@@ -279,6 +290,295 @@ class IdcsRoleMapperProviderTest {
         }
     }
 
+    @Test
+    void testSingleTenantMetadataLoadsOnFirstTokenRequest() {
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            metadataRequests.incrementAndGet();
+                            res.send(metadata[0]);
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            authorization.set(req.headers()
+                                                      .first(HeaderNames.AUTHORIZATION)
+                                                      .orElse(null));
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+
+        try {
+            String tokenHost = "idcs-lazy.example.test";
+            String baseUri = "http://" + tokenHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
+            builder.oidcConfig(OidcConfig.builder()
+                                       .clientId("client-id")
+                                       .clientSecret("client-secret")
+                                       .identityUri(URI.create(baseUri))
+                                       .serverType("idcs")
+                                       .validateJwtWithJwk(false)
+                                       .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                                              InetAddress.getLoopbackAddress()))
+                                       .build());
+
+            IdcsRoleMapperProvider provider = builder.build();
+
+            assertThat(metadataRequests.get(), is(0));
+
+            Optional<String> token = provider.getAppToken(SecurityTracing.get().roleMapTracing("idcs"));
+            String expectedAuthorization = "Basic " + Base64.getEncoder()
+                    .encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(authorization.get(), is(expectedAuthorization));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void testMultitenantMetadataLoadsOnFirstTokenRequest() {
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            metadataRequests.incrementAndGet();
+                            res.send(metadata[0]);
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            authorization.set(req.headers()
+                                                      .first(HeaderNames.AUTHORIZATION)
+                                                      .orElse(null));
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+
+        try {
+            String infraHost = "infra.example.test";
+            String tenantId = "tenant1";
+            String tenantHost = tenantId + ".example.test";
+            String baseUri = "http://" + infraHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            OidcConfig oidcConfig = OidcConfig.builder()
+                    .clientId("client-id")
+                    .clientSecret("client-secret")
+                    .identityUri(URI.create(baseUri))
+                    .serverType("idcs")
+                    .validateJwtWithJwk(false)
+                    .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                           InetAddress.getLoopbackAddress()))
+                    .build();
+            IdcsMtRoleMapperProvider.Builder<?> builder = IdcsMtRoleMapperProvider.builder();
+            builder.oidcConfig(oidcConfig)
+                    .multitenantEndpoints(new TestMultitenancyEndpoints(
+                            oidcConfig,
+                            URI.create("http://" + tenantHost + ":" + server.port()
+                                               + "/oauth2/v1/token?IDCS_CLIENT_TENANT=infra")));
+
+            IdcsMtRoleMapperProvider provider = builder.build();
+
+            assertThat(metadataRequests.get(), is(0));
+
+            Optional<String> token = provider.getAppToken(tenantId, SecurityTracing.get().roleMapTracing("idcs"));
+            String expectedAuthorization = "Basic " + Base64.getEncoder()
+                    .encodeToString("client-id:client-secret".getBytes(StandardCharsets.UTF_8));
+
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(authorization.get(), is(expectedAuthorization));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void testSingleTenantMetadataFailureIsSharedByConcurrentRequests() throws Exception {
+        assertMetadataFailureSharedByConcurrentRequests(false);
+    }
+
+    @Test
+    void testMultitenantMetadataFailureIsSharedByConcurrentRequests() throws Exception {
+        assertMetadataFailureSharedByConcurrentRequests(true);
+    }
+
+    private void assertMetadataFailureSharedByConcurrentRequests(boolean multitenant) throws Exception {
+        int followerCount = 3;
+        AtomicInteger metadataRequests = new AtomicInteger();
+        AtomicInteger tokenRequests = new AtomicInteger();
+        CountDownLatch firstMetadataRequest = new CountDownLatch(1);
+        CountDownLatch releaseMetadataFailure = new CountDownLatch(1);
+        JsonObject[] metadata = new JsonObject[1];
+        String accessToken = signedToken();
+
+        WebServer server = WebServer.builder()
+                .host(InetAddress.getLoopbackAddress().getHostAddress())
+                .routing(routing -> routing
+                        .get("/.well-known/openid-configuration", (req, res) -> {
+                            if (metadataRequests.incrementAndGet() == 1) {
+                                firstMetadataRequest.countDown();
+                                try {
+                                    releaseMetadataFailure.await();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                res.status(Status.INTERNAL_SERVER_ERROR_500)
+                                        .send("metadata unavailable");
+                            } else {
+                                res.send(metadata[0]);
+                            }
+                        })
+                        .post("/oauth2/v1/token", (req, res) -> {
+                            tokenRequests.incrementAndGet();
+                            res.header(HeaderValues.CONTENT_TYPE_JSON)
+                                    .send("{\"access_token\":\"" + accessToken + "\"}");
+                        }))
+                .build()
+                .start();
+        ExecutorService executor = Executors.newFixedThreadPool(followerCount + 1);
+
+        try {
+            String infraHost = "infra.example.test";
+            String tenantHost = "tenant1.example.test";
+            String baseUri = "http://" + infraHost + ":" + server.port();
+            metadata[0] = JsonObject.builder()
+                    .set("token_endpoint", baseUri + "/oauth2/v1/token")
+                    .set("authorization_endpoint", baseUri + "/oauth2/v1/authorize")
+                    .set("end_session_endpoint", baseUri + "/oauth2/v1/userlogout")
+                    .set("introspection_endpoint", baseUri + "/oauth2/v1/introspect")
+                    .set("issuer", baseUri)
+                    .build();
+
+            OidcConfig oidcConfig = OidcConfig.builder()
+                    .clientId("client-id")
+                    .clientSecret("client-secret")
+                    .identityUri(URI.create(baseUri))
+                    .serverType("idcs")
+                    .validateJwtWithJwk(false)
+                    .webclient(webClient -> webClient.dnsResolver((hostname, dnsAddressLookup) ->
+                                                                           InetAddress.getLoopbackAddress()))
+                    .build();
+
+            IntFunction<Optional<String>> tokenRequest;
+            if (multitenant) {
+                IdcsMtRoleMapperProvider.Builder<?> builder = IdcsMtRoleMapperProvider.builder();
+                builder.oidcConfig(oidcConfig)
+                        .multitenantEndpoints(new TestMultitenancyEndpoints(
+                                oidcConfig,
+                                URI.create("http://" + tenantHost + ":" + server.port()
+                                                   + "/oauth2/v1/token?IDCS_CLIENT_TENANT=infra")));
+                IdcsMtRoleMapperProvider provider = builder.build();
+                tokenRequest = requestIndex -> provider.getAppToken(requestIndex % 2 == 0 ? "tenant1" : "tenant2",
+                                                                    SecurityTracing.get().roleMapTracing("idcs"));
+            } else {
+                IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
+                builder.oidcConfig(oidcConfig);
+                IdcsRoleMapperProvider provider = builder.build();
+                tokenRequest = requestIndex -> provider.getAppToken(SecurityTracing.get().roleMapTracing("idcs"));
+            }
+
+            List<Future<Optional<String>>> requests = new ArrayList<>();
+            requests.add(executor.submit(() -> tokenRequest.apply(0)));
+            assertThat(firstMetadataRequest.await(10, TimeUnit.SECONDS), is(true));
+
+            CountDownLatch followersAtCallSite = new CountDownLatch(followerCount);
+            Thread[] followerThreads = new Thread[followerCount];
+            for (int i = 1; i <= followerCount; i++) {
+                int requestIndex = i;
+                requests.add(executor.submit(() -> {
+                    followerThreads[requestIndex - 1] = Thread.currentThread();
+                    followersAtCallSite.countDown();
+                    return tokenRequest.apply(requestIndex);
+                }));
+            }
+            assertThat(followersAtCallSite.await(10, TimeUnit.SECONDS), is(true));
+            // A started task can still be descheduled before it reads the current attempt. Wait until every follower
+            // is parked inside the retryable lazy value before allowing that attempt to fail.
+            for (Thread followerThread : followerThreads) {
+                awaitWaitingInRetryableLazyValue(followerThread);
+            }
+            releaseMetadataFailure.countDown();
+
+            RuntimeException firstFailure = null;
+            for (Future<Optional<String>> request : requests) {
+                ExecutionException failure = assertThrows(ExecutionException.class,
+                                                          () -> request.get(10, TimeUnit.SECONDS));
+                assertThat(failure.getCause(), instanceOf(Errors.ErrorMessagesException.class));
+                if (firstFailure == null) {
+                    firstFailure = (RuntimeException) failure.getCause();
+                } else {
+                    assertThat(failure.getCause(), sameInstance(firstFailure));
+                }
+            }
+            assertThat(metadataRequests.get(), is(1));
+            assertThat(tokenRequests.get(), is(0));
+
+            Optional<String> token = tokenRequest.apply(0);
+            assertThat(token.orElseThrow(), is(accessToken));
+            assertThat(metadataRequests.get(), is(2));
+            assertThat(tokenRequests.get(), is(1));
+        } finally {
+            releaseMetadataFailure.countDown();
+            executor.shutdownNow();
+            server.stop();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS), is(true));
+        }
+    }
+
+    private static void awaitWaitingInRetryableLazyValue(Thread thread) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            if (waitingInRetryableLazyValue(thread)) {
+                return;
+            }
+            Thread.onSpinWait();
+        } while (deadline - System.nanoTime() > 0);
+        fail("Follower did not join the current initialization attempt: " + thread.getName());
+    }
+
+    private static boolean waitingInRetryableLazyValue(Thread thread) {
+        if (thread.getState() != Thread.State.WAITING) {
+            return false;
+        }
+        String retryableLazyValueClass = IdcsRoleMapperProviderBase.class.getName() + "$RetryableLazyValue";
+        for (StackTraceElement element : thread.getStackTrace()) {
+            if (element.getClassName().equals(retryableLazyValueClass)
+                    && element.getMethodName().equals("get")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static IdcsRoleMapperProvider.Builder<?> roleMapperBuilder() {
         IdcsRoleMapperProvider.Builder<?> builder = IdcsRoleMapperProvider.builder();
         builder.oidcConfig(OidcConfig.builder()
@@ -346,6 +646,26 @@ class IdcsRoleMapperProviderTest {
         protected List<? extends Grant> addAdditionalGrants(Subject subject, List<Grant> idcsGrants) {
             return List.of(Role.create("additional_" + COUNTER.incrementAndGet()),
                            Role.create("additional-fixed"));
+        }
+    }
+
+    private static final class TestMultitenancyEndpoints
+            extends IdcsMtRoleMapperProvider.DefaultMultitenancyEndpoints {
+        private final URI tokenEndpoint;
+
+        private TestMultitenancyEndpoints(OidcConfig config, URI tokenEndpoint) {
+            super(config);
+            this.tokenEndpoint = tokenEndpoint;
+        }
+
+        @Override
+        public URI tokenEndpoint(String tenantId) {
+            return tokenEndpoint;
+        }
+
+        @Override
+        public boolean useClientCredentials(String tenantId, URI tokenEndpoint) {
+            return true;
         }
     }
 


### PR DESCRIPTION
Resolves #12355

Carries forward #12285 and #12286 to `main`. Defer IDCS metadata, WebClient, and application-token initialization until the first role-mapping request; share concurrent initialization attempts, cache successful initialization, and allow retry after failure.

This is a source-faithful carry-forward with only the target-line repository-split adaptation. It is not an attempt to resolve inherited findings in the source change.

The MicroProfile startup regression is tracked separately by helidon-io/helidon-microprofile#96 and remains postponed until helidon-io/helidon-microprofile#85 is merged.
