### PR TITLE
Classify HTTP/2 reset write failures as server I/O

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -382,7 +382,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 writeResetStream(frame, clientSettings);
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
-        } catch (UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write window update", e);
         }
     }
@@ -976,7 +976,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 discardDataAfterReset(currentFrameLength);
             }
             if (sendReset) {
-                writeResetStream(rst, clientSettings);
+                try {
+                    writeResetStream(rst, clientSettings);
+                } catch (SocketWriterException | UncheckedIOException e) {
+                    throw new ServerConnectionException("Failed to write reset stream", e);
+                }
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
         } finally {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.http2;
 
+import java.io.UncheckedIOException;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -24,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.ConnectionFlowControl;
@@ -43,6 +47,7 @@ import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.DirectHandlers;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
@@ -54,6 +59,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -197,6 +203,26 @@ class ConnectionStreamTest {
     }
 
     @Test
+    void invalidContentLengthResetWritePreservesSocketWriterException() {
+        assertInvalidContentLengthResetWriteFailure(new SocketWriterException());
+    }
+
+    @Test
+    void invalidContentLengthResetWritePreservesUncheckedIOException() {
+        assertInvalidContentLengthResetWriteFailure(new UncheckedIOException(new SocketException("Broken pipe")));
+    }
+
+    @Test
+    void invalidWindowUpdateResetWritePreservesSocketWriterException() {
+        assertInvalidWindowUpdateResetWriteFailure(new SocketWriterException());
+    }
+
+    @Test
+    void invalidWindowUpdateResetWritePreservesUncheckedIOException() {
+        assertInvalidWindowUpdateResetWriteFailure(new UncheckedIOException(new SocketException("Broken pipe")));
+    }
+
+    @Test
     void resetRestoresOnlyConnectionCreditForQueuedData() {
         List<WindowUpdate> windowUpdates = new ArrayList<>();
         ConnectionFlowControl flowControl = ConnectionFlowControl.serverBuilder(
@@ -269,6 +295,33 @@ class ConnectionStreamTest {
         Http2ServerStream s = mock(Http2ServerStream.class);
         when(s.streamId()).thenReturn(streamId);
         return s;
+    }
+
+    private static void assertInvalidContentLengthResetWriteFailure(RuntimeException writeFailure) {
+        Http2ServerStream stream = stream(new Http2ConnectionStreams(), new RecordingConnectionWriter(writeFailure));
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 2);
+        stream.headers(Http2Headers.create(headers), false);
+        BufferData payload = BufferData.create("frank");
+        Http2FrameHeader header = Http2FrameHeader.create(payload.available(),
+                                                          Http2FrameTypes.DATA,
+                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                          STREAM_ID);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> stream.data(header, payload, true));
+
+        assertThat(exception.getCause(), sameInstance(writeFailure));
+    }
+
+    private static void assertInvalidWindowUpdateResetWriteFailure(RuntimeException writeFailure) {
+        Http2ServerStream stream = stream(new Http2ConnectionStreams(), new RecordingConnectionWriter(writeFailure));
+        stream.headers(Http2Headers.create(WritableHeaders.create()), false);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> stream.windowUpdate(new Http2WindowUpdate(0)));
+
+        assertThat(exception.getCause(), sameInstance(writeFailure));
     }
 
     private static Http2ServerStream stream(Http2ConnectionStreams streams, Http2ConnectionWriter writer) {
@@ -397,10 +450,16 @@ class ConnectionStreamTest {
     }
 
     private static final class RecordingConnectionWriter extends Http2ConnectionWriter {
+        private final RuntimeException writeFailure;
         private Runnable terminalCallback;
 
         private RecordingConnectionWriter() {
+            this(null);
+        }
+
+        private RecordingConnectionWriter(RuntimeException writeFailure) {
             super(mock(SocketContext.class), mock(DataWriter.class), List.of());
+            this.writeFailure = writeFailure;
         }
 
         @Override
@@ -457,6 +516,9 @@ class ConnectionStreamTest {
 
         @Override
         public void write(Http2FrameData frame) {
+            if (writeFailure != null) {
+                throw writeFailure;
+            }
         }
 
         private void completeTerminalWrite() {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -16,27 +16,13 @@
 
 package io.helidon.webserver.tests.http2;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UncheckedIOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.buffers.DataWriter;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
-import io.helidon.http.http2.Http2ConnectionWriter;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
@@ -44,12 +30,8 @@ import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
-import io.helidon.http.http2.Http2Setting;
-import io.helidon.http.http2.Http2Settings;
-import io.helidon.http.http2.Http2Util;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.logging.common.LogConfig;
-import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpRouting;
@@ -75,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ContentLengthTest {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(100);
-    private static final Logger CONNECTION_HANDLER_LOGGER = Logger.getLogger("io.helidon.webserver.ConnectionHandler");
     private static final String SHORTER_DATA_PATH = "/shorter-data";
     private static final String LONGER_DATA_PATH = "/longer-data";
     private static final String PADDED_DATA_PATH = "/padded-data";
@@ -166,23 +147,6 @@ class ContentLengthTest {
         /*
         Now this fails already in connection, we never reach routing.
          */
-    }
-
-    @Test
-    void longerDataClosedPeerIsHandledAsServerIo(WebServer server) throws Exception {
-        TestLogHandler logHandler = new TestLogHandler();
-        Level originalLevel = CONNECTION_HANDLER_LOGGER.getLevel();
-        CONNECTION_HANDLER_LOGGER.setLevel(Level.ALL);
-        CONNECTION_HANDLER_LOGGER.addHandler(logHandler);
-        try {
-            sendLongerDataAndResetPeer(server.port());
-
-            assertThat(logHandler.awaitConnectionFailure(Duration.ofSeconds(5)), is(true));
-            assertThat(logHandler.unexpectedException(), is(false));
-        } finally {
-            CONNECTION_HANDLER_LOGGER.removeHandler(logHandler);
-            CONNECTION_HANDLER_LOGGER.setLevel(originalLevel);
-        }
     }
 
     @Test
@@ -444,59 +408,6 @@ class ContentLengthTest {
         return headers;
     }
 
-    private static void sendLongerDataAndResetPeer(int port) throws IOException {
-        try (Socket socket = new Socket()) {
-            socket.setTcpNoDelay(true);
-            socket.setSoLinger(true, 0);
-            socket.connect(new InetSocketAddress("localhost", port));
-
-            InputStream input = socket.getInputStream();
-            DataWriter rawWriter = new SocketDataWriter(socket.getOutputStream());
-            rawWriter.writeNow(Http2Util.prefaceData());
-            Http2ConnectionWriter h2 = new Http2ConnectionWriter(null, rawWriter, List.of());
-            h2.write(Http2Settings.builder()
-                             .add(Http2Setting.INITIAL_WINDOW_SIZE, 65535L)
-                             .add(Http2Setting.MAX_FRAME_SIZE, 16384L)
-                             .add(Http2Setting.ENABLE_PUSH, false)
-                             .build()
-                             .toFrameData(null, 0, Http2Flag.SettingsFlags.create(0)));
-            assertThat(readFrame(input).header().type(), is(Http2FrameType.SETTINGS));
-            h2.write(new Http2FrameData(Http2FrameHeader.create(0,
-                                                                Http2FrameTypes.SETTINGS,
-                                                                Http2Flag.SettingsFlags.create(Http2Flag.ACK),
-                                                                0),
-                                        BufferData.empty()));
-
-            WritableHeaders<?> headers = WritableHeaders.create();
-            headers.add(HeaderNames.CONTENT_LENGTH, 2);
-            Http2Headers h2Headers = Http2Headers.create(headers);
-            h2Headers.method(POST);
-            h2Headers.path(LONGER_DATA_PATH);
-            h2Headers.scheme("http");
-            h2.writeHeaders(h2Headers,
-                            1,
-                            Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
-                            FlowControl.Outbound.NOOP);
-
-            BufferData payload = BufferData.create("frank");
-            h2.writeData(new Http2FrameData(Http2FrameHeader.create(payload.available(),
-                                                                    Http2FrameTypes.DATA,
-                                                                    Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
-                                                                    1),
-                                           payload),
-                         FlowControl.Outbound.NOOP);
-        }
-    }
-
-    private static Http2FrameData readFrame(InputStream input) throws IOException {
-        byte[] frameHeaderBytes = input.readNBytes(Http2FrameHeader.LENGTH);
-        assertThat(frameHeaderBytes.length, is(Http2FrameHeader.LENGTH));
-        Http2FrameHeader header = Http2FrameHeader.create(BufferData.create(frameHeaderBytes));
-        byte[] frameBytes = input.readNBytes(header.length());
-        assertThat(frameBytes.length, is(header.length()));
-        return new Http2FrameData(header, BufferData.create(frameBytes));
-    }
-
     private WritableHeaders<?> requestHeadersWithContentLengthValue(String... contentLengths) {
         var headers = WritableHeaders.create();
         for (String contentLength : contentLengths) {
@@ -587,76 +498,8 @@ class ContentLengthTest {
         assertNull(testProbe.sendException);
     }
 
-    private record SocketDataWriter(OutputStream output) implements DataWriter {
-        @Override
-        public void write(BufferData... buffers) {
-            writeNow(buffers);
-        }
-
-        @Override
-        public void write(BufferData buffer) {
-            writeNow(buffer);
-        }
-
-        @Override
-        public void writeNow(BufferData... buffers) {
-            for (BufferData buffer : buffers) {
-                writeNow(buffer);
-            }
-        }
-
-        @Override
-        public void writeNow(BufferData buffer) {
-            try {
-                buffer.writeTo(output);
-                output.flush();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-    }
-
     private void assertProtocolRstStream(Http2TestConnection h2conn, int streamId) {
         assertThat(h2conn.assertRstStream(streamId, TIMEOUT).errorCode(), is(Http2ErrorCode.PROTOCOL));
-    }
-
-    private static final class TestLogHandler extends java.util.logging.Handler {
-        private final CountDownLatch connectionFailure = new CountDownLatch(1);
-        private volatile boolean unexpectedException;
-
-        private TestLogHandler() {
-            setLevel(Level.ALL);
-        }
-
-        @Override
-        public void publish(LogRecord record) {
-            String message = record.getMessage();
-            if (message == null) {
-                return;
-            }
-            if (message.contains("server I/O issue")) {
-                connectionFailure.countDown();
-            }
-            if (message.contains("unexpected exception")) {
-                unexpectedException = true;
-            }
-        }
-
-        @Override
-        public void flush() {
-        }
-
-        @Override
-        public void close() {
-        }
-
-        private boolean awaitConnectionFailure(Duration timeout) throws InterruptedException {
-            return connectionFailure.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        }
-
-        private boolean unexpectedException() {
-            return unexpectedException;
-        }
     }
 
     private static final class TestProbe {


### PR DESCRIPTION
Resolves #12356

Classifies HTTP/2 reset write failures as server I/O for invalid content length and invalid window updates. Replaces the timing-dependent peer-close logging test with deterministic writer-failure coverage.
