### PR TITLE
Add method for use of deprecated config setting without a non-deprecated replacement

### DIFF
--- a/config/config/src/main/java/io/helidon/config/DeprecatedConfig.java
+++ b/config/config/src/main/java/io/helidon/config/DeprecatedConfig.java
@@ -31,6 +31,22 @@ public final class DeprecatedConfig {
     }
 
     /**
+     * Get a deprecated value from config, logging a warning if it is present.
+     *
+     * @param config configuration instance
+     * @param deprecatedKey key that should not be used
+     * @return config node of the deprecated key
+     */
+    public static Config get(Config config, String deprecatedKey) {
+        Config deprecatedConfig = config.get(deprecatedKey);
+        if (deprecatedConfig.exists()) {
+            LOGGER.log(Level.WARNING, "You are using a deprecated configuration key. "
+                    + "Deprecated key: \"" + deprecatedConfig.key() + "\".");
+        }
+        return deprecatedConfig;
+    }
+
+    /**
      * Get a value from config, attempting to read both the keys.
      * Warning is logged if either the current key is not defined, or both the keys are defined.
      *

--- a/config/config/src/test/java/io/helidon/config/DeprecatedConfigTest.java
+++ b/config/config/src/test/java/io/helidon/config/DeprecatedConfigTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+class DeprecatedConfigTest {
+    private static final String DEPRECATED_KEY = "deprecated-key";
+
+    private final List<LogRecord> records = new ArrayList<>();
+    private final Logger logger = Logger.getLogger(DeprecatedConfig.class.getName());
+    private final Handler handler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    @BeforeEach
+    void addHandler() {
+        logger.addHandler(handler);
+    }
+
+    @AfterEach
+    void removeHandler() {
+        logger.removeHandler(handler);
+    }
+
+    @Test
+    void warnsWhenDeprecatedKeyIsPresent() {
+        Config config = Config.create(ConfigSources.create(Map.of(DEPRECATED_KEY, "true")));
+
+        assertThat(DeprecatedConfig.get(config, DEPRECATED_KEY).asBoolean().orElseThrow(), is(true));
+        assertThat(records.size(), is(1));
+        assertThat(records.getFirst().getMessage(), containsString(DEPRECATED_KEY));
+    }
+
+    @Test
+    void doesNotWarnWhenDeprecatedKeyIsAbsent() {
+        Config config = Config.create(ConfigSources.empty());
+
+        assertThat(DeprecatedConfig.get(config, DEPRECATED_KEY).exists(), is(false));
+        assertThat(records.isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
### Description
Small part of forward port of #12344. The rest of the forward port affects the helidon-microprofile repo in another PR.

Adds a method to `DeprecatedConfig` for the use of a deprecated setting that does not have a non-deprecated counterpart.

### Documentation
No impact