### PR TITLE
Generate service loader metadata from module uses

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -314,21 +314,24 @@ class BuilderCodegen implements CodegenExtension {
         String resourceLocation = MetadataConstants.LOCATION
                 + (moduleName == null ? "" : "/" + moduleName)
                 + "/" + MetadataConstants.SERVICE_LOADER_FILE;
-        FilerTextResource serviceLoaderResource = filer.textResource(resourceLocation);
+        FilerTextResource serviceLoaderResource = filer.manifest().deferredTextResource(resourceLocation);
         List<String> lines = new ArrayList<>(serviceLoaderResource.lines());
         if (lines.isEmpty()) {
             lines.add("# List of service contracts we want to support either from service registry, or from service loader");
         }
-        boolean modified = false;
-        for (String serviceLoaderContract : this.serviceLoaderContracts) {
-            if (!lines.contains(serviceLoaderContract)) {
-                modified = true;
-                lines.add(serviceLoaderContract);
-            }
-        }
+        Set<String> contracts = lines.stream()
+                .map(String::trim)
+                .filter(it -> !it.isEmpty())
+                .filter(it -> !it.startsWith("#"))
+                .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
+        boolean modified = contracts.addAll(serviceLoaderContracts);
 
         if (modified) {
-            serviceLoaderResource.lines(lines);
+            List<String> newLines = lines.stream()
+                    .filter(it -> it.trim().isEmpty() || it.trim().startsWith("#"))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            newLines.addAll(contracts);
+            serviceLoaderResource.lines(newLines);
             serviceLoaderResource.write();
             filer.manifest()
                     .add(resourceLocation);

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ServiceLoaderMetadataTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ServiceLoaderMetadataTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+class ServiceLoaderMetadataTest {
+    private static final String HEADER =
+            "# List of service contracts we want to support either from service registry, or from service loader";
+
+    @Test
+    void generatesProviderContractsWithoutModuleAnnotation() throws IOException {
+        Path metadata = Path.of("target", "classes", "META-INF", "helidon");
+        List<String> lines = Files.readAllLines(metadata.resolve("io.helidon.builder.test.builder")
+                                                        .resolve("service.loader"));
+
+        assertThat(lines,
+                   contains(HEADER,
+                            "io.helidon.builder.test.testsubjects.ProviderNoImpls",
+                            "io.helidon.builder.test.testsubjects.ProviderNoImpls.SomeService",
+                            "io.helidon.builder.test.testsubjects.SomeProvider"));
+    }
+}

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ManifestResource.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ManifestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
 package io.helidon.codegen;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import io.helidon.metadata.MetadataConstants;
 
@@ -25,11 +28,14 @@ import io.helidon.metadata.MetadataConstants;
  * Support for Helidon manifest file, that lists all manifest resources on the classpath.
  */
 public class ManifestResource {
+    private final CodegenFiler filer;
     private final FilerTextResource manifestResource;
     private final List<String> locations;
+    private final Map<String, DeferredTextResource> deferredTextResources = new LinkedHashMap<>();
     private boolean modified;
 
-    private ManifestResource(FilerTextResource manifestResource, List<String> locations) {
+    private ManifestResource(CodegenFiler filer, FilerTextResource manifestResource, List<String> locations) {
+        this.filer = filer;
         this.manifestResource = manifestResource;
         this.locations = locations;
     }
@@ -48,7 +54,7 @@ public class ManifestResource {
         if (lines.isEmpty()) {
             lines.add(MetadataConstants.MANIFEST_ID_LINE);
         }
-        return new ManifestResource(manifestResource, lines);
+        return new ManifestResource(filer, manifestResource, lines);
     }
 
     /**
@@ -64,12 +70,63 @@ public class ManifestResource {
     }
 
     /**
-     * Write the manifest resource to the file system if modified.
+     * Obtain a shared text resource that is written when this manifest is written.
+     * All callers requesting the same location contribute to the same in-memory resource, so codegen extensions can
+     * update it independently without attempting to create the file more than once during annotation processing.
+     * Calling {@link FilerTextResource#write()} stages the current content; the physical write is deferred until
+     * {@link #write()} is called.
+     *
+     * @param resourceLocation resource location in the classes output directory
+     * @param originatingElements elements that caused this resource to be generated
+     * @return shared deferred resource
+     */
+    public FilerTextResource deferredTextResource(String resourceLocation, Object... originatingElements) {
+        Objects.requireNonNull(resourceLocation);
+        Objects.requireNonNull(originatingElements);
+        return deferredTextResources.computeIfAbsent(resourceLocation,
+                                                     _ -> new DeferredTextResource(
+                                                             filer.textResource(resourceLocation, originatingElements)));
+    }
+
+    /**
+     * Write staged text resources, and write the manifest resource to the file system if modified.
      */
     public void write() {
+        deferredTextResources.values().forEach(DeferredTextResource::writeNow);
         if (modified) {
             manifestResource.lines(locations);
             manifestResource.write();
+        }
+    }
+
+    private static final class DeferredTextResource implements FilerTextResource {
+        private final FilerTextResource delegate;
+        private boolean writeRequested;
+
+        private DeferredTextResource(FilerTextResource delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public List<String> lines() {
+            return delegate.lines();
+        }
+
+        @Override
+        public void lines(List<String> newLines) {
+            delegate.lines(newLines);
+        }
+
+        @Override
+        public void write() {
+            writeRequested = true;
+        }
+
+        private void writeNow() {
+            if (writeRequested) {
+                delegate.write();
+                writeRequested = false;
+            }
         }
     }
 }

--- a/codegen/codegen/src/test/java/io/helidon/codegen/ManifestResourceTest.java
+++ b/codegen/codegen/src/test/java/io/helidon/codegen/ManifestResourceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.codegen;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.types.TypeName;
+import io.helidon.metadata.MetadataConstants;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ManifestResourceTest {
+    private static final String LOCATION = MetadataConstants.LOCATION + "/test.module/service.loader";
+
+    @Test
+    void combinesDeferredResourceUpdatesIntoOneWrite() {
+        var filer = new TestFiler();
+        ManifestResource manifest = ManifestResource.create(filer);
+        FilerTextResource first = manifest.deferredTextResource(LOCATION);
+        FilerTextResource second = manifest.deferredTextResource(LOCATION);
+
+        assertThat(second, sameInstance(first));
+
+        first.lines(List.of("# header", "example.First"));
+        first.write();
+        List<String> combined = new ArrayList<>(second.lines());
+        combined.add("example.Second");
+        second.lines(combined);
+        second.write();
+        manifest.add(LOCATION);
+
+        assertThat(filer.resource(LOCATION).writeCount(), is(0));
+
+        manifest.write();
+
+        assertThat(filer.resource(LOCATION).lines(), is(List.of("# header", "example.First", "example.Second")));
+        assertThat(filer.resource(LOCATION).writeCount(), is(1));
+        assertThat(filer.resource(MetadataConstants.LOCATION + "/" + MetadataConstants.MANIFEST_FILE).lines(),
+                   is(List.of(MetadataConstants.MANIFEST_ID_LINE, LOCATION)));
+    }
+
+    private static final class TestFiler implements CodegenFiler {
+        private final Map<String, TestTextResource> resources = new HashMap<>();
+
+        @Override
+        public Path writeSourceFile(ClassModel classModel, Object... originatingElements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Path writeSourceFile(TypeName type, String content, Object... originatingElements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Path writeResource(byte[] resource, String location, Object... originatingElements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FilerTextResource textResource(String location, Object... originatingElements) {
+            return resource(location);
+        }
+
+        private TestTextResource resource(String location) {
+            return resources.computeIfAbsent(location, _ -> new TestTextResource());
+        }
+    }
+
+    private static final class TestTextResource implements FilerTextResource {
+        private List<String> lines = List.of();
+        private int writeCount;
+
+        @Override
+        public List<String> lines() {
+            return lines;
+        }
+
+        @Override
+        public void lines(List<String> newLines) {
+            lines = List.copyOf(newLines);
+        }
+
+        @Override
+        public void write() {
+            writeCount++;
+        }
+
+        private int writeCount() {
+            return writeCount;
+        }
+    }
+}

--- a/common/mapper/src/main/java/module-info.java
+++ b/common/mapper/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import io.helidon.service.registry.Service;
+
 /**
  * Helidon Common Mapper.
  */
+@Service.DiscoverFromServiceLoader
 module io.helidon.common.mapper {
     requires transitive io.helidon.common;
     requires transitive io.helidon.builder.api;

--- a/common/mapper/src/main/resources/META-INF/helidon/io.helidon.common.mapper/service.loader
+++ b/common/mapper/src/main/resources/META-INF/helidon/io.helidon.common.mapper/service.loader
@@ -1,2 +1,0 @@
-# List of service contracts we want to support either from service registry, or from service loader
-io.helidon.common.mapper.spi.MapperProvider

--- a/common/mapper/src/main/resources/META-INF/helidon/manifest
+++ b/common/mapper/src/main/resources/META-INF/helidon/manifest
@@ -1,2 +1,0 @@
-#HELIDON MANIFEST#
-META-INF/helidon/io.helidon.common.mapper/service.loader

--- a/json/schema/schema/pom.xml
+++ b/json/schema/schema/pom.xml
@@ -89,6 +89,11 @@
                             <artifactId>helidon-common-features-codegen</artifactId>
                             <version>${helidon.version}</version>
                         </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
@@ -110,6 +115,11 @@
                     <dependency>
                         <groupId>io.helidon.common.features</groupId>
                         <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/json/schema/schema/src/main/java/module-info.java
+++ b/json/schema/schema/src/main/java/module-info.java
@@ -15,6 +15,7 @@
  */
 
 import io.helidon.common.features.api.Features;
+import io.helidon.service.registry.Service;
 
 /**
  * JSON Schema annotations and lookup.
@@ -27,6 +28,7 @@ import io.helidon.common.features.api.Features;
 @Features.Path({"JSON", "Schema"})
 @Features.Description("JSON - Schema")
 @Features.Incubating
+@Service.DiscoverFromServiceLoader
 module io.helidon.json.schema {
     requires static io.helidon.common.features.api;
     requires transitive io.helidon.json;
@@ -36,4 +38,6 @@ module io.helidon.json.schema {
 
     exports io.helidon.json.schema;
     exports io.helidon.json.schema.spi;
+
+    uses io.helidon.json.schema.spi.JsonSchemaProvider;
 }

--- a/json/schema/schema/src/main/resources/META-INF/helidon/io.helidon.json.schema/service.loader
+++ b/json/schema/schema/src/main/resources/META-INF/helidon/io.helidon.json.schema/service.loader
@@ -1,1 +1,0 @@
-io.helidon.json.schema.spi.JsonSchemaProvider

--- a/json/schema/schema/src/main/resources/META-INF/helidon/manifest
+++ b/json/schema/schema/src/main/resources/META-INF/helidon/manifest
@@ -1,2 +1,0 @@
-#HELIDON MANIFEST#
-META-INF/helidon/io.helidon.json.schema/service.loader

--- a/metrics/api/src/main/java/module-info.java
+++ b/metrics/api/src/main/java/module-info.java
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import io.helidon.service.registry.Service;
+
 /**
  * Helidon metrics API.
  */
+@Service.DiscoverFromServiceLoader
 module io.helidon.metrics.api {
 
     requires io.helidon.http;

--- a/metrics/api/src/main/resources/META-INF/helidon/io.helidon.metrics.api/service.loader
+++ b/metrics/api/src/main/resources/META-INF/helidon/io.helidon.metrics.api/service.loader
@@ -1,8 +1,0 @@
-# List of service contracts we want to support either from service registry, or from service loader
-io.helidon.metrics.spi.ExemplarService
-io.helidon.metrics.spi.MetricsProgrammaticConfig
-io.helidon.metrics.spi.MetricsFactoryProvider
-io.helidon.metrics.spi.MeterRegistryFormatterProvider
-io.helidon.metrics.api.MetricsFactory
-io.helidon.metrics.spi.MetersProvider
-io.helidon.metrics.spi.MeterRegistryLifeCycleListener

--- a/metrics/api/src/main/resources/META-INF/helidon/manifest
+++ b/metrics/api/src/main/resources/META-INF/helidon/manifest
@@ -1,2 +1,0 @@
-#HELIDON MANIFEST#
-META-INF/helidon/io.helidon.metrics.api/service.loader

--- a/metrics/providers/micrometer/src/main/java/module-info.java
+++ b/metrics/providers/micrometer/src/main/java/module-info.java
@@ -16,6 +16,7 @@
 
 import io.helidon.common.features.api.Features;
 import io.helidon.common.features.api.HelidonFlavor;
+import io.helidon.service.registry.Service;
 
 /**
  * Micrometer adapter for Helidon metrics API.
@@ -24,6 +25,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Description("Micrometer provider for metrics")
 @Features.Flavor(HelidonFlavor.SE)
 @Features.Path({"Metrics", "Micrometer"})
+@Service.DiscoverFromServiceLoader
 module io.helidon.metrics.providers.micrometer {
 
     requires static io.helidon.common.features.api;

--- a/metrics/providers/micrometer/src/main/resources/META-INF/helidon/io.helidon.metrics.providers.micrometer/service.loader
+++ b/metrics/providers/micrometer/src/main/resources/META-INF/helidon/io.helidon.metrics.providers.micrometer/service.loader
@@ -1,2 +1,0 @@
-# List of service contracts we want to support either from service registry, or from service loader
-io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider

--- a/metrics/providers/micrometer/src/main/resources/META-INF/helidon/manifest
+++ b/metrics/providers/micrometer/src/main/resources/META-INF/helidon/manifest
@@ -1,2 +1,0 @@
-#HELIDON MANIFEST#
-META-INF/helidon/io.helidon.metrics.providers.micrometer/service.loader

--- a/service/codegen/pom.xml
+++ b/service/codegen/pom.xml
@@ -33,11 +33,6 @@
         Code generation implementation for Helidon Service, to be used from annotation processing and from maven plugin
     </description>
 
-    <properties>
-        <!-- TestCompiler module-path setup is incorrectly reported as compile-scope test-only dependencies. -->
-        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -67,49 +62,5 @@
             <groupId>io.helidon.service</groupId>
             <artifactId>helidon-service-metadata</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.helidon.codegen</groupId>
-            <artifactId>helidon-codegen-apt</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.codegen</groupId>
-            <artifactId>helidon-codegen-testing</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <configuration>
-                            <proc>none</proc>
-                            <compilerArgs combine.children="append">
-                                <compilerArg>--add-modules</compilerArg>
-                                <compilerArg>java.compiler</compilerArg>
-                                <compilerArg>--add-reads</compilerArg>
-                                <compilerArg>io.helidon.service.codegen=java.compiler</compilerArg>
-                            </compilerArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/service/codegen/pom.xml
+++ b/service/codegen/pom.xml
@@ -33,6 +33,11 @@
         Code generation implementation for Helidon Service, to be used from annotation processing and from maven plugin
     </description>
 
+    <properties>
+        <!-- TestCompiler module-path setup is incorrectly reported as compile-scope test-only dependencies. -->
+        <dependency-plugin-check-dependencies.skip>true</dependency-plugin-check-dependencies.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -62,5 +67,49 @@
             <groupId>io.helidon.service</groupId>
             <artifactId>helidon-service-metadata</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-apt</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <proc>none</proc>
+                            <compilerArgs combine.children="append">
+                                <compilerArg>--add-modules</compilerArg>
+                                <compilerArg>java.compiler</compilerArg>
+                                <compilerArg>--add-reads</compilerArg>
+                                <compilerArg>io.helidon.service.codegen=java.compiler</compilerArg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceCodegenTypes.java
@@ -42,6 +42,12 @@ public final class ServiceCodegenTypes {
     public static final TypeName SERVICE_ANNOTATION_RUN_LEVEL =
             TypeName.create("io.helidon.service.registry.Service.RunLevel");
     /**
+     * {@link io.helidon.common.types.TypeName} for
+     * {@code io.helidon.service.registry.Service.DiscoverFromServiceLoader}.
+     */
+    public static final TypeName SERVICE_ANNOTATION_DISCOVER_FROM_SERVICE_LOADER =
+            TypeName.create("io.helidon.service.registry.Service.DiscoverFromServiceLoader");
+    /**
      * {@link io.helidon.common.types.TypeName} for {@code io.helidon.service.registry.Service.EntryPoint}.
      */
     public static final TypeName SERVICE_ANNOTATION_ENTRY_POINT =

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceLoaderMetadata.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceLoaderMetadata.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.codegen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.codegen.CodegenException;
+import io.helidon.codegen.CodegenFiler;
+import io.helidon.codegen.FilerTextResource;
+import io.helidon.common.types.ModuleTypeInfo;
+import io.helidon.metadata.MetadataConstants;
+
+final class ServiceLoaderMetadata {
+    private static final String HEADER =
+            "# List of service contracts we want to support either from service registry, or from service loader";
+
+    private ServiceLoaderMetadata() {
+    }
+
+    static void write(CodegenFiler filer, ModuleTypeInfo module) {
+        List<String> contracts = module.uses()
+                .stream()
+                .map(it -> it.service().fqName())
+                .sorted()
+                .toList();
+        if (contracts.isEmpty()) {
+            throw new CodegenException("Module annotated for service loader discovery must declare at least one uses directive",
+                                       module.originatingElementValue());
+        }
+
+        String resourceLocation = MetadataConstants.LOCATION
+                + "/" + module.name()
+                + "/" + MetadataConstants.SERVICE_LOADER_FILE;
+        FilerTextResource resource = filer.manifest().deferredTextResource(resourceLocation,
+                                                                          module.originatingElementValue());
+        List<String> existingLines = resource.lines();
+        List<String> newLines = new ArrayList<>(contracts.size() + 1);
+
+        newLines.add(HEADER);
+        newLines.addAll(contracts);
+
+        if (!newLines.equals(existingLines)) {
+            resource.lines(newLines);
+            resource.write();
+        }
+        filer.manifest().add(resourceLocation);
+    }
+}

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenExtension.java
@@ -82,6 +82,9 @@ class ServiceRegistryCodegenExtension implements CodegenExtension {
 
     @Override
     public void process(io.helidon.codegen.RoundContext roundContext) {
+        roundContext.modules()
+                .forEach(module -> ServiceLoaderMetadata.write(ctx.filer(), module));
+
         List<DescriptorClassCode> descriptors = new ArrayList<>();
         Collection<TypeInfo> allTypes = roundContext.types();
         if (allTypes.isEmpty()) {

--- a/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenProvider.java
+++ b/service/codegen/src/main/java/io/helidon/service/codegen/ServiceRegistryCodegenProvider.java
@@ -57,6 +57,7 @@ public class ServiceRegistryCodegenProvider implements CodegenExtensionProvider 
                                   .map(RegistryCodegenExtensionProvider::supportedAnnotations)
                                   .flatMap(Set::stream),
                           Stream.of(TypeNames.GENERATED,
+                                    ServiceCodegenTypes.SERVICE_ANNOTATION_DISCOVER_FROM_SERVICE_LOADER,
                                     ServiceCodegenTypes.SERVICE_ANNOTATION_DESCRIPTOR))
                     .collect(Collectors.toUnmodifiableSet());
 

--- a/service/codegen/src/test/java/io/helidon/service/codegen/ServiceLoaderMetadataTest.java
+++ b/service/codegen/src/test/java/io/helidon/service/codegen/ServiceLoaderMetadataTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.metadata.MetadataConstants;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ServiceLoaderMetadataTest {
+    private static final String HEADER =
+            "# List of service contracts we want to support either from service registry, or from service loader";
+    private static final String ANNOTATION_SOURCE = """
+            package io.helidon.service.registry;
+
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+
+            public final class Service {
+                private Service() {
+                }
+
+                @Retention(RetentionPolicy.CLASS)
+                @Target(ElementType.MODULE)
+                public @interface DiscoverFromServiceLoader {
+                }
+            }
+            """;
+
+    @Test
+    void replacesServiceLoaderContractsFromModuleUses() throws IOException {
+        var first = compiler("""
+                import io.helidon.service.registry.Service;
+
+                @Service.DiscoverFromServiceLoader
+                module test.module {
+                    uses test.spi.Second;
+                    uses test.spi.First;
+                }
+                """, "Second")
+                .build()
+                .compile();
+        assertSuccess(first);
+        assertServiceLoader(first.classOutput(), "test.spi.First", "test.spi.Second");
+
+        Path workDir = first.classOutput().getParent();
+        var second = compiler("""
+                import io.helidon.service.registry.Service;
+
+                @Service.DiscoverFromServiceLoader
+                module test.module {
+                    uses test.spi.Third;
+                    uses test.spi.First;
+                }
+                """, "Third")
+                .workDir(workDir)
+                .build()
+                .compile();
+        assertSuccess(second);
+        assertServiceLoader(second.classOutput(), "test.spi.First", "test.spi.Third");
+    }
+
+    private static TestCompiler.Builder compiler(String moduleInfo, String additionalContract) {
+        return TestCompiler.builder()
+                .currentRelease()
+                .addProcessor(AptProcessor::new)
+                .printDiagnostics(false)
+                .addSource("module-info.java", moduleInfo)
+                .addSource("io/helidon/service/registry/Service.java", ANNOTATION_SOURCE)
+                .addSource("test/spi/First.java", "package test.spi; public interface First {}")
+                .addSource("test/spi/" + additionalContract + ".java",
+                           "package test.spi; public interface " + additionalContract + " {}");
+    }
+
+    private static void assertSuccess(TestCompiler.Result result) {
+        assertThat("Compilation diagnostics: " + String.join("\n", result.diagnostics()), result.success(), is(true));
+    }
+
+    private static void assertServiceLoader(Path classOutput, String... contracts) throws IOException {
+        Path serviceLoader = classOutput.resolve(MetadataConstants.LOCATION)
+                .resolve("test.module")
+                .resolve(MetadataConstants.SERVICE_LOADER_FILE);
+        List<String> expected = new ArrayList<>();
+        expected.add(HEADER);
+        expected.addAll(List.of(contracts));
+        assertThat(Files.readAllLines(serviceLoader), is(expected));
+    }
+}

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -290,6 +290,19 @@ public final class Service {
     }
 
     /**
+     * Discover Java {@link java.util.ServiceLoader} providers through the service registry.
+     * <p>
+     * When a module is annotated with this annotation, Helidon service code generation contributes every service contract
+     * declared by a {@code uses} directive in that module to the module's {@code service.loader} metadata. Other code
+     * generators may contribute additional contracts to the same metadata.
+     */
+    @Documented
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.MODULE)
+    public @interface DiscoverFromServiceLoader {
+    }
+
+    /**
      * A service that has instances created for each named instance of the service it is driven by.
      * The instance created will have the same {@link Named} qualifier as the
      * driving instance (in addition to all qualifiers defined on this service).

--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -72,6 +72,56 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.plugin.surefire}</version>
                 <configuration>

--- a/service/tests/codegen/pom.xml
+++ b/service/tests/codegen/pom.xml
@@ -47,6 +47,17 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-apt</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.codegen</groupId>
+            <artifactId>helidon-codegen-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/service/tests/codegen/src/main/java/io/helidon/service/tests/codegen/testsubject/ServiceLoaderMetadataBlueprint.java
+++ b/service/tests/codegen/src/main/java/io/helidon/service/tests/codegen/testsubject/ServiceLoaderMetadataBlueprint.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.codegen.testsubject;
+
+import java.util.List;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.service.registry.DependencyPlanBinder;
+
+/**
+ * Blueprint that contributes a provider contract to service loader metadata independently of JPMS {@code uses}.
+ */
+@Prototype.Blueprint
+@Prototype.RegistrySupport
+interface ServiceLoaderMetadataBlueprint {
+    /**
+     * Providers discovered through service loader or service registry.
+     *
+     * @return discovered providers
+     */
+    @Option.Provider(DependencyPlanBinder.class)
+    List<DependencyPlanBinder> providers();
+}

--- a/service/tests/codegen/src/main/java/module-info.java
+++ b/service/tests/codegen/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import io.helidon.service.registry.Service;
+
+@Service.DiscoverFromServiceLoader
 module io.helidon.service.tests.codegen {
     requires io.helidon.service.registry;
     requires io.helidon.service.codegen;
     requires io.helidon.config.metadata;
+
+    uses io.helidon.service.registry.EventManager;
+    uses io.helidon.service.registry.RegistryStartupProvider;
 }

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceCodegenTypesTest.java
@@ -116,6 +116,11 @@ class ServiceCodegenTypesTest {
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_PER_LOOKUP", Service.PerLookup.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_PER_INSTANCE", Service.PerInstance.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_RUN_LEVEL", Service.RunLevel.class);
+        checkField(toCheck,
+                   checked,
+                   fields,
+                   "SERVICE_ANNOTATION_DISCOVER_FROM_SERVICE_LOADER",
+                   Service.DiscoverFromServiceLoader.class);
         checkField(toCheck, checked, fields, "SERVICE_ANNOTATION_ENTRY_POINT", Service.EntryPoint.class);
         checkField(toCheck, checked, fields, "SERVICE_INJECTION_POINT_FACTORY", Service.InjectionPointFactory.class);
         checkField(toCheck, checked, fields, "SERVICE_SCOPE_HANDLER", Service.ScopeHandler.class);

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceLoaderCodegenTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceLoaderCodegenTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.tests.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.service.registry.DependencyPlanBinder;
+import io.helidon.service.registry.EventManager;
+import io.helidon.service.registry.RegistryStartupProvider;
+import io.helidon.testing.junit5.Testing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+@Testing.Test
+class ServiceLoaderCodegenTest {
+    private static final String HEADER =
+            "# List of service contracts we want to support either from service registry, or from service loader";
+    private static final String MODULE_NAME = "io.helidon.service.tests.codegen";
+    private static final Path METADATA = Path.of("target", "classes", "META-INF", "helidon");
+
+    @Test
+    void generatesServiceLoaderMetadataFromModuleUses() throws IOException {
+        Path serviceLoader = METADATA.resolve(MODULE_NAME)
+                .resolve("service.loader");
+        List<String> lines = Files.readAllLines(serviceLoader);
+
+        assertThat(lines,
+                   contains(HEADER,
+                            DependencyPlanBinder.class.getName(),
+                            EventManager.class.getName(),
+                            RegistryStartupProvider.class.getName()));
+        assertThat(Files.readAllLines(METADATA.resolve("manifest")),
+                   contains("#HELIDON MANIFEST#",
+                            "META-INF/helidon/" + MODULE_NAME + "/service.loader"));
+    }
+}

--- a/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceLoaderMetadataTest.java
+++ b/service/tests/codegen/src/test/java/io/helidon/service/tests/codegen/ServiceLoaderMetadataTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.service.codegen;
+package io.helidon.service.tests.codegen;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,7 +24,6 @@ import java.util.List;
 
 import io.helidon.codegen.apt.AptProcessor;
 import io.helidon.codegen.testing.TestCompiler;
-import io.helidon.metadata.MetadataConstants;
 
 import org.junit.jupiter.api.Test;
 
@@ -103,9 +102,10 @@ class ServiceLoaderMetadataTest {
     }
 
     private static void assertServiceLoader(Path classOutput, String... contracts) throws IOException {
-        Path serviceLoader = classOutput.resolve(MetadataConstants.LOCATION)
+        Path serviceLoader = classOutput.resolve("META-INF")
+                .resolve("helidon")
                 .resolve("test.module")
-                .resolve(MetadataConstants.SERVICE_LOADER_FILE);
+                .resolve("service.loader");
         List<String> expected = new ArrayList<>();
         expected.add(HEADER);
         expected.addAll(List.of(contracts));

--- a/service/tests/codegen/src/test/java/module-info.java
+++ b/service/tests/codegen/src/test/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ module io.helidon.service.tests.codegen.test {
     requires io.helidon.service.registry;
     requires io.helidon.service.codegen;
     requires io.helidon.config.metadata;
+    requires io.helidon.codegen.apt;
+    requires helidon.codegen.testing;
 
     requires hamcrest.all;
     requires org.junit.jupiter.api;


### PR DESCRIPTION
Generate module-local `service.loader` metadata from annotated JPMS `uses` directives.

Builder codegen continues to contribute provider contracts independently. Both code generators stage updates through a shared deferred manifest resource so annotation processing writes the metadata once.

This migrates common mapper, JSON schema, metrics API, and Micrometer from checked-in metadata. Config remains unchanged.
