### PR TITLE
Support SSE over HTTP/2 (27.x)

### DIFF
--- a/docs/modules/sse.md
+++ b/docs/modules/sse.md
@@ -46,7 +46,7 @@ the WebServer.
 Sending events is accomplished by obtaining an `SseSink` instance from a
 `ServerResponse` using the `SseSink.TYPE` constant. The following example
 converts the response into an `SseSink`, emits two string messages and then
-closes the connection.
+closes the SSE response stream.
 
 ```java
 try (SseSink sseSink = res.sink(SseSink.TYPE)) {
@@ -153,7 +153,7 @@ try (Http1ClientResponse r = client.get("/sseJson")
 
 The `SseSource` type defines other methods such as `onOpen`, `onClose` and
 `onError`. The following example waits for zero or more string events until the
-connection is closed. A `CountDownLatch` is a convenient way to asynchronously
+event stream is closed. A `CountDownLatch` is a convenient way to asynchronously
 wait until all the events are received.
 
 ```java

--- a/docs/modules/sse.md
+++ b/docs/modules/sse.md
@@ -59,6 +59,10 @@ Once an `SseSink` is obtained from a `ServerResponse`, the latter is no longer
 usable to send additional data to the client given that response `Content-Type`
 will be automatically set to `text/event-stream`. Note that an `SseSink` is auto
 closeable, so it can be part of a try-with-resources block as shown above.
+The server-side `SseSink` supports both HTTP/1.1 and HTTP/2 when HTTP/2 is enabled
+for the WebServer. Closing the sink completes the SSE response stream, while the
+underlying connection can remain available for later HTTP/1.1 requests or other
+HTTP/2 streams.
 
 Events can be created using any of the static `create` methods in `SseEvent` as
 well as via a builder obtained by calling `SseEvent.builder()`. For more
@@ -154,7 +158,9 @@ try (Http1ClientResponse r = client.get("/sseJson")
 The `SseSource` type defines other methods such as `onOpen`, `onClose` and
 `onError`. The following example waits for zero or more string events until the
 event stream is closed. A `CountDownLatch` is a convenient way to asynchronously
-wait until all the events are received.
+wait until all the events are received. The server-side HTTP/2 support described
+above does not extend the WebClient `SseSource` to HTTP/2; this example continues
+to use an `Http1ClientResponse`.
 
 ```java
 try (Http1ClientResponse r = client.get("/sseString")

--- a/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
@@ -167,12 +167,16 @@ public class ConnectionFlowControl {
         outboundConnectionWindowSize.connectionClosed();
     }
 
-    void streamClosed() {
-        outboundConnectionWindowSize.triggerUpdate();
+    WindowSizeImpl.Outbound.ConnectionWindowWaiter createConnectionWindowWaiter(BooleanSupplier streamClosed) {
+        return outboundConnectionWindowSize.createConnectionWindowWaiter(streamClosed);
     }
 
-    void blockTillUpdate(BooleanSupplier streamClosed) {
-        outboundConnectionWindowSize.blockTillUpdate(streamClosed);
+    void streamClosed(WindowSizeImpl.Outbound.ConnectionWindowWaiter waiter) {
+        outboundConnectionWindowSize.triggerUpdate(waiter);
+    }
+
+    void blockTillUpdate(WindowSizeImpl.Outbound.ConnectionWindowWaiter waiter) {
+        outboundConnectionWindowSize.blockTillUpdate(waiter);
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/ConnectionFlowControl.java
@@ -18,6 +18,7 @@ package io.helidon.http.http2;
 
 import java.time.Duration;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 
 import io.helidon.common.Builder;
 
@@ -164,6 +165,14 @@ public class ConnectionFlowControl {
 
     void connectionClosed() {
         outboundConnectionWindowSize.connectionClosed();
+    }
+
+    void streamClosed() {
+        outboundConnectionWindowSize.triggerUpdate();
+    }
+
+    void blockTillUpdate(BooleanSupplier streamClosed) {
+        outboundConnectionWindowSize.blockTillUpdate(streamClosed);
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControl.java
@@ -108,6 +108,14 @@ public interface FlowControl {
         }
 
         /**
+         * Notify flow control that the stream has closed.
+         * <p>
+         * Releases threads blocked waiting for a window update on this stream without closing the connection flow control.
+         */
+        default void streamClosed() {
+        }
+
+        /**
          * MAX_FRAME_SIZE setting last received from the other side or default.
          * @return MAX_FRAME_SIZE
          */

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.http.http2;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
@@ -133,9 +135,23 @@ abstract class FlowControlImpl implements FlowControl {
 
     static class Outbound extends FlowControlImpl implements FlowControl.Outbound {
 
+        private static final VarHandle CONNECTION_WINDOW_WAITER;
+
+        static {
+            try {
+                CONNECTION_WINDOW_WAITER = MethodHandles.lookup()
+                        .findVarHandle(FlowControlImpl.Outbound.class,
+                                       "connectionWindowWaiter",
+                                       WindowSizeImpl.Outbound.ConnectionWindowWaiter.class);
+            } catch (ReflectiveOperationException e) {
+                throw new Error("Unable to obtain connection window waiter VarHandle", e);
+            }
+        }
+
         private final ConnectionFlowControl.Type type;
         private final ConnectionFlowControl connectionFlowControl;
         private final WindowSizeImpl.Outbound streamWindowSize;
+        private volatile WindowSizeImpl.Outbound.ConnectionWindowWaiter connectionWindowWaiter;
 
         Outbound(ConnectionFlowControl.Type type,
                  int streamId,
@@ -186,7 +202,7 @@ abstract class FlowControlImpl implements FlowControl {
 
         @Override
         public void blockTillUpdate() {
-            connectionFlowControl.blockTillUpdate(streamWindowSize::isStreamClosed);
+            connectionFlowControl.blockTillUpdate(connectionWindowWaiter());
             streamWindowSize.blockTillUpdate();
         }
 
@@ -199,12 +215,29 @@ abstract class FlowControlImpl implements FlowControl {
         @Override
         public void streamClosed() {
             streamWindowSize.streamClosed();
-            connectionFlowControl.streamClosed();
+            WindowSizeImpl.Outbound.ConnectionWindowWaiter waiter = connectionWindowWaiter;
+            if (waiter != null) {
+                connectionFlowControl.streamClosed(waiter);
+            }
         }
 
         @Override
         public int maxFrameSize() {
             return connectionFlowControl.maxFrameSize();
+        }
+
+        private WindowSizeImpl.Outbound.ConnectionWindowWaiter connectionWindowWaiter() {
+            WindowSizeImpl.Outbound.ConnectionWindowWaiter waiter = connectionWindowWaiter;
+            if (waiter == null) {
+                WindowSizeImpl.Outbound.ConnectionWindowWaiter newWaiter =
+                        connectionFlowControl.createConnectionWindowWaiter(streamWindowSize::isStreamClosed);
+                if (CONNECTION_WINDOW_WAITER.compareAndSet(this, null, newWaiter)) {
+                    waiter = newWaiter;
+                } else {
+                    waiter = connectionWindowWaiter;
+                }
+            }
+            return waiter;
         }
     }
 

--- a/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/FlowControlImpl.java
@@ -186,7 +186,7 @@ abstract class FlowControlImpl implements FlowControl {
 
         @Override
         public void blockTillUpdate() {
-            connectionFlowControl.outbound().blockTillUpdate();
+            connectionFlowControl.blockTillUpdate(streamWindowSize::isStreamClosed);
             streamWindowSize.blockTillUpdate();
         }
 
@@ -194,6 +194,12 @@ abstract class FlowControlImpl implements FlowControl {
         public void connectionClosed() {
             connectionFlowControl.connectionClosed();
             streamWindowSize.connectionClosed();
+        }
+
+        @Override
+        public void streamClosed() {
+            streamWindowSize.streamClosed();
+            connectionFlowControl.streamClosed();
         }
 
         @Override

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 
 import static java.lang.System.Logger.Level.DEBUG;
 
@@ -135,6 +136,7 @@ abstract class WindowSizeImpl implements WindowSize {
         private final int streamId;
         private final long timeoutMillis;
         private boolean connectionClosed;
+        private volatile boolean streamClosed;
 
         Outbound(ConnectionFlowControl.Type type, int streamId, ConnectionFlowControl connectionFlowControl) {
             super(type, streamId, connectionFlowControl.initialWindowSize());
@@ -196,8 +198,26 @@ abstract class WindowSizeImpl implements WindowSize {
             }
         }
 
+        void streamClosed() {
+            updateLock.lock();
+            try {
+                streamClosed = true;
+                updated.signalAll();
+            } finally {
+                updateLock.unlock();
+            }
+        }
+
+        boolean isStreamClosed() {
+            return streamClosed;
+        }
+
         @Override
         public void blockTillUpdate() {
+            blockTillUpdate(() -> false);
+        }
+
+        void blockTillUpdate(BooleanSupplier otherStreamClosed) {
             var startTime = System.nanoTime();
             long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
             try {
@@ -209,6 +229,10 @@ abstract class WindowSizeImpl implements WindowSize {
                         if (connectionClosed) {
                             throw new Http2Exception(Http2ErrorCode.CANCEL,
                                                      "Connection closed while waiting for a flow control update.");
+                        }
+                        if (streamClosed || otherStreamClosed.getAsBoolean()) {
+                            throw new Http2Exception(Http2ErrorCode.CANCEL,
+                                                     "Stream closed while waiting for a flow control update.");
                         }
                         // Updates acquire this lock, so the predicate check and await enrollment are atomic.
                         int remainingWindowSize = getRemainingWindowSize();

--- a/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/WindowSizeImpl.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.http.http2;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
@@ -137,6 +139,7 @@ abstract class WindowSizeImpl implements WindowSize {
         private final long timeoutMillis;
         private boolean connectionClosed;
         private volatile boolean streamClosed;
+        private Set<ConnectionWindowWaiter> connectionWindowWaiters;
 
         Outbound(ConnectionFlowControl.Type type, int streamId, ConnectionFlowControl connectionFlowControl) {
             super(type, streamId, connectionFlowControl.initialWindowSize());
@@ -152,6 +155,7 @@ abstract class WindowSizeImpl implements WindowSize {
             try {
                 remaining = super.incrementWindowSize(increment);
                 updated.signalAll();
+                signalConnectionWindowWaiters();
             } finally {
                 updateLock.unlock();
             }
@@ -168,6 +172,7 @@ abstract class WindowSizeImpl implements WindowSize {
             try {
                 super.resetWindowSize(size);
                 updated.signalAll();
+                signalConnectionWindowWaiters();
             } finally {
                 updateLock.unlock();
             }
@@ -183,6 +188,7 @@ abstract class WindowSizeImpl implements WindowSize {
             updateLock.lock();
             try {
                 updated.signalAll();
+                signalConnectionWindowWaiters();
             } finally {
                 updateLock.unlock();
             }
@@ -193,6 +199,7 @@ abstract class WindowSizeImpl implements WindowSize {
             try {
                 connectionClosed = true;
                 updated.signalAll();
+                signalConnectionWindowWaiters();
             } finally {
                 updateLock.unlock();
             }
@@ -212,12 +219,25 @@ abstract class WindowSizeImpl implements WindowSize {
             return streamClosed;
         }
 
-        @Override
-        public void blockTillUpdate() {
-            blockTillUpdate(() -> false);
+        ConnectionWindowWaiter createConnectionWindowWaiter(BooleanSupplier streamClosed) {
+            return new ConnectionWindowWaiter(updateLock.newCondition(), streamClosed);
         }
 
-        void blockTillUpdate(BooleanSupplier otherStreamClosed) {
+        void triggerUpdate(ConnectionWindowWaiter waiter) {
+            updateLock.lock();
+            try {
+                waiter.updated.signalAll();
+            } finally {
+                updateLock.unlock();
+            }
+        }
+
+        @Override
+        public void blockTillUpdate() {
+            blockTillUpdate(null);
+        }
+
+        void blockTillUpdate(ConnectionWindowWaiter connectionWindowWaiter) {
             var startTime = System.nanoTime();
             long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
             try {
@@ -230,7 +250,9 @@ abstract class WindowSizeImpl implements WindowSize {
                             throw new Http2Exception(Http2ErrorCode.CANCEL,
                                                      "Connection closed while waiting for a flow control update.");
                         }
-                        if (streamClosed || otherStreamClosed.getAsBoolean()) {
+                        if (streamClosed
+                                || (connectionWindowWaiter != null
+                                && connectionWindowWaiter.streamClosed.getAsBoolean())) {
                             throw new Http2Exception(Http2ErrorCode.CANCEL,
                                                      "Stream closed while waiting for a flow control update.");
                         }
@@ -245,7 +267,18 @@ abstract class WindowSizeImpl implements WindowSize {
                         } else {
                             timedOut = false;
                             long remainingNanos = timeoutNanos - elapsedNanos;
-                            var _ = updated.await(remainingNanos, TimeUnit.NANOSECONDS);
+                            Condition waitCondition = updated;
+                            if (connectionWindowWaiter != null) {
+                                register(connectionWindowWaiter);
+                                waitCondition = connectionWindowWaiter.updated;
+                            }
+                            try {
+                                var _ = waitCondition.await(remainingNanos, TimeUnit.NANOSECONDS);
+                            } finally {
+                                if (connectionWindowWaiter != null) {
+                                    unregister(connectionWindowWaiter);
+                                }
+                            }
                             waiting = getRemainingWindowSize() < 1;
                         }
                     } finally {
@@ -265,6 +298,27 @@ abstract class WindowSizeImpl implements WindowSize {
             }
         }
 
+        private void register(ConnectionWindowWaiter waiter) {
+            if (waiter.activeBlocks++ == 0) {
+                if (connectionWindowWaiters == null) {
+                    connectionWindowWaiters = new HashSet<>();
+                }
+                connectionWindowWaiters.add(waiter);
+            }
+        }
+
+        private void unregister(ConnectionWindowWaiter waiter) {
+            if (--waiter.activeBlocks == 0) {
+                connectionWindowWaiters.remove(waiter);
+            }
+        }
+
+        private void signalConnectionWindowWaiters() {
+            if (connectionWindowWaiters != null) {
+                connectionWindowWaiters.forEach(waiter -> waiter.updated.signalAll());
+            }
+        }
+
         private void debugLog(String message, Exception e) {
             if (LOGGER_OUTBOUND.isLoggable(DEBUG)) {
                 if (e != null) {
@@ -272,6 +326,17 @@ abstract class WindowSizeImpl implements WindowSize {
                 } else {
                     LOGGER_OUTBOUND.log(DEBUG, String.format(message, type, streamId));
                 }
+            }
+        }
+
+        static final class ConnectionWindowWaiter {
+            private final Condition updated;
+            private final BooleanSupplier streamClosed;
+            private int activeBlocks;
+
+            private ConnectionWindowWaiter(Condition updated, BooleanSupplier streamClosed) {
+                this.updated = updated;
+                this.streamClosed = streamClosed;
             }
         }
     }

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class WindowSizeTest {
 
@@ -101,6 +102,87 @@ class WindowSizeTest {
 
         assertThat("both flow-control waiters must resume", returnedNormally.get(), is(2));
         assertThat(failure.get(), is(nullValue()));
+    }
+
+    @Test
+    void rejectsStreamClosedBeforeBlockingWaitStarts() {
+        ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
+                .blockTimeout(Duration.ofSeconds(1))
+                .build();
+        FlowControl.Outbound outbound = connection.createStreamFlowControl(1,
+                                                                            WindowSize.DEFAULT_WIN_SIZE,
+                                                                            WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                .outbound();
+        outbound.resetStreamWindowSize(0);
+
+        outbound.streamClosed();
+        Http2Exception exception = assertThrows(Http2Exception.class, outbound::blockTillUpdate);
+
+        assertThat(exception.code(), is(Http2ErrorCode.CANCEL));
+    }
+
+    @Test
+    void streamCloseReleasesConnectionWindowWaitWithoutClosingSibling() throws InterruptedException {
+        ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
+                .blockTimeout(Duration.ofSeconds(10))
+                .build();
+        WindowSize.Outbound connectionWindow = connection.outbound();
+        connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
+        FlowControl.Outbound first = connection.createStreamFlowControl(1,
+                                                                         WindowSize.DEFAULT_WIN_SIZE,
+                                                                         WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                .outbound();
+        FlowControl.Outbound sibling = connection.createStreamFlowControl(3,
+                                                                           WindowSize.DEFAULT_WIN_SIZE,
+                                                                           WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                .outbound();
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        AtomicReference<Throwable> siblingFailure = new AtomicReference<>();
+        AtomicBoolean siblingReturned = new AtomicBoolean();
+        Thread firstBlocker = Thread.ofVirtual().start(() -> {
+            try {
+                first.blockTillUpdate();
+            } catch (Throwable t) {
+                firstFailure.set(t);
+            }
+        });
+        Thread siblingBlocker = Thread.ofVirtual().start(() -> {
+            try {
+                sibling.blockTillUpdate();
+                siblingReturned.set(true);
+            } catch (Throwable t) {
+                siblingFailure.set(t);
+            }
+        });
+        try {
+            long waitDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while ((firstBlocker.getState() != Thread.State.TIMED_WAITING
+                    || siblingBlocker.getState() != Thread.State.TIMED_WAITING)
+                    && System.nanoTime() < waitDeadline) {
+                Thread.onSpinWait();
+            }
+            assertThat("first flow-control wait must start", firstBlocker.getState(), is(Thread.State.TIMED_WAITING));
+            assertThat("sibling flow-control wait must start", siblingBlocker.getState(), is(Thread.State.TIMED_WAITING));
+
+            first.streamClosed();
+            firstBlocker.join(1000);
+            assertThat("closed stream flow-control wait must finish", firstBlocker.isAlive(), is(false));
+            assertThat(firstFailure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) firstFailure.get()).code(), is(Http2ErrorCode.CANCEL));
+            assertThat("sibling flow-control wait must remain blocked", siblingBlocker.isAlive(), is(true));
+
+            connectionWindow.incrementWindowSize(1);
+            siblingBlocker.join(1000);
+        } finally {
+            first.streamClosed();
+            sibling.streamClosed();
+            connectionWindow.incrementWindowSize(1);
+            firstBlocker.join();
+            siblingBlocker.join();
+        }
+
+        assertThat("sibling flow-control wait must resume normally", siblingReturned.get(), is(true));
+        assertThat(siblingFailure.get(), is(nullValue()));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -122,33 +123,37 @@ class WindowSizeTest {
     }
 
     @Test
-    void streamCloseReleasesConnectionWindowWaitWithoutClosingSibling() throws InterruptedException {
+    void streamCloseReleasesConnectionWindowWaitWithoutWakingSibling() throws InterruptedException {
         ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
                 .blockTimeout(Duration.ofSeconds(10))
                 .build();
-        WindowSize.Outbound connectionWindow = connection.outbound();
+        WindowSizeImpl.Outbound connectionWindow = (WindowSizeImpl.Outbound) connection.outbound();
         connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
-        FlowControl.Outbound first = connection.createStreamFlowControl(1,
-                                                                         WindowSize.DEFAULT_WIN_SIZE,
-                                                                         WindowSize.DEFAULT_MAX_FRAME_SIZE)
-                .outbound();
-        FlowControl.Outbound sibling = connection.createStreamFlowControl(3,
-                                                                           WindowSize.DEFAULT_WIN_SIZE,
-                                                                           WindowSize.DEFAULT_MAX_FRAME_SIZE)
-                .outbound();
+        AtomicBoolean firstClosed = new AtomicBoolean();
+        AtomicBoolean siblingClosed = new AtomicBoolean();
+        AtomicInteger firstChecks = new AtomicInteger();
+        AtomicInteger siblingChecks = new AtomicInteger();
+        WindowSizeImpl.Outbound.ConnectionWindowWaiter first = connectionWindow.createConnectionWindowWaiter(() -> {
+            firstChecks.incrementAndGet();
+            return firstClosed.get();
+        });
+        WindowSizeImpl.Outbound.ConnectionWindowWaiter sibling = connectionWindow.createConnectionWindowWaiter(() -> {
+            siblingChecks.incrementAndGet();
+            return siblingClosed.get();
+        });
         AtomicReference<Throwable> firstFailure = new AtomicReference<>();
         AtomicReference<Throwable> siblingFailure = new AtomicReference<>();
         AtomicBoolean siblingReturned = new AtomicBoolean();
         Thread firstBlocker = Thread.ofVirtual().start(() -> {
             try {
-                first.blockTillUpdate();
+                connectionWindow.blockTillUpdate(first);
             } catch (Throwable t) {
                 firstFailure.set(t);
             }
         });
         Thread siblingBlocker = Thread.ofVirtual().start(() -> {
             try {
-                sibling.blockTillUpdate();
+                connectionWindow.blockTillUpdate(sibling);
                 siblingReturned.set(true);
             } catch (Throwable t) {
                 siblingFailure.set(t);
@@ -164,25 +169,138 @@ class WindowSizeTest {
             assertThat("first flow-control wait must start", firstBlocker.getState(), is(Thread.State.TIMED_WAITING));
             assertThat("sibling flow-control wait must start", siblingBlocker.getState(), is(Thread.State.TIMED_WAITING));
 
-            first.streamClosed();
+            int siblingChecksBeforeReset = siblingChecks.get();
+            assertThat("first stream cancellation must be checked before waiting", firstChecks.get(), greaterThan(0));
+            assertThat("sibling cancellation must be checked before waiting", siblingChecksBeforeReset, greaterThan(0));
+            firstClosed.set(true);
+            connectionWindow.triggerUpdate(first);
             firstBlocker.join(1000);
             assertThat("closed stream flow-control wait must finish", firstBlocker.isAlive(), is(false));
             assertThat(firstFailure.get(), instanceOf(Http2Exception.class));
             assertThat(((Http2Exception) firstFailure.get()).code(), is(Http2ErrorCode.CANCEL));
             assertThat("sibling flow-control wait must remain blocked", siblingBlocker.isAlive(), is(true));
+            assertThat("targeted stream cancellation must not wake the sibling",
+                       siblingChecks.get(), is(siblingChecksBeforeReset));
 
             connectionWindow.incrementWindowSize(1);
             siblingBlocker.join(1000);
         } finally {
-            first.streamClosed();
-            sibling.streamClosed();
+            firstClosed.set(true);
+            siblingClosed.set(true);
+            connectionWindow.triggerUpdate(first);
+            connectionWindow.triggerUpdate(sibling);
             connectionWindow.incrementWindowSize(1);
             firstBlocker.join();
             siblingBlocker.join();
         }
 
         assertThat("sibling flow-control wait must resume normally", siblingReturned.get(), is(true));
+        assertThat("connection credit must wake the sibling", siblingChecks.get(), greaterThan(1));
         assertThat(siblingFailure.get(), is(nullValue()));
+    }
+
+    @Test
+    void interruptedConnectionWaiterRemainsRegisteredForSiblingWriter() throws InterruptedException {
+        ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
+                .blockTimeout(Duration.ofSeconds(10))
+                .build();
+        WindowSizeImpl.Outbound connectionWindow = (WindowSizeImpl.Outbound) connection.outbound();
+        connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
+        AtomicBoolean streamClosed = new AtomicBoolean();
+        WindowSizeImpl.Outbound.ConnectionWindowWaiter waiter =
+                connectionWindow.createConnectionWindowWaiter(streamClosed::get);
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        AtomicReference<Throwable> secondFailure = new AtomicReference<>();
+        AtomicBoolean secondReturned = new AtomicBoolean();
+        Thread firstBlocker = Thread.ofVirtual().start(() -> {
+            try {
+                connectionWindow.blockTillUpdate(waiter);
+            } catch (Throwable t) {
+                firstFailure.set(t);
+            }
+        });
+        Thread secondBlocker = Thread.ofVirtual().start(() -> {
+            try {
+                connectionWindow.blockTillUpdate(waiter);
+                secondReturned.set(true);
+            } catch (Throwable t) {
+                secondFailure.set(t);
+            }
+        });
+        try {
+            long waitDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while ((firstBlocker.getState() != Thread.State.TIMED_WAITING
+                    || secondBlocker.getState() != Thread.State.TIMED_WAITING)
+                    && System.nanoTime() < waitDeadline) {
+                Thread.onSpinWait();
+            }
+            assertThat("first flow-control wait must start", firstBlocker.getState(), is(Thread.State.TIMED_WAITING));
+            assertThat("second flow-control wait must start", secondBlocker.getState(), is(Thread.State.TIMED_WAITING));
+
+            firstBlocker.interrupt();
+            firstBlocker.join(1000);
+            assertThat(firstFailure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) firstFailure.get()).code(), is(Http2ErrorCode.FLOW_CONTROL));
+            assertThat("second writer must remain blocked after its sibling is interrupted",
+                       secondBlocker.isAlive(), is(true));
+
+            connectionWindow.incrementWindowSize(1);
+            secondBlocker.join(1000);
+        } finally {
+            streamClosed.set(true);
+            connectionWindow.triggerUpdate(waiter);
+            connectionWindow.incrementWindowSize(1);
+            firstBlocker.join();
+            secondBlocker.join();
+        }
+
+        assertThat("remaining writer must resume on connection credit", secondReturned.get(), is(true));
+        assertThat(secondFailure.get(), is(nullValue()));
+    }
+
+    @Test
+    void concurrentFirstConnectionWaitsShareLazyStreamWaiter() throws InterruptedException {
+        ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
+                .blockTimeout(Duration.ofSeconds(10))
+                .build();
+        WindowSize.Outbound connectionWindow = connection.outbound();
+        connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
+        FlowControl.Outbound stream = connection.createStreamFlowControl(1,
+                                                                          WindowSize.DEFAULT_WIN_SIZE,
+                                                                          WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                .outbound();
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        AtomicReference<Throwable> secondFailure = new AtomicReference<>();
+        CountDownLatch start = new CountDownLatch(1);
+        Thread firstBlocker = Thread.ofVirtual().start(() -> blockAfter(start, stream, firstFailure));
+        Thread secondBlocker = Thread.ofVirtual().start(() -> blockAfter(start, stream, secondFailure));
+        try {
+            start.countDown();
+            long waitDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while ((firstBlocker.getState() != Thread.State.TIMED_WAITING
+                    || secondBlocker.getState() != Thread.State.TIMED_WAITING)
+                    && System.nanoTime() < waitDeadline) {
+                Thread.onSpinWait();
+            }
+            assertThat("first flow-control wait must start", firstBlocker.getState(), is(Thread.State.TIMED_WAITING));
+            assertThat("second flow-control wait must start", secondBlocker.getState(), is(Thread.State.TIMED_WAITING));
+
+            stream.streamClosed();
+            firstBlocker.join(1000);
+            secondBlocker.join(1000);
+            assertThat("first targeted flow-control cancellation must finish", firstBlocker.isAlive(), is(false));
+            assertThat("second targeted flow-control cancellation must finish", secondBlocker.isAlive(), is(false));
+            assertThat(firstFailure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) firstFailure.get()).code(), is(Http2ErrorCode.CANCEL));
+            assertThat(secondFailure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) secondFailure.get()).code(), is(Http2ErrorCode.CANCEL));
+        } finally {
+            start.countDown();
+            stream.streamClosed();
+            connectionWindow.incrementWindowSize(1);
+            firstBlocker.join();
+            secondBlocker.join();
+        }
     }
 
     @Test
@@ -325,5 +443,16 @@ class WindowSizeTest {
         stream.incrementStreamWindowSize(WindowSize.DEFAULT_MAX_FRAME_SIZE);
         assertThat(connectionUpdate.get(), is(WindowSize.DEFAULT_MAX_FRAME_SIZE));
         assertThat(streamUpdate.get(), is(WindowSize.DEFAULT_MAX_FRAME_SIZE));
+    }
+
+    private static void blockAfter(CountDownLatch start,
+                                   FlowControl.Outbound flowControl,
+                                   AtomicReference<Throwable> failure) {
+        try {
+            start.await();
+            flowControl.blockTillUpdate();
+        } catch (Throwable t) {
+            failure.set(t);
+        }
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/WindowSizeTest.java
@@ -30,7 +30,6 @@ import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -123,7 +122,7 @@ class WindowSizeTest {
     }
 
     @Test
-    void streamCloseReleasesConnectionWindowWaitWithoutWakingSibling() throws InterruptedException {
+    void streamCloseReleasesTargetWithoutReleasingSibling() throws InterruptedException {
         ConnectionFlowControl connection = ConnectionFlowControl.clientBuilder((_, _) -> { })
                 .blockTimeout(Duration.ofSeconds(10))
                 .build();
@@ -131,16 +130,10 @@ class WindowSizeTest {
         connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
         AtomicBoolean firstClosed = new AtomicBoolean();
         AtomicBoolean siblingClosed = new AtomicBoolean();
-        AtomicInteger firstChecks = new AtomicInteger();
-        AtomicInteger siblingChecks = new AtomicInteger();
-        WindowSizeImpl.Outbound.ConnectionWindowWaiter first = connectionWindow.createConnectionWindowWaiter(() -> {
-            firstChecks.incrementAndGet();
-            return firstClosed.get();
-        });
-        WindowSizeImpl.Outbound.ConnectionWindowWaiter sibling = connectionWindow.createConnectionWindowWaiter(() -> {
-            siblingChecks.incrementAndGet();
-            return siblingClosed.get();
-        });
+        WindowSizeImpl.Outbound.ConnectionWindowWaiter first =
+                connectionWindow.createConnectionWindowWaiter(firstClosed::get);
+        WindowSizeImpl.Outbound.ConnectionWindowWaiter sibling =
+                connectionWindow.createConnectionWindowWaiter(siblingClosed::get);
         AtomicReference<Throwable> firstFailure = new AtomicReference<>();
         AtomicReference<Throwable> siblingFailure = new AtomicReference<>();
         AtomicBoolean siblingReturned = new AtomicBoolean();
@@ -169,9 +162,6 @@ class WindowSizeTest {
             assertThat("first flow-control wait must start", firstBlocker.getState(), is(Thread.State.TIMED_WAITING));
             assertThat("sibling flow-control wait must start", siblingBlocker.getState(), is(Thread.State.TIMED_WAITING));
 
-            int siblingChecksBeforeReset = siblingChecks.get();
-            assertThat("first stream cancellation must be checked before waiting", firstChecks.get(), greaterThan(0));
-            assertThat("sibling cancellation must be checked before waiting", siblingChecksBeforeReset, greaterThan(0));
             firstClosed.set(true);
             connectionWindow.triggerUpdate(first);
             firstBlocker.join(1000);
@@ -179,8 +169,6 @@ class WindowSizeTest {
             assertThat(firstFailure.get(), instanceOf(Http2Exception.class));
             assertThat(((Http2Exception) firstFailure.get()).code(), is(Http2ErrorCode.CANCEL));
             assertThat("sibling flow-control wait must remain blocked", siblingBlocker.isAlive(), is(true));
-            assertThat("targeted stream cancellation must not wake the sibling",
-                       siblingChecks.get(), is(siblingChecksBeforeReset));
 
             connectionWindow.incrementWindowSize(1);
             siblingBlocker.join(1000);
@@ -195,7 +183,6 @@ class WindowSizeTest {
         }
 
         assertThat("sibling flow-control wait must resume normally", siblingReturned.get(), is(true));
-        assertThat("connection credit must wake the sibling", siblingChecks.get(), greaterThan(1));
         assertThat(siblingFailure.get(), is(nullValue()));
     }
 

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-sse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-grpc</artifactId>
         </dependency>
         <dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ConnectionWindowUpdateJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ConnectionWindowUpdateJmhBenchmark.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.http.http2.ConnectionFlowControl;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.WindowSize;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+public class Http2ConnectionWindowUpdateJmhBenchmark {
+    private static final Duration FLOW_CONTROL_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ENROLLMENT_TIMEOUT = Duration.ofSeconds(10);
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void updateConnectionWindow(UpdateState state) {
+        state.updateConnectionWindow();
+    }
+
+    @State(Scope.Thread)
+    public static class UpdateState {
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        @Param({"1", "128", "1024", "8192"})
+        private int streamCount;
+        private WindowSize.Outbound connectionWindow;
+        private Thread[] writers;
+        private volatile boolean released;
+
+        @Setup(Level.Invocation)
+        public void setup() throws InterruptedException {
+            released = false;
+            ConnectionFlowControl connection = ConnectionFlowControl.serverBuilder((_, _) -> { })
+                    .blockTimeout(FLOW_CONTROL_TIMEOUT)
+                    .build();
+            connectionWindow = connection.outbound();
+            connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
+            writers = new Thread[streamCount];
+            CountDownLatch ready = new CountDownLatch(streamCount);
+            for (int i = 0; i < streamCount; i++) {
+                FlowControl.Outbound flowControl = connection.createStreamFlowControl(i * 2 + 1,
+                                                                                       WindowSize.DEFAULT_WIN_SIZE,
+                                                                                       WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                        .outbound();
+                writers[i] = Thread.ofVirtual().start(() -> {
+                    ready.countDown();
+                    try {
+                        flowControl.blockTillUpdate();
+                        if (!released) {
+                            failure.compareAndSet(null,
+                                                  new AssertionError("Flow-control wait returned before WINDOW_UPDATE"));
+                        }
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    }
+                });
+            }
+            if (!ready.await(ENROLLMENT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("Flow-control writers did not start");
+            }
+            long deadline = System.nanoTime() + ENROLLMENT_TIMEOUT.toNanos();
+            for (Thread writer : writers) {
+                while (writer.getState() != Thread.State.TIMED_WAITING && System.nanoTime() < deadline) {
+                    Thread.onSpinWait();
+                }
+                if (writer.getState() != Thread.State.TIMED_WAITING) {
+                    throw new IllegalStateException("Flow-control writer did not block");
+                }
+            }
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() throws InterruptedException {
+            if (!released) {
+                updateConnectionWindow();
+            }
+            for (Thread writer : writers) {
+                writer.join();
+            }
+            Throwable throwable = failure.getAndSet(null);
+            if (throwable != null) {
+                throw new IllegalStateException("Connection WINDOW_UPDATE benchmark failed", throwable);
+            }
+        }
+
+        private void updateConnectionWindow() {
+            released = true;
+            connectionWindow.incrementWindowSize(1);
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ResetCancellationJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ResetCancellationJmhBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.http.http2.ConnectionFlowControl;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
+import io.helidon.http.http2.WindowSize;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+public class Http2ResetCancellationJmhBenchmark {
+    private static final Duration FLOW_CONTROL_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ENROLLMENT_TIMEOUT = Duration.ofSeconds(10);
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void resetConnectionWindowWaiters(ResetState state) throws InterruptedException {
+        state.resetWaiters();
+    }
+
+    @State(Scope.Thread)
+    public static class ResetState {
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        @Param({"1", "128", "1024", "8192"})
+        private int streamCount;
+        private ConnectionFlowControl connection;
+        private WindowSize.Outbound connectionWindow;
+        private FlowControl.Outbound[] flowControls;
+        private Thread[] writers;
+        private volatile boolean tearDown;
+
+        @Setup(Level.Invocation)
+        public void setup() throws InterruptedException {
+            tearDown = false;
+            connection = ConnectionFlowControl.serverBuilder((_, _) -> { })
+                    .blockTimeout(FLOW_CONTROL_TIMEOUT)
+                    .build();
+            connectionWindow = connection.outbound();
+            connectionWindow.decrementWindowSize(connectionWindow.getRemainingWindowSize());
+            flowControls = new FlowControl.Outbound[streamCount];
+            writers = new Thread[streamCount];
+            CountDownLatch ready = new CountDownLatch(streamCount);
+            for (int i = 0; i < streamCount; i++) {
+                int streamIndex = i;
+                FlowControl.Outbound flowControl = connection.createStreamFlowControl(i * 2 + 1,
+                                                                                       WindowSize.DEFAULT_WIN_SIZE,
+                                                                                       WindowSize.DEFAULT_MAX_FRAME_SIZE)
+                        .outbound();
+                flowControls[i] = flowControl;
+                writers[i] = Thread.ofVirtual().start(() -> {
+                    ready.countDown();
+                    try {
+                        flowControl.blockTillUpdate();
+                        if (!tearDown) {
+                            failure.compareAndSet(null,
+                                                  new AssertionError("Flow-control wait returned without cancellation"));
+                        }
+                    } catch (Http2Exception e) {
+                        if (e.code() != Http2ErrorCode.CANCEL || streamIndex != streamCount - 1) {
+                            failure.compareAndSet(null, e);
+                        }
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    }
+                });
+            }
+            if (!ready.await(ENROLLMENT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("Flow-control writers did not start");
+            }
+            long deadline = System.nanoTime() + ENROLLMENT_TIMEOUT.toNanos();
+            for (Thread writer : writers) {
+                while (writer.getState() != Thread.State.TIMED_WAITING && System.nanoTime() < deadline) {
+                    Thread.onSpinWait();
+                }
+                if (writer.getState() != Thread.State.TIMED_WAITING) {
+                    throw new IllegalStateException("Flow-control writer did not block");
+                }
+            }
+        }
+
+        @TearDown(Level.Invocation)
+        public void tearDown() throws InterruptedException {
+            tearDown = true;
+            connectionWindow.incrementWindowSize(1);
+            for (Thread writer : writers) {
+                writer.join();
+            }
+            Throwable throwable = failure.getAndSet(null);
+            if (throwable != null) {
+                throw new IllegalStateException("Flow-control reset benchmark failed", throwable);
+            }
+        }
+
+        private void resetWaiters() throws InterruptedException {
+            flowControls[streamCount - 1].streamClosed();
+            writers[streamCount - 1].join();
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -85,6 +85,7 @@ public class ResponseFilterJmhBenchmark {
     private HttpRequest http1StreamNone;
     private HttpRequest http1StreamEntity;
     private HttpRequest http1StreamPublic;
+    private HttpRequest http1Sse;
 
     @Setup
     public void setup() {
@@ -128,6 +129,11 @@ public class ResponseFilterJmhBenchmark {
         http1StreamNone = request(baseUri, STREAM_NONE);
         http1StreamEntity = request(baseUri, STREAM_ENTITY);
         http1StreamPublic = request(baseUri, STREAM_PUBLIC);
+        http1Sse = HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create(baseUri + SSE))
+                .header(HeaderValues.ACCEPT_EVENT_STREAM.name(), HeaderValues.ACCEPT_EVENT_STREAM.get())
+                .build();
     }
 
     @TearDown
@@ -182,6 +188,12 @@ public class ResponseFilterJmhBenchmark {
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http1StreamPublicFilter(Blackhole blackhole) throws IOException, InterruptedException {
         http1(http1StreamPublic, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1SseSink(Blackhole blackhole) throws IOException, InterruptedException {
+        http1(http1Sse, blackhole);
     }
 
     @Benchmark

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -29,6 +29,8 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
+import io.helidon.http.HeaderValues;
+import io.helidon.http.sse.SseEvent;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientResponse;
@@ -40,6 +42,7 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http2.Http2Config;
 import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.sse.SseSink;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -65,6 +68,7 @@ public class ResponseFilterJmhBenchmark {
     private static final String STREAM_ENTITY = "/stream-entity";
     private static final String STREAM_NONE = "/stream-none";
     private static final String STREAM_PUBLIC = "/stream-public";
+    private static final String SSE = "/sse";
     private static final int REQUESTS_PER_INVOCATION = 16;
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     private static final Runnable BEFORE_SEND = () -> { };
@@ -101,7 +105,8 @@ public class ResponseFilterJmhBenchmark {
                         .get(DIRECT_ENTITY_BEFORE_SEND, ResponseFilterJmhBenchmark::sendDirect)
                         .get(STREAM_NONE, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_ENTITY, ResponseFilterJmhBenchmark::sendStream)
-                        .get(STREAM_PUBLIC, ResponseFilterJmhBenchmark::sendStream))
+                        .get(STREAM_PUBLIC, ResponseFilterJmhBenchmark::sendStream)
+                        .get(SSE, ResponseFilterJmhBenchmark::sendSse))
                 .build()
                 .start();
 
@@ -227,6 +232,19 @@ public class ResponseFilterJmhBenchmark {
         http2(STREAM_PUBLIC, blackhole);
     }
 
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2SseSink(Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (Http2ClientResponse response = http2Client.get(SSE)
+                    .header(HeaderValues.ACCEPT_EVENT_STREAM)
+                    .request()) {
+                blackhole.consume(response.status());
+                blackhole.consume(response.entity().as(byte[].class));
+            }
+        }
+    }
+
     private static HttpRequest request(String baseUri, String path) {
         return HttpRequest.newBuilder()
                 .GET()
@@ -255,6 +273,12 @@ public class ResponseFilterJmhBenchmark {
             outputStream.write(RESPONSE_BYTES);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void sendSse(ServerRequest request, ServerResponse response) {
+        try (SseSink sink = response.sink(SseSink.TYPE)) {
+            sink.emit(SseEvent.create(RESPONSE_BYTES));
         }
     }
 

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/ResponseFilterJmhBenchmark.java
@@ -26,7 +26,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 import io.helidon.http.HeaderValues;
@@ -69,11 +71,15 @@ public class ResponseFilterJmhBenchmark {
     private static final String STREAM_NONE = "/stream-none";
     private static final String STREAM_PUBLIC = "/stream-public";
     private static final String SSE = "/sse";
+    private static final String SSE_SUSTAINED = "/sse-sustained";
     private static final int REQUESTS_PER_INVOCATION = 16;
+    private static final int SSE_STREAMS_PER_INVOCATION = 4;
+    private static final int SSE_EVENTS_PER_STREAM = 256;
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     private static final Runnable BEFORE_SEND = () -> { };
     private static final UnaryOperator<OutputStream> OUTPUT_FILTER = PassthroughOutputStream::new;
 
+    private final AtomicReference<String> http2SseSocketId = new AtomicReference<>();
     private WebServer server;
     private HttpClient http1Client;
     private Http2Client http2Client;
@@ -107,7 +113,8 @@ public class ResponseFilterJmhBenchmark {
                         .get(STREAM_NONE, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_ENTITY, ResponseFilterJmhBenchmark::sendStream)
                         .get(STREAM_PUBLIC, ResponseFilterJmhBenchmark::sendStream)
-                        .get(SSE, ResponseFilterJmhBenchmark::sendSse))
+                        .get(SSE, ResponseFilterJmhBenchmark::sendSse)
+                        .get(SSE_SUSTAINED, this::sendSustainedSse))
                 .build()
                 .start();
 
@@ -247,14 +254,13 @@ public class ResponseFilterJmhBenchmark {
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2SseSink(Blackhole blackhole) {
-        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
-            try (Http2ClientResponse response = http2Client.get(SSE)
-                    .header(HeaderValues.ACCEPT_EVENT_STREAM)
-                    .request()) {
-                blackhole.consume(response.status());
-                blackhole.consume(response.entity().as(byte[].class));
-            }
-        }
+        http2Sse(SSE, REQUESTS_PER_INVOCATION, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(SSE_STREAMS_PER_INVOCATION * SSE_EVENTS_PER_STREAM)
+    public void http2SseSustained(Blackhole blackhole) {
+        http2Sse(SSE_SUSTAINED, SSE_STREAMS_PER_INVOCATION, blackhole);
     }
 
     private static HttpRequest request(String baseUri, String path) {
@@ -289,9 +295,30 @@ public class ResponseFilterJmhBenchmark {
     }
 
     private static void sendSse(ServerRequest request, ServerResponse response) {
+        sendSse(response, 1);
+    }
+
+    private static void sendSse(ServerResponse response, int eventCount) {
         try (SseSink sink = response.sink(SseSink.TYPE)) {
-            sink.emit(SseEvent.create(RESPONSE_BYTES));
+            SseEvent event = SseEvent.create(RESPONSE_BYTES);
+            for (int i = 0; i < eventCount; i++) {
+                sink.emit(event);
+            }
         }
+    }
+
+    private void sendSustainedSse(ServerRequest request, ServerResponse response) {
+        String socketId = request.socketId();
+        String expectedSocketId = http2SseSocketId.get();
+        if (expectedSocketId == null) {
+            http2SseSocketId.compareAndSet(null, socketId);
+            expectedSocketId = http2SseSocketId.get();
+        }
+        if (!Objects.equals(expectedSocketId, socketId)) {
+            throw new IllegalStateException("HTTP/2 SSE benchmark expected one physical connection, but observed socket IDs "
+                                                    + expectedSocketId + " and " + socketId);
+        }
+        sendSse(response, SSE_EVENTS_PER_STREAM);
     }
 
     private void http1(HttpRequest request, Blackhole blackhole) throws IOException, InterruptedException {
@@ -306,6 +333,21 @@ public class ResponseFilterJmhBenchmark {
         for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
             try (Http2ClientResponse response = http2Client.get(path).request()) {
                 blackhole.consume(response.status());
+                blackhole.consume(response.entity().as(byte[].class));
+            }
+        }
+    }
+
+    private void http2Sse(String path, int requestCount, Blackhole blackhole) {
+        for (int i = 0; i < requestCount; i++) {
+            try (Http2ClientResponse response = http2Client.get(path)
+                    .header(HeaderValues.ACCEPT_EVENT_STREAM)
+                    .request()) {
+                int status = response.status().code();
+                if (status != 200) {
+                    throw new IllegalStateException("HTTP/2 SSE benchmark request failed with status " + status);
+                }
+                blackhole.consume(status);
                 blackhole.consume(response.entity().as(byte[].class));
             }
         }

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/Http2ConnectionWindowUpdateJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/Http2ConnectionWindowUpdateJmhRunnerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+class Http2ConnectionWindowUpdateJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String benchmark = Pattern.quote(Http2ConnectionWindowUpdateJmhBenchmark.class.getName());
+        String include = System.getProperty("http2.connection.window.jmh.include",
+                                            "^" + benchmark + ".updateConnectionWindow$");
+        String result = System.getProperty("http2.connection.window.jmh.result",
+                                           "target/http2-connection-window-update-jmh.json");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+                .forks(Integer.getInteger("http2.connection.window.jmh.forks", 3))
+                .threads(1)
+                .warmupIterations(Integer.getInteger("http2.connection.window.jmh.warmupIterations", 1))
+                .measurementIterations(Integer.getInteger("http2.connection.window.jmh.measurementIterations", 3))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/Http2ResetCancellationJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/Http2ResetCancellationJmhRunnerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+class Http2ResetCancellationJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String benchmark = Pattern.quote(Http2ResetCancellationJmhBenchmark.class.getName());
+        String include = System.getProperty("http2.reset.jmh.include",
+                                            "^" + benchmark + ".resetConnectionWindowWaiters$");
+        String result = System.getProperty("http2.reset.jmh.result",
+                                           "target/http2-reset-cancellation-jmh.json");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+                .forks(Integer.getInteger("http2.reset.jmh.forks", 3))
+                .threads(1)
+                .warmupIterations(Integer.getInteger("http2.reset.jmh.warmupIterations", 1))
+                .measurementIterations(Integer.getInteger("http2.reset.jmh.measurementIterations", 3))
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -353,12 +353,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         return headers.contains(HeaderNames.TRAILER);
     }
 
-    private void flushHeaders() {
-        if (outputStream != null) {
-            outputStream.flushHeaders();
-        }
-    }
-
     private void validateResponse(Http2Headers http2Headers) {
         http2Headers.validateResponse();
         if (validateResponseHeaders) {
@@ -388,6 +382,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
         headers.remove(HeaderNames.TRANSFER_ENCODING);
         headers.remove(HeaderNames.TRAILER);
+    }
+
+    private void flushHeaders() {
+        if (outputStream != null) {
+            outputStream.flushHeaders();
+        }
     }
 
     private static class BlockingOutputStream extends OutputStream {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -347,6 +347,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
     }
 
+    void flushHeaders() {
+        if (outputStream != null) {
+            outputStream.flushHeaders();
+        }
+    }
+
     private static boolean sendTrailers(ServerResponseHeaders headers) {
         return headers.contains(HeaderNames.TRAILER);
     }
@@ -380,12 +386,6 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
         headers.remove(HeaderNames.TRANSFER_ENCODING);
         headers.remove(HeaderNames.TRAILER);
-    }
-
-    void flushHeaders() {
-        if (outputStream != null) {
-            outputStream.flushHeaders();
-        }
     }
 
     private static class BlockingOutputStream extends OutputStream {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -252,9 +252,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
         OutputStream encodedOutputStream = contentEncode(outputStream);
         OutputStream applicationOutputStream = applyStreamFilters(encodedOutputStream);
-        return outputStream.headRequest
-                ? new ApplicationOutputStream(applicationOutputStream, outputStream)
-                : applicationOutputStream;
+        return new ApplicationOutputStream(applicationOutputStream, outputStream);
     }
 
     private boolean prepareResponse() {
@@ -409,6 +407,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         private boolean headResponseSent;
         private long bytesWritten;
         private long headRepresentationLength;
+        private boolean discardWrites;
+        private RuntimeException writeFailure;
         private final Consumer<ServerResponseTrailers> beforeTrailers;
 
         private BlockingOutputStream(Http2ServerRequest request,
@@ -432,26 +432,70 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
         @Override
         public void write(int b) throws IOException {
-            write(BufferData.create(1).write(b));
+            if (discardWrites) {
+                return;
+            }
+            try {
+                write(BufferData.create(1).write(b));
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b) throws IOException {
-            write(BufferData.create(b));
+            if (discardWrites) {
+                return;
+            }
+            try {
+                write(BufferData.create(b));
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            write(BufferData.create(b, off, len));
+            if (discardWrites) {
+                return;
+            }
+            try {
+                write(BufferData.create(b, off, len));
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void flush() throws IOException {
+            if (discardWrites) {
+                return;
+            }
             if (headRequest) {
                 return;
             }
             if (firstByte && firstBuffer != null) {
-                write(BufferData.empty());
+                try {
+                    write(BufferData.empty());
+                } catch (IOException e) {
+                    failedWrite(e);
+                    throw e;
+                } catch (RuntimeException e) {
+                    failedWrite(e);
+                    throw e;
+                }
             }
         }
 
@@ -462,6 +506,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
         void commit() {
             if (closed) {
+                return;
+            }
+            if (discardWrites) {
+                if (writeFailure != null) {
+                    throw writeFailure;
+                }
                 return;
             }
             this.closed = true;
@@ -513,6 +563,9 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             if (closed) {
                 return;
             }
+            if (discardWrites) {
+                return;
+            }
             if (!firstByte) {
                 responseSentRunnable.run();
                 return;
@@ -555,6 +608,9 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void write(BufferData buffer) throws IOException {
+            if (discardWrites) {
+                return;
+            }
             if (closed) {
                 throw new IOException("Stream already closed");
             }
@@ -653,12 +709,28 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void checkWriteAllowed(int length) throws IOException {
+            if (discardWrites) {
+                if (writeFailure != null) {
+                    throw writeFailure;
+                }
+                return;
+            }
             if (length > 0 && headRequest) {
                 throw new IllegalStateException("Cannot write response entity for a HEAD request");
             }
             if (length > 0 && noEntityResponse) {
                 throw new IllegalStateException("Attempting to write data on a response with status " + status);
             }
+        }
+
+        private void failedWrite(IOException e) {
+            discardWrites = true;
+            writeFailure = new UncheckedIOException(e);
+        }
+
+        private void failedWrite(RuntimeException e) {
+            discardWrites = true;
+            writeFailure = e;
         }
     }
 
@@ -691,6 +763,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
         @Override
         public void flush() throws IOException {
+            blockingOutputStream.checkWriteAllowed(0);
             delegate.flush();
         }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -532,6 +532,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                     if (sendTrailers) {
                         sendTrailers();
                     }
+                } else if (sendTrailers) {
+                    sendTrailers();
                 }
             } else if (firstByte) {
                 // if sendTrailers, will not send end-of-stream
@@ -560,6 +562,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 return;
             }
             if (!firstByte) {
+                responseSentRunnable.run();
+                return;
+            }
+            if (headRequest) {
+                sendHeadHeaders(!Http2ServerResponse.sendTrailers(headers));
+                firstByte = false;
                 responseSentRunnable.run();
                 return;
             }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -384,7 +384,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         headers.remove(HeaderNames.TRAILER);
     }
 
-    private void flushHeaders() {
+    void flushHeaders() {
         if (outputStream != null) {
             outputStream.flushHeaders();
         }
@@ -471,13 +471,8 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             boolean sendTrailers = Http2ServerResponse.sendTrailers(headers);
 
             if (noEntityResponse) {
-                headers.setIfAbsent(HeaderValues.create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));
-
-                Http2Headers http2Headers = Http2Headers.create(headers);
-                http2Headers.status(status);
-                response.validateResponse(http2Headers);
                 if (!headResponseSent) {
-                    bytesWritten += stream.writeHeaders(http2Headers, true);
+                    sendNoEntityHeaders();
                 }
             } else if (headRequest) {
                 if (!headResponseSent) {
@@ -528,6 +523,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 responseSentRunnable.run();
                 return;
             }
+            if (noEntityResponse) {
+                normalizeNoEntityHeaders(headers, status);
+                sendNoEntityHeaders();
+                firstByte = false;
+                responseSentRunnable.run();
+                return;
+            }
             if (firstBuffer != null) {
                 try {
                     write(BufferData.empty());
@@ -540,6 +542,16 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             sendHeadersAndPrepare();
             firstByte = false;
             responseSentRunnable.run();
+        }
+
+        private void sendNoEntityHeaders() {
+            headers.setIfAbsent(HeaderValues.create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));
+
+            Http2Headers http2Headers = Http2Headers.create(headers);
+            http2Headers.status(status);
+            response.validateResponse(http2Headers);
+            bytesWritten += stream.writeHeaders(http2Headers, true);
+            headResponseSent = true;
         }
 
         private void write(BufferData buffer) throws IOException {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -587,7 +587,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 try {
                     write(BufferData.empty());
                 } catch (IOException e) {
-                    throw new UncheckedIOException(e);
+                    UncheckedIOException failure = new UncheckedIOException(e);
+                    failedWrite(failure);
+                    throw failure;
+                } catch (RuntimeException e) {
+                    failedWrite(e);
+                    throw e;
                 }
                 responseSentRunnable.run();
                 return;
@@ -724,13 +729,17 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void failedWrite(IOException e) {
-            discardWrites = true;
-            writeFailure = new UncheckedIOException(e);
+            if (!discardWrites) {
+                discardWrites = true;
+                writeFailure = new UncheckedIOException(e);
+            }
         }
 
         private void failedWrite(RuntimeException e) {
-            discardWrites = true;
-            writeFailure = e;
+            if (!discardWrites) {
+                discardWrites = true;
+                writeFailure = e;
+            }
         }
     }
 
@@ -746,30 +755,70 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         @Override
         public void write(int b) throws IOException {
             blockingOutputStream.checkWriteAllowed(1);
-            delegate.write(b);
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b) throws IOException {
             blockingOutputStream.checkWriteAllowed(b.length);
-            delegate.write(b);
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             blockingOutputStream.checkWriteAllowed(len);
-            delegate.write(b, off, len);
+            try {
+                delegate.write(b, off, len);
+            } catch (IOException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void flush() throws IOException {
             blockingOutputStream.checkWriteAllowed(0);
-            delegate.flush();
+            try {
+                delegate.flush();
+            } catch (IOException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void close() throws IOException {
-            delegate.close();
+            try {
+                delegate.close();
+            } catch (IOException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                blockingOutputStream.failedWrite(e);
+                throw e;
+            }
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -19,13 +19,20 @@ package io.helidon.webserver.http2;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.function.Consumer;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.DateTime;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpException;
 import io.helidon.http.Method;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
@@ -36,12 +43,20 @@ import io.helidon.http.http2.Http2Headers;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.ServerResponseBase;
+import io.helidon.webserver.http.spi.Sink;
+import io.helidon.webserver.http.spi.SinkProvider;
+import io.helidon.webserver.http.spi.SinkProviderContext;
 
 class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     private static final System.Logger LOGGER = System.getLogger(Http2ServerResponse.class.getName());
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
+    @SuppressWarnings("rawtypes")
+    private static final List<SinkProvider> SINK_PROVIDERS =
+            HelidonServiceLoader.builder(ServiceLoader.load(SinkProvider.class)).build().asList();
 
     private final ConnectionContext ctx;
     private final ServerResponseHeaders headers;
@@ -87,6 +102,48 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
         headers.set(header);
         return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <X extends Sink<?>> X sink(GenericType<X> sinkType) {
+        for (SinkProvider<?> provider : SINK_PROVIDERS) {
+            if (provider.supports(sinkType, request)) {
+                return (X) provider.create(new SinkProviderContext() {
+                    @Override
+                    public ServerResponse serverResponse() {
+                        return Http2ServerResponse.this;
+                    }
+
+                    @Override
+                    public ServerRequest serverRequest() {
+                        return request;
+                    }
+
+                    @Override
+                    public ConnectionContext connectionContext() {
+                        return ctx;
+                    }
+
+                    @Override
+                    public Optional<OutputStream> entityOutputStream(Runnable responsePreparation) {
+                        return Optional.of(Http2ServerResponse.this.outputStream(responsePreparation));
+                    }
+
+                    @Override
+                    public void flushHeaders() {
+                        Http2ServerResponse.this.flushHeaders();
+                    }
+
+                    @Override
+                    public Runnable closeRunnable() {
+                        return Http2ServerResponse.this::commit;
+                    }
+                });
+            }
+        }
+
+        throw new HttpException("Unable to find sink provider for request", Status.NOT_ACCEPTABLE_406);
     }
 
     @Override
@@ -207,6 +264,11 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
     @Override
     public OutputStream outputStream() {
+        return outputStream(() -> { });
+    }
+
+    private OutputStream outputStream(Runnable responsePreparation) {
+        Objects.requireNonNull(responsePreparation);
         if (preparingResponse) {
             throw new IllegalStateException("Response preparation already in progress");
         }
@@ -221,7 +283,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             headers.add(STREAM_TRAILERS);
         }
 
-        boolean noEntityResponse = prepareResponse();
+        boolean noEntityResponse = prepareResponse(responsePreparation);
         streamingEntity = true;
 
         outputStream = new BlockingOutputStream(request, this, () -> this.isSent = true, () -> {
@@ -239,9 +301,14 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     private boolean prepareResponse() {
+        return prepareResponse(() -> { });
+    }
+
+    private boolean prepareResponse(Runnable responsePreparation) {
         preparingResponse = true;
         try {
             beforeSend();
+            responsePreparation.run();
         } finally {
             preparingResponse = false;
         }
@@ -327,6 +394,12 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
     private static boolean sendTrailers(ServerResponseHeaders headers) {
         return headers.contains(HeaderNames.TRAILER);
+    }
+
+    private void flushHeaders() {
+        if (outputStream != null) {
+            outputStream.flushHeaders();
+        }
     }
 
     private void validateResponse(Http2Headers http2Headers) {
@@ -480,6 +553,28 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+
+        void flushHeaders() {
+            if (closed) {
+                return;
+            }
+            if (!firstByte) {
+                responseSentRunnable.run();
+                return;
+            }
+            if (firstBuffer != null) {
+                try {
+                    write(BufferData.empty());
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                responseSentRunnable.run();
+                return;
+            }
+            sendHeadersAndPrepare();
+            firstByte = false;
+            responseSentRunnable.run();
         }
 
         private void write(BufferData buffer) throws IOException {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerResponse.java
@@ -19,20 +19,16 @@ package io.helidon.webserver.http2;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.function.Consumer;
 
 import io.helidon.common.GenericType;
-import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.DateTime;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
-import io.helidon.http.HttpException;
 import io.helidon.http.Method;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
@@ -43,20 +39,13 @@ import io.helidon.http.http2.Http2Headers;
 import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerConnectionException;
-import io.helidon.webserver.http.ServerRequest;
-import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.ServerResponseBase;
 import io.helidon.webserver.http.spi.Sink;
-import io.helidon.webserver.http.spi.SinkProvider;
-import io.helidon.webserver.http.spi.SinkProviderContext;
 
 class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     private static final System.Logger LOGGER = System.getLogger(Http2ServerResponse.class.getName());
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
-    @SuppressWarnings("rawtypes")
-    private static final List<SinkProvider> SINK_PROVIDERS =
-            HelidonServiceLoader.builder(ServiceLoader.load(SinkProvider.class)).build().asList();
 
     private final ConnectionContext ctx;
     private final ServerResponseHeaders headers;
@@ -105,45 +94,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <X extends Sink<?>> X sink(GenericType<X> sinkType) {
-        for (SinkProvider<?> provider : SINK_PROVIDERS) {
-            if (provider.supports(sinkType, request)) {
-                return (X) provider.create(new SinkProviderContext() {
-                    @Override
-                    public ServerResponse serverResponse() {
-                        return Http2ServerResponse.this;
-                    }
-
-                    @Override
-                    public ServerRequest serverRequest() {
-                        return request;
-                    }
-
-                    @Override
-                    public ConnectionContext connectionContext() {
-                        return ctx;
-                    }
-
-                    @Override
-                    public Optional<OutputStream> entityOutputStream(Runnable responsePreparation) {
-                        return Optional.of(Http2ServerResponse.this.outputStream(responsePreparation));
-                    }
-
-                    @Override
-                    public void flushHeaders() {
-                        Http2ServerResponse.this.flushHeaders();
-                    }
-
-                    @Override
-                    public Runnable closeRunnable() {
-                        return Http2ServerResponse.this::commit;
-                    }
-                });
-            }
-        }
-
-        throw new HttpException("Unable to find sink provider for request", Status.NOT_ACCEPTABLE_406);
+        return createSink(findSinkProvider(sinkType, request),
+                          request,
+                          ctx,
+                          responsePreparation -> Optional.of(outputStream(responsePreparation)),
+                          this::commit,
+                          this::flushHeaders);
     }
 
     @Override

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -1111,7 +1111,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private boolean claimResetStreamSent() {
         resetCompletionLock.lock();
         try {
-            if (resetStreamSent) {
+            if (remoteResetReceived || resetStreamSent) {
                 return false;
             }
             resetStreamSent = true;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -278,7 +278,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         resetCompletionLock.lock();
         try {
             remoteResetReceived = true;
-            rapidReset = writeState.get() == WriteState.INIT;
+            rapidReset = writeState.getAndSet(WriteState.END) == WriteState.INIT;
         } finally {
             resetCompletionLock.unlock();
         }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -972,7 +972,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
         } finally {
             resetCompletionLock.unlock();
         }
-        flowControl.outbound().streamClosed();
         try {
             if (currentFrameLength > 0) {
                 discardDataAfterReset(currentFrameLength);
@@ -1162,6 +1161,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     private void writeResetStream(Http2RstStream reset, Http2Settings settings) {
+        flowControl.outbound().streamClosed();
         resetCompletionLock.lock();
         try {
             windowUpdatesClosed = true;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -1161,14 +1161,17 @@ class Http2ServerStream implements Runnable, Http2Stream {
     }
 
     private void writeResetStream(Http2RstStream reset, Http2Settings settings) {
-        flowControl.outbound().streamClosed();
         resetCompletionLock.lock();
         try {
             windowUpdatesClosed = true;
         } finally {
             resetCompletionLock.unlock();
         }
-        writer.write(reset.toFrameData(settings, streamId, Http2Flag.NoFlags.create()));
+        try {
+            writer.write(reset.toFrameData(settings, streamId, Http2Flag.NoFlags.create()));
+        } finally {
+            flowControl.outbound().streamClosed();
+        }
     }
 
     private void remoteCompleteAfterReset() {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -282,6 +282,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         } finally {
             resetCompletionLock.unlock();
         }
+        flowControl.outbound().streamClosed();
         if (ignoreInboundDataAfterReset) {
             remoteCompleteAfterReset();
         }

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -372,16 +372,13 @@ class Http2ServerStream implements Runnable, Http2Stream {
             }
             //6.9/2
             if (windowUpdate.windowSizeIncrement() == 0) {
-                Http2RstStream frame = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-                writeResetStream(frame, clientSettings);
-                connectionAttackVectorMetrics.madeYouResetCheck();
+                closeRejectedStream(Http2ErrorCode.PROTOCOL, true);
+                return;
             }
             //6.9.1/3
             long size = flowControl.outbound().incrementStreamWindowSize(windowUpdate.windowSizeIncrement());
             if (size > WindowSize.MAX_WIN_SIZE || size < 0L) {
-                Http2RstStream frame = new Http2RstStream(Http2ErrorCode.FLOW_CONTROL);
-                writeResetStream(frame, clientSettings);
-                connectionAttackVectorMetrics.madeYouResetCheck();
+                closeRejectedStream(Http2ErrorCode.FLOW_CONTROL, true);
             }
         } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write window update", e);
@@ -604,12 +601,15 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     ? h2Exception.code()
                     : Http2ErrorCode.STREAM_CLOSED;
             Http2RstStream rst = new Http2RstStream(errorCode);
-            try {
-                writeResetStream(rst, serverSettings);
-                resetSent = true;
-            } catch (SocketWriterException | UncheckedIOException writeFailure) {
-                connectionFailed = true;
-                throw writeFailure;
+            boolean sendReset = claimResetStreamSent();
+            if (sendReset) {
+                try {
+                    writeResetStream(rst, serverSettings);
+                    resetSent = true;
+                } catch (SocketWriterException | UncheckedIOException writeFailure) {
+                    connectionFailed = true;
+                    throw writeFailure;
+                }
             }
             // no sense in throwing an exception, as this is invoked from an executor service directly
         } catch (RequestException e) {
@@ -627,12 +627,15 @@ class Http2ServerStream implements Runnable, Http2Stream {
             try {
                 if (!completed && state != Http2StreamState.CLOSED) {
                     if (!connectionFailed && !resetSent) {
-                        Http2RstStream rst = new Http2RstStream(Http2ErrorCode.INTERNAL);
-                        try {
-                            writeResetStream(rst, serverSettings);
-                            resetSent = true;
-                        } catch (SocketWriterException | UncheckedIOException writeFailure) {
-                            ctx.log(LOGGER, DEBUG, "Failed to reset stream %d after handler failure", streamId);
+                        boolean sendReset = claimResetStreamSent();
+                        if (sendReset) {
+                            Http2RstStream rst = new Http2RstStream(Http2ErrorCode.INTERNAL);
+                            try {
+                                writeResetStream(rst, serverSettings);
+                                resetSent = true;
+                            } catch (SocketWriterException | UncheckedIOException writeFailure) {
+                                ctx.log(LOGGER, DEBUG, "Failed to reset stream %d after handler failure", streamId);
+                            }
                         }
                     }
                     if (resetSent) {
@@ -1089,6 +1092,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                     }
                 }
                 streams.deactivate(this.streamId);
+                state = Http2StreamState.CLOSED;
             } finally {
                 resetCompletionLock.unlock();
             }
@@ -1100,8 +1104,20 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 cancelSubProtocol(new Http2RstStream(resetCode));
                 locallyResetStreamTracker.localComplete(this.streamId);
             }
-            this.state = Http2StreamState.CLOSED;
             streams.remove(this.streamId);
+        }
+    }
+
+    private boolean claimResetStreamSent() {
+        resetCompletionLock.lock();
+        try {
+            if (resetStreamSent) {
+                return false;
+            }
+            resetStreamSent = true;
+            return true;
+        } finally {
+            resetCompletionLock.unlock();
         }
     }
 

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -972,6 +972,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         } finally {
             resetCompletionLock.unlock();
         }
+        flowControl.outbound().streamClosed();
         try {
             if (currentFrameLength > 0) {
                 discardDataAfterReset(currentFrameLength);

--- a/webserver/http2/src/main/java/module-info.java
+++ b/webserver/http2/src/main/java/module-info.java
@@ -54,7 +54,6 @@ module io.helidon.webserver.http2 {
     provides io.helidon.webserver.spi.ProtocolConfigProvider
             with io.helidon.webserver.http2.Http2ProtocolConfigProvider;
 
-    uses io.helidon.webserver.http.spi.SinkProvider;
     uses io.helidon.webserver.http2.spi.Http2SubProtocolProvider;
 
 }

--- a/webserver/http2/src/main/java/module-info.java
+++ b/webserver/http2/src/main/java/module-info.java
@@ -54,6 +54,7 @@ module io.helidon.webserver.http2 {
     provides io.helidon.webserver.spi.ProtocolConfigProvider
             with io.helidon.webserver.http2.Http2ProtocolConfigProvider;
 
+    uses io.helidon.webserver.http.spi.SinkProvider;
     uses io.helidon.webserver.http2.spi.Http2SubProtocolProvider;
 
 }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -38,6 +38,8 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentEncoder;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.encoding.gzip.GzipEncoding;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.ConnectionContext;
@@ -52,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,6 +118,36 @@ class Http2ServerResponseTest {
                 () -> assertThat(responseHeaders.getValue().httpHeaders().contentLength().orElseThrow(), is(6L)),
                 () -> assertThat(new String(responseEntity.getValue().readBytes(), StandardCharsets.UTF_8), is("xerror"))
         );
+    }
+
+    @Test
+    void failedStreamingWriteDiscardsEncoderCloseBytes() throws IOException {
+        AtomicInteger dataWrites = new AtomicInteger();
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder(() -> { }, true));
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        when(stream.writeData(any(BufferData.class), eq(false))).thenAnswer(_ -> {
+            dataWrites.incrementAndGet();
+            throw new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Flow control update wait time-out.");
+        });
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+
+        Http2Exception failure = assertThrows(Http2Exception.class,
+                                              () -> outputStream.write("hello".getBytes(StandardCharsets.UTF_8)));
+        Http2Exception repeatedFailure = assertThrows(Http2Exception.class, () -> outputStream.write('y'));
+        outputStream.close();
+        Http2Exception commitFailure = assertThrows(Http2Exception.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure.code(), is(Http2ErrorCode.FLOW_CONTROL)),
+                () -> assertThat(repeatedFailure, sameInstance(failure)),
+                () -> assertThat(commitFailure, sameInstance(failure)),
+                () -> assertThat(dataWrites.get(), is(1))
+        );
+        verify(stream, never()).writeData(any(BufferData.class), eq(true));
     }
 
     @Test
@@ -767,6 +800,10 @@ class Http2ServerResponseTest {
     }
 
     private static ContentEncoder testEncoder(Runnable onWrite) {
+        return testEncoder(onWrite, false);
+    }
+
+    private static ContentEncoder testEncoder(Runnable onWrite, boolean writeOnClose) {
         return new ContentEncoder() {
             @Override
             public OutputStream apply(OutputStream network) {
@@ -786,7 +823,15 @@ class Http2ServerResponseTest {
                     }
 
                     @Override
+                    public void flush() throws IOException {
+                        network.flush();
+                    }
+
+                    @Override
                     public void close() throws IOException {
+                        if (writeOnClose) {
+                            network.write('z');
+                        }
                         network.close();
                     }
                 };

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -350,6 +350,34 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void eagerlyFlushedNoEntityStatusIsSentOnce() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            Http2ServerStream stream = mock(Http2ServerStream.class);
+            Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+            response.status(status);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderValues.create(HeaderNames.TRAILER, "test-trailer"));
+
+            response.outputStream();
+            response.flushHeaders();
+            response.commit();
+
+            var responseHeaders = ArgumentCaptor.forClass(Http2Headers.class);
+            verify(stream).writeHeaders(responseHeaders.capture(), eq(true));
+            verify(stream, never()).writeHeadersWithData(any(), anyInt(), any(), anyBoolean());
+            verify(stream, never()).writeData(any(), anyBoolean());
+            verify(stream, never()).writeTrailers(any());
+            assertAll(
+                    () -> assertThat(responseHeaders.getValue().status(), is(status)),
+                    () -> assertNoEntityContentLength(status, responseHeaders.getValue().httpHeaders())
+            );
+        }
+    }
+
+    @Test
     void beforeSendNoEntityStatusesBypassNegotiatedGzip() {
         for (Status status : NO_ENTITY_STATUSES) {
             ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerResponseTest.java
@@ -151,6 +151,99 @@ class Http2ServerResponseTest {
     }
 
     @Test
+    void failedFilterWriteDiscardsEncoderCloseBytes() throws IOException {
+        AtomicInteger dataWrites = new AtomicInteger();
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder(() -> { }, true));
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        when(stream.writeData(any(BufferData.class), eq(false))).thenAnswer(_ -> dataWrites.incrementAndGet());
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        Http2Exception filterFailure = new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Filter write failed.");
+        response.streamFilter(delegate -> new FilterOutputStream(delegate) {
+            @Override
+            public void write(int value) {
+                throw filterFailure;
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) {
+                throw filterFailure;
+            }
+        });
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+
+        Http2Exception failure = assertThrows(Http2Exception.class,
+                                              () -> outputStream.write("hello".getBytes(StandardCharsets.UTF_8)));
+        outputStream.close();
+        Http2Exception commitFailure = assertThrows(Http2Exception.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure, sameInstance(filterFailure)),
+                () -> assertThat(commitFailure, sameInstance(filterFailure)),
+                () -> assertThat(dataWrites.get(), is(0))
+        );
+        verify(stream, never()).writeData(any(BufferData.class), anyBoolean());
+    }
+
+    @Test
+    void failedFilterCloseDoesNotCompleteResponse() throws IOException {
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2ServerResponse response = createResponse(stream, Method.GET, contentEncodingContext);
+        Http2Exception filterFailure = new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Filter close failed.");
+        response.streamFilter(delegate -> new FilterOutputStream(delegate) {
+            @Override
+            public void close() {
+                throw filterFailure;
+            }
+        });
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+
+        Http2Exception failure = assertThrows(Http2Exception.class, outputStream::close);
+        Http2Exception commitFailure = assertThrows(Http2Exception.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure, sameInstance(filterFailure)),
+                () -> assertThat(commitFailure, sameInstance(filterFailure))
+        );
+        verify(stream, never()).writeData(any(BufferData.class), anyBoolean());
+        verify(stream, never()).writeTrailers(any());
+    }
+
+    @Test
+    void failedEagerGzipFlushDoesNotCompleteResponse() {
+        ContentEncodingContext contentEncodingContext = ContentEncodingContext.builder()
+                .addContentEncoding(GzipEncoding.create())
+                .build();
+        WritableHeaders<?> requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ACCEPT_ENCODING, "gzip");
+        Http2ServerStream stream = mock(Http2ServerStream.class);
+        Http2Exception flowControlFailure =
+                new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Flow control update wait time-out.");
+        when(stream.writeData(any(BufferData.class), eq(false))).thenThrow(flowControlFailure);
+        Http2ServerResponse response = createResponse(stream,
+                                                      Method.GET,
+                                                      contentEncodingContext,
+                                                      ServerRequestHeaders.create(requestHeaders));
+        response.outputStream();
+
+        Http2Exception failure = assertThrows(Http2Exception.class, response::flushHeaders);
+        Http2Exception commitFailure = assertThrows(Http2Exception.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure, sameInstance(flowControlFailure)),
+                () -> assertThat(commitFailure, sameInstance(flowControlFailure))
+        );
+        verify(stream).writeData(any(BufferData.class), eq(false));
+        verify(stream, never()).writeData(any(BufferData.class), eq(true));
+        verify(stream, never()).writeTrailers(any());
+    }
+
+    @Test
     void directHandlerHeadPreservesContentLengthWithoutEntity() {
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
         when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamSniTest.java
@@ -994,6 +994,56 @@ class Http2ServerStreamSniTest {
     }
 
     @Test
+    void peerResetBeforeHandlerFailureSuppressesServerReset() throws InterruptedException {
+        Http2ConnectionStreams streams = new Http2ConnectionStreams();
+        RecordingStreamWriter writer = new RecordingStreamWriter();
+        CountDownLatch initEntered = new CountDownLatch(1);
+        CountDownLatch initRelease = new CountDownLatch(1);
+        CountDownLatch workerExited = new CountDownLatch(1);
+        Http2SubProtocolSelector.SubProtocolHandler handler = mock(Http2SubProtocolSelector.SubProtocolHandler.class);
+        doAnswer(_ -> {
+            initEntered.countDown();
+            if (!initRelease.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting for peer reset");
+            }
+            throw new ServerConnectionException("Handler failed after peer reset",
+                                                new Http2Exception(Http2ErrorCode.STREAM_CLOSED, "Stream closed"));
+        }).when(handler).init();
+        doAnswer(_ -> {
+            initRelease.countDown();
+            return null;
+        }).when(handler).rstStream(any(Http2RstStream.class));
+        when(handler.streamState()).thenReturn(Http2StreamState.OPEN);
+        Http2SubProtocolSelector selector = (_, _, _, _, _, _, _, _, _, _) -> new SubProtocolResult(true, handler);
+        Http2ServerStream stream = stream(streams,
+                                          writer,
+                                          new ArrayList<>(),
+                                          sniContext(),
+                                          List.of(selector),
+                                          new Http2ServerStream.InboundDataBudget(1, 1),
+                                          _ -> { });
+        streams.put(new Http2Connection.StreamContext(STREAM_ID, 8192, stream));
+        stream.prologue(PROLOGUE);
+        stream.headers(headersWithAuthority("api.example.com"), false);
+        Thread worker = Thread.ofVirtual().start(() -> {
+            try {
+                stream.run();
+            } finally {
+                workerExited.countDown();
+            }
+        });
+        assertThat("subprotocol init entered", initEntered.await(5, TimeUnit.SECONDS), is(true));
+
+        stream.rstStream(new Http2RstStream(Http2ErrorCode.CANCEL));
+
+        assertThat("worker exited", workerExited.await(5, TimeUnit.SECONDS), is(true));
+        worker.join();
+        verify(handler, times(1)).rstStream(any(Http2RstStream.class));
+        assertThat(writer.rstStreamCodes, is(List.of()));
+        assertThat(stream.streamState(), is(Http2StreamState.CLOSED));
+    }
+
+    @Test
     void concurrentLocalFailuresSendSingleReset() throws InterruptedException {
         Http2ConnectionStreams streams = new Http2ConnectionStreams();
         RecordingStreamWriter writer = new RecordingStreamWriter();

--- a/webserver/sse/pom.xml
+++ b/webserver/sse/pom.xml
@@ -46,6 +46,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http-http2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.sse;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -88,7 +89,11 @@ class DataWriterSseSink implements SseSink {
         prepareResponseHeaders(true);
         Optional<OutputStream> entityOutputStream = context.entityOutputStream(() -> prepareResponseHeaders(false));
         if (entityOutputStream.isPresent()) {
-            this.outputStream = entityOutputStream.orElseThrow();
+            OutputStream protocolOutputStream = entityOutputStream.orElseThrow();
+            int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
+            this.outputStream = writeBufferSize > 0
+                    ? new BufferedOutputStream(protocolOutputStream, writeBufferSize)
+                    : protocolOutputStream;
             this.closeServerSocket = false;
             this.closeOutputStreamBeforeCommit = true;
             context.flushHeaders();

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -16,12 +16,12 @@
 
 package io.helidon.webserver.sse;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.GenericType;
@@ -77,8 +77,11 @@ class DataWriterSseSink implements SseSink {
     private final Runnable closeRunnable;
     private final ConnectionContext ctx;
     private final OutputStream outputStream;
+    private final EventBufferedOutputStream bufferedOutputStream;
     private final boolean closeServerSocket;
     private final boolean closeOutputStreamBeforeCommit;
+    private boolean emitFailed;
+    private RuntimeException emitFailure;
 
     DataWriterSseSink(SinkProviderContext context) {
         this.response = context.serverResponse();
@@ -91,9 +94,11 @@ class DataWriterSseSink implements SseSink {
         if (entityOutputStream.isPresent()) {
             OutputStream protocolOutputStream = entityOutputStream.orElseThrow();
             int writeBufferSize = ctx.listenerContext().config().writeBufferSize();
-            this.outputStream = writeBufferSize > 0
-                    ? new BufferedOutputStream(protocolOutputStream, writeBufferSize)
-                    : protocolOutputStream;
+            EventBufferedOutputStream eventBufferedOutputStream = writeBufferSize > 0
+                    ? new EventBufferedOutputStream(protocolOutputStream, writeBufferSize)
+                    : null;
+            this.outputStream = eventBufferedOutputStream == null ? protocolOutputStream : eventBufferedOutputStream;
+            this.bufferedOutputStream = eventBufferedOutputStream;
             this.closeServerSocket = false;
             this.closeOutputStreamBeforeCommit = true;
             context.flushHeaders();
@@ -114,6 +119,7 @@ class DataWriterSseSink implements SseSink {
             OutputStream headersOutputStream = new DataWriterOutputStream(ctx.dataWriter());
             writeStatusAndHeaders(headersOutputStream);
             this.outputStream = (encoder != null) ? encoder.apply(headersOutputStream) : headersOutputStream;
+            this.bufferedOutputStream = null;
             this.closeServerSocket = true;
             this.closeOutputStreamBeforeCommit = false;
         }
@@ -121,6 +127,10 @@ class DataWriterSseSink implements SseSink {
 
     @Override
     public DataWriterSseSink emit(SseEvent sseEvent) {
+        if (emitFailure != null) {
+            throw emitFailure;
+        }
+        boolean completed = false;
         try {
             Optional<String> comment = sseEvent.comment();
             if (comment.isPresent()) {
@@ -144,9 +154,19 @@ class DataWriterSseSink implements SseSink {
             // write event to the output
             outputStream.flush();
 
+            completed = true;
             return this;
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            UncheckedIOException failure = new UncheckedIOException(e);
+            emitFailure = failure;
+            throw failure;
+        } catch (RuntimeException e) {
+            emitFailure = e;
+            throw e;
+        } finally {
+            if (!completed) {
+                emitFailed = true;
+            }
         }
     }
 
@@ -155,8 +175,15 @@ class DataWriterSseSink implements SseSink {
         try {
             if (closeOutputStreamBeforeCommit) {
                 // Protocol responses commit after stream wrappers finish so final bytes are sent before FIN/trailers.
-                outputStream.close();
-                closeRunnable.run();
+                if (emitFailed) {
+                    if (bufferedOutputStream != null) {
+                        bufferedOutputStream.discardBuffer();
+                    }
+                    outputStream.close();
+                } else {
+                    outputStream.close();
+                    closeRunnable.run();
+                }
                 return;
             }
 
@@ -286,6 +313,89 @@ class DataWriterSseSink implements SseSink {
             outputStream.write(field);
             outputStream.write(value, start, value.length - start);
             outputStream.write(SSE_NL);
+        }
+    }
+
+    private static final class EventBufferedOutputStream extends OutputStream {
+        private final OutputStream delegate;
+        private final byte[] buffer;
+
+        private int count;
+        private boolean discardOnClose;
+        private boolean closed;
+
+        private EventBufferedOutputStream(OutputStream delegate, int size) {
+            this.delegate = Objects.requireNonNull(delegate);
+            this.buffer = new byte[size];
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ensureOpen();
+            if (count >= buffer.length) {
+                flushBuffer();
+            }
+            buffer[count++] = (byte) b;
+        }
+
+        @Override
+        public void write(byte[] bytes, int offset, int length) throws IOException {
+            Objects.checkFromIndexSize(offset, length, bytes.length);
+            ensureOpen();
+            if (length == 0) {
+                return;
+            }
+            if (length >= buffer.length) {
+                flushBuffer();
+                delegate.write(bytes, offset, length);
+                return;
+            }
+            if (length > buffer.length - count) {
+                flushBuffer();
+            }
+            System.arraycopy(bytes, offset, buffer, count, length);
+            count += length;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            ensureOpen();
+            flushBuffer();
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            try {
+                if (!discardOnClose) {
+                    flushBuffer();
+                    delegate.flush();
+                }
+            } finally {
+                closed = true;
+                delegate.close();
+            }
+        }
+
+        private void discardBuffer() {
+            count = 0;
+            discardOnClose = true;
+        }
+
+        private void flushBuffer() throws IOException {
+            if (count > 0) {
+                delegate.write(buffer, 0, count);
+                count = 0;
+            }
+        }
+
+        private void ensureOpen() throws IOException {
+            if (closed) {
+                throw new IOException("Stream already closed");
+            }
         }
     }
 }

--- a/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
+++ b/webserver/sse/src/main/java/io/helidon/webserver/sse/DataWriterSseSink.java
@@ -210,6 +210,7 @@ class DataWriterSseSink implements SseSink {
         if (ct == null) {
             headers.add(CONTENT_TYPE_EVENT_STREAM);
         }
+        headers.remove(HeaderNames.CONTENT_LENGTH);
         headers.set(CACHE_NO_CACHE_ONLY);
         if (addDateHeader && !headers.contains(HeaderNames.DATE)) {
             headers.set(create(HeaderNames.DATE, true, false, DateTime.rfc1123String()));

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.http.HeaderNames;
 import io.helidon.http.ServerRequestHeaders;
@@ -28,6 +29,7 @@ import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.sse.SseEvent;
 import io.helidon.webserver.ConnectionContext;
+import io.helidon.webserver.ListenerConfig;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,6 +85,7 @@ class DataWriterSseSinkTest {
         when(request.headers()).thenReturn(ServerRequestHeaders.create());
         when(connectionContext.listenerContext()).thenReturn(listenerContext);
         when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        enableBuffering(listenerContext);
 
         try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
             sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
@@ -114,6 +118,7 @@ class DataWriterSseSinkTest {
         when(request.headers()).thenReturn(ServerRequestHeaders.create());
         when(connectionContext.listenerContext()).thenReturn(listenerContext);
         when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        enableBuffering(listenerContext);
 
         try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
             sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
@@ -145,6 +150,7 @@ class DataWriterSseSinkTest {
         when(response.status()).thenReturn(Status.OK_200);
         when(response.headers()).thenReturn(responseHeaders);
         when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        enableBuffering(listenerContext);
 
         try (DataWriterSseSink _ = new DataWriterSseSink(context)) {
             // Close the protocol stream before committing the response.
@@ -179,12 +185,82 @@ class DataWriterSseSinkTest {
         when(response.status()).thenReturn(Status.OK_200);
         when(response.headers()).thenReturn(ServerResponseHeaders.create());
         when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        enableBuffering(listenerContext);
 
         try (DataWriterSseSink _ = new DataWriterSseSink(context)) {
             assertThat("protocol headers flushed after entity stream creation",
                        headersFlushedAfterStreamCreation.get(),
                        is(true));
             assertThat("entity bytes before first event", entityOutputStream.size(), is(0));
+        }
+    }
+
+    @Test
+    void shouldWriteSmallProtocolEventOnce() {
+        AtomicInteger writes = new AtomicInteger();
+        ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream() {
+            @Override
+            public synchronized void write(byte[] bytes, int offset, int length) {
+                writes.incrementAndGet();
+                super.write(bytes, offset, length);
+            }
+        };
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> { });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        enableBuffering(listenerContext);
+
+        try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+            sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
+            assertThat("one protocol write per small event", writes.get(), is(1));
+            assertThat(entityOutputStream.toString(StandardCharsets.UTF_8), equalTo("data:hello\n\n"));
+        }
+    }
+
+    @Test
+    void shouldStreamProtocolEventLargerThanConfiguredBuffer() {
+        AtomicInteger writes = new AtomicInteger();
+        ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream() {
+            @Override
+            public synchronized void write(byte[] bytes, int offset, int length) {
+                writes.incrementAndGet();
+                super.write(bytes, offset, length);
+            }
+        };
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        String payload = "x".repeat(64);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> { });
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        writeBufferSize(listenerContext, 8);
+
+        try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+            sink.emit(SseEvent.create(payload.getBytes(StandardCharsets.UTF_8)));
+            assertThat("event larger than the configured buffer must stream", writes.get(), greaterThan(1));
+            assertThat(entityOutputStream.toString(StandardCharsets.UTF_8), equalTo("data:" + payload + "\n\n"));
         }
     }
 
@@ -210,5 +286,15 @@ class DataWriterSseSinkTest {
 
         assertThrows(IllegalStateException.class, () -> new DataWriterSseSink(context));
         assertThat("entity stream created after invalid response", entityStreamCreated.get(), is(false));
+    }
+
+    private static void enableBuffering(ListenerContext listenerContext) {
+        writeBufferSize(listenerContext, 4096);
+    }
+
+    private static void writeBufferSize(ListenerContext listenerContext, int size) {
+        ListenerConfig config = mock(ListenerConfig.class);
+        when(config.writeBufferSize()).thenReturn(size);
+        when(listenerContext.config()).thenReturn(config);
     }
 }

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -200,7 +200,7 @@ class DataWriterSseSinkTest {
         AtomicInteger writes = new AtomicInteger();
         ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream() {
             @Override
-            public synchronized void write(byte[] bytes, int offset, int length) {
+            public void write(byte[] bytes, int offset, int length) {
                 writes.incrementAndGet();
                 super.write(bytes, offset, length);
             }
@@ -234,7 +234,7 @@ class DataWriterSseSinkTest {
         AtomicInteger writes = new AtomicInteger();
         ByteArrayOutputStream entityOutputStream = new ByteArrayOutputStream() {
             @Override
-            public synchronized void write(byte[] bytes, int offset, int length) {
+            public void write(byte[] bytes, int offset, int length) {
                 writes.incrementAndGet();
                 super.write(bytes, offset, length);
             }

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -17,6 +17,9 @@
 package io.helidon.webserver.sse;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,6 +30,8 @@ import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.sse.SseEvent;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerConfig;
@@ -41,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -193,6 +199,120 @@ class DataWriterSseSinkTest {
                        is(true));
             assertThat("entity bytes before first event", entityOutputStream.size(), is(0));
         }
+    }
+
+    @Test
+    void shouldNotReplayBufferedProtocolEventAfterFailedFlushCleanup() {
+        AtomicInteger writes = new AtomicInteger();
+        AtomicBoolean responseCommitted = new AtomicBoolean();
+        AtomicBoolean entityStreamClosed = new AtomicBoolean();
+        ByteArrayOutputStream entityBytes = new ByteArrayOutputStream();
+        OutputStream entityOutputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                write(new byte[] {(byte) b}, 0, 1);
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) throws IOException {
+                writes.incrementAndGet();
+                entityBytes.write(bytes, offset, Math.min(length, 5));
+                throw new IOException("flow-control timeout");
+            }
+
+            @Override
+            public void close() {
+                entityStreamClosed.set(true);
+            }
+        };
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> responseCommitted.set(true));
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        enableBuffering(listenerContext);
+
+        assertThrows(UncheckedIOException.class, () -> {
+            try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+                sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8)));
+            }
+        });
+
+        assertThat("failed cleanup must not replay buffered event bytes", writes.get(), is(1));
+        assertThat("failed cleanup must not commit the protocol response", responseCommitted.get(), is(false));
+        assertThat("failed cleanup must close the decorated protocol stream", entityStreamClosed.get(), is(true));
+        assertThat(entityBytes.toString(StandardCharsets.UTF_8), equalTo("data:"));
+    }
+
+    @Test
+    void shouldNotReplayBufferedProtocolEventAfterHttp2TimeoutCleanup() {
+        AtomicInteger writes = new AtomicInteger();
+        AtomicBoolean responseCommitted = new AtomicBoolean();
+        AtomicBoolean entityStreamClosed = new AtomicBoolean();
+        ByteArrayOutputStream entityBytes = new ByteArrayOutputStream();
+        OutputStream entityOutputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                write(new byte[] {(byte) b}, 0, 1);
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) {
+                if (writes.incrementAndGet() == 1) {
+                    entityBytes.write(bytes, offset, Math.min(length, 5));
+                    throw new Http2Exception(Http2ErrorCode.FLOW_CONTROL, "Flow control update wait time-out.");
+                }
+                entityBytes.write(bytes, offset, length);
+            }
+
+            @Override
+            public void close() {
+                entityStreamClosed.set(true);
+            }
+        };
+        SinkProviderContext context = mock(SinkProviderContext.class);
+        ServerResponse response = mock(ServerResponse.class);
+        ConnectionContext connectionContext = mock(ConnectionContext.class);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+
+        when(context.serverResponse()).thenReturn(response);
+        when(context.connectionContext()).thenReturn(connectionContext);
+        when(context.entityOutputStream(any())).thenAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return Optional.of(entityOutputStream);
+        });
+        when(context.closeRunnable()).thenReturn(() -> responseCommitted.set(true));
+        when(response.status()).thenReturn(Status.OK_200);
+        when(response.headers()).thenReturn(ServerResponseHeaders.create());
+        when(connectionContext.listenerContext()).thenReturn(listenerContext);
+        enableBuffering(listenerContext);
+
+        try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
+            Http2Exception failure = assertThrows(Http2Exception.class,
+                                                  () -> sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8))));
+            Http2Exception repeatedFailure = assertThrows(Http2Exception.class,
+                                                          () -> sink.emit(SseEvent.create("again".getBytes(StandardCharsets.UTF_8))));
+
+            assertThat(failure.code(), is(Http2ErrorCode.FLOW_CONTROL));
+            assertThat("subsequent emits must report the original transport failure",
+                       repeatedFailure,
+                       sameInstance(failure));
+        }
+
+        assertThat("failed cleanup must not replay buffered event bytes", writes.get(), is(1));
+        assertThat("failed cleanup must not commit the protocol response", responseCommitted.get(), is(false));
+        assertThat("failed cleanup must close the decorated protocol stream", entityStreamClosed.get(), is(true));
+        assertThat(entityBytes.toString(StandardCharsets.UTF_8), equalTo("data:"));
     }
 
     @Test

--- a/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
+++ b/webserver/sse/src/test/java/io/helidon/webserver/sse/DataWriterSseSinkTest.java
@@ -300,8 +300,9 @@ class DataWriterSseSinkTest {
         try (DataWriterSseSink sink = new DataWriterSseSink(context)) {
             Http2Exception failure = assertThrows(Http2Exception.class,
                                                   () -> sink.emit(SseEvent.create("hello".getBytes(StandardCharsets.UTF_8))));
+            SseEvent repeatedEvent = SseEvent.create("again".getBytes(StandardCharsets.UTF_8));
             Http2Exception repeatedFailure = assertThrows(Http2Exception.class,
-                                                          () -> sink.emit(SseEvent.create("again".getBytes(StandardCharsets.UTF_8))));
+                                                          () -> sink.emit(repeatedEvent));
 
             assertThat(failure.code(), is(Http2ErrorCode.FLOW_CONTROL));
             assertThat("subsequent emits must report the original transport failure",

--- a/webserver/tests/http2/pom.xml
+++ b/webserver/tests/http2/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-sse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-context</artifactId>
             <scope>test</scope>
         </dependency>

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Route;
+import io.helidon.webserver.sse.SseSink;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class SseHttp2Test {
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder router) {
+        router.route(Http2Route.route(Method.GET, "/sse", (req, res) -> {
+                    try (SseSink sink = res.sink(SseSink.TYPE)) {
+                        sink.emit(SseEvent.create("first"))
+                                .emit(SseEvent.create("second"));
+                    }
+                }))
+                .route(Http2Route.route(Method.GET, "/ping", (req, res) -> res.send("ok")));
+    }
+
+    @Test
+    void testSseClose(WebServer server) throws IOException, InterruptedException {
+        URI uri = URI.create("http://localhost:" + server.port());
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(TIMEOUT)
+                .build();
+
+        HttpResponse<String> sseResponse = client.send(HttpRequest.newBuilder()
+                                                               .uri(uri.resolve("/sse"))
+                                                               .timeout(TIMEOUT)
+                                                               .header(HeaderNames.ACCEPT.lowerCase(), "text/event-stream")
+                                                               .GET()
+                                                               .build(),
+                                                       HttpResponse.BodyHandlers.ofString());
+
+        assertThat(sseResponse.statusCode(), is(Status.OK_200.code()));
+        assertThat(sseResponse.version(), is(HttpClient.Version.HTTP_2));
+        assertThat(sseResponse.headers().firstValue(HeaderNames.CONTENT_TYPE.lowerCase()).orElseThrow(),
+                   is("text/event-stream"));
+        assertThat(sseResponse.body(), is("data:first\n\ndata:second\n\n"));
+
+        // verify the SSE sink closed only the HTTP/2 stream and left the connection usable
+        HttpResponse<String> pingResponse = client.send(HttpRequest.newBuilder()
+                                                                .uri(uri.resolve("/ping"))
+                                                                .timeout(TIMEOUT)
+                                                                .GET()
+                                                                .build(),
+                                                        HttpResponse.BodyHandlers.ofString());
+
+        assertThat(pingResponse.statusCode(), is(Status.OK_200.code()));
+        assertThat(pingResponse.version(), is(HttpClient.Version.HTTP_2));
+        assertThat(pingResponse.body(), is("ok"));
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -286,6 +286,53 @@ class SseHttp2Test {
     }
 
     @Test
+    void clientCancelReleasesZeroWindowSseHandler(Http2TestClient client) throws InterruptedException {
+        StreamControl canceled = new StreamControl(null, "late-cancel", false);
+        STREAM_CONTROLS.put("zero-window-cancel", canceled);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            connection.sendSettings(Http2Settings.builder()
+                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, 0L)
+                                            .build());
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=zero-window-cancel", sseHeaders());
+
+            Http2FrameData settingsAck = frames.next(0, "zero-window SETTINGS acknowledgment").frame();
+            assertThat("Zero-window response frame type", settingsAck.header().type(), is(Http2FrameType.SETTINGS));
+            assertThat("Zero-window SETTINGS must be acknowledged before response headers",
+                       settingsAck.header().flags(Http2FrameTypes.SETTINGS).ack(), is(true));
+
+            StreamCapture canceledCapture = new StreamCapture();
+            canceledCapture.accept(frames.next(1, "zero-window SSE response headers"));
+            assertThat("Zero-window SSE response must start with HEADERS",
+                       canceledCapture.responseHeaders, notNullValue());
+            assertThat("Zero-window SSE response must remain open after HEADERS", canceledCapture.ended, is(false));
+
+            connection.writer().write(new Http2RstStream(Http2ErrorCode.CANCEL)
+                                              .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            request(connection, 3, "/ping", WritableHeaders.create());
+
+            StreamCapture ping = new StreamCapture();
+            ping.accept(frames.next(3, "sibling ping response headers after client reset"));
+            assertThat("Sibling ping response status", ping.responseHeaders.status(), is(Status.OK_200));
+            assertThat("Sibling ping must remain flow-control blocked before WINDOW_UPDATE", ping.ended, is(false));
+
+            canceled.release.countDown();
+            await("Canceled zero-window SSE handler completion", canceled.completed);
+            assertThat("Canceled zero-window SSE handler must observe stream cancellation",
+                       canceled.failure.get(), notNullValue());
+
+            connection.writer().write(new Http2WindowUpdate(2)
+                                              .toFrameData(null, 3, Http2Flag.NoFlags.create()));
+            ping.readUntilEnd(frames, 3);
+            assertThat("Sibling ping survives zero-window SSE cancellation", ping.body(), is("ok"));
+        } finally {
+            canceled.release.countDown();
+            STREAM_CONTROLS.remove("zero-window-cancel");
+        }
+    }
+
+    @Test
     void sustainedSseHonorsStreamFlowControl(Http2TestClient client) throws InterruptedException {
         String payload = "x".repeat(1024);
         StreamControl control = new StreamControl(payload, null, true);

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -455,6 +455,48 @@ class SseHttp2Test {
     }
 
     @Test
+    void invalidWindowUpdateResetRejectsAvailableCreditSseWrite(Http2TestClient client)
+            throws InterruptedException {
+        StreamControl reset = new StreamControl(null, "late-after-reset", false);
+        STREAM_CONTROLS.put("post-reset-window-update", reset);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=post-reset-window-update", sseHeaders());
+            await("post-reset SSE sink creation", reset.sinkCreated);
+
+            StreamCapture capture = new StreamCapture();
+            capture.accept(frames.next(1, "post-reset SSE response headers"));
+            assertThat("Post-reset SSE response headers", capture.responseHeaders, notNullValue());
+            assertThat("Post-reset SSE must remain open before invalid WINDOW_UPDATE", capture.ended, is(false));
+
+            connection.writer().write(new Http2WindowUpdate(0)
+                                              .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            assertThat(connection.assertRstStream(1, TIMEOUT).errorCode(), is(Http2ErrorCode.PROTOCOL));
+
+            reset.release.countDown();
+            await("Invalid-window-update post-reset SSE handler completion", reset.completed);
+            assertThat("SSE write after local reset must fail", reset.failure.get(), notNullValue());
+
+            Http2FrameData postResetFrame = connection.awaitNextFrame(Duration.ofMillis(500));
+            String postResetFrameDescription = postResetFrame == null
+                    ? "none"
+                    : postResetFrame.header().type() + " on stream " + postResetFrame.header().streamId()
+                            + (postResetFrame.header().type() == Http2FrameType.RST_STREAM
+                            ? " with error " + Http2RstStream.create(postResetFrame.data()).errorCode()
+                            : "");
+            assertThat("Unexpected frame after local RST_STREAM: " + postResetFrameDescription,
+                       postResetFrame, nullValue());
+
+            request(connection, 3, "/ping", WritableHeaders.create());
+            assertPing(frames, 3);
+        } finally {
+            reset.release.countDown();
+            STREAM_CONTROLS.remove("post-reset-window-update");
+        }
+    }
+
+    @Test
     void sustainedSseHonorsStreamFlowControl(Http2TestClient client) throws InterruptedException {
         String payload = "x".repeat(1024);
         StreamControl control = new StreamControl(payload, null, true);

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -16,76 +16,569 @@
 
 package io.helidon.webserver.tests.http2;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
 
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.Keys;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.http.encoding.gzip.GzipEncoding;
+import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2FrameTypes;
+import io.helidon.http.http2.Http2GoAway;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2RstStream;
+import io.helidon.http.http2.Http2Setting;
+import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.sse.SseEvent;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http2.Http2Route;
 import io.helidon.webserver.sse.SseSink;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.http2.Http2TestClient;
+import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 @ServerTest
 class SseHttp2Test {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final int FLOW_WINDOW = 64;
+    private static final HeaderName SOCKET_ID = HeaderNames.create("x-socket-id");
+    private static final HeaderName CONTROL_TRAILER = HeaderNames.create("x-control-complete");
+    private static final HeaderName SSE_TRAILER = HeaderNames.create("x-sse-trailer");
+    private static final byte[] FILTER_CLOSE_MARKER = "filter-closed".getBytes(StandardCharsets.UTF_8);
+    private static final ConcurrentMap<String, StreamControl> STREAM_CONTROLS = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, LifecycleProbe> LIFECYCLE_PROBES = new ConcurrentHashMap<>();
+
+    private final int tlsPort;
+    private final Tls clientTls;
+
+    SseHttp2Test(WebServer server) {
+        tlsPort = server.port("https");
+        clientTls = Tls.builder()
+                .trust(trust -> trust.keystore(store -> store
+                        .passphrase("password")
+                        .trustStore(true)
+                        .keystore(Resource.create("client.p12"))))
+                .build();
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        Keys serverKeys = Keys.builder()
+                .keystore(store -> store
+                        .passphrase("password")
+                        .keystore(Resource.create("server.p12")))
+                .build();
+        Tls tls = Tls.builder()
+                .privateKey(serverKeys)
+                .privateKeyCertChain(serverKeys)
+                .build();
+
+        server.contentEncoding(ContentEncodingContext.builder()
+                                       .addContentEncoding(GzipEncoding.create())
+                                       .build())
+                .putSocket("https", socket -> socket.tls(tls));
+    }
 
     @SetUpRoute
     static void routing(HttpRouting.Builder router) {
-        router.route(Http2Route.route(Method.GET, "/sse", (req, res) -> {
-                    try (SseSink sink = res.sink(SseSink.TYPE)) {
-                        sink.emit(SseEvent.create("first"))
-                                .emit(SseEvent.create("second"));
-                    }
-                }))
-                .route(Http2Route.route(Method.GET, "/ping", (req, res) -> res.send("ok")));
+        configureRoutes(router);
+    }
+
+    @SetUpRoute("https")
+    static void tlsRouting(HttpRouting.Builder router) {
+        configureRoutes(router);
     }
 
     @Test
-    void testSseClose(WebServer server) throws IOException, InterruptedException {
-        URI uri = URI.create("http://localhost:" + server.port());
-        HttpClient client = HttpClient.newBuilder()
+    void tlsAlpnSseUsesOnePhysicalHttp2Connection() throws IOException, InterruptedException {
+        URI uri = URI.create("https://localhost:" + tlsPort);
+        try (HttpClient client = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
                 .connectTimeout(TIMEOUT)
+                .sslContext(clientTls.sslContext())
+                .build()) {
+
+            HttpResponse<String> sse = client.send(request(uri.resolve("/sse")), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> ping = client.send(request(uri.resolve("/ping")), HttpResponse.BodyHandlers.ofString());
+
+            assertThat("SSE must be negotiated with ALPN as HTTP/2", sse.version(), is(HttpClient.Version.HTTP_2));
+            assertThat("Ping must use HTTP/2", ping.version(), is(HttpClient.Version.HTTP_2));
+            assertThat("SSE status", sse.statusCode(), is(Status.OK_200.code()));
+            assertThat("SSE framing", sse.body(), is("data:first\n\ndata:second\n\n"));
+            assertThat("Ping status", ping.statusCode(), is(Status.OK_200.code()));
+            assertThat("Ping body", ping.body(), is("ok"));
+            assertThat("SSE and ping must use the same physical server socket",
+                       ping.headers().firstValue(SOCKET_ID.lowerCase()).orElseThrow(),
+                       is(sse.headers().firstValue(SOCKET_ID.lowerCase()).orElseThrow()));
+        }
+    }
+
+    @Test
+    void headersArriveBeforeDelayedFirstEvent(Http2TestClient client) throws InterruptedException {
+        StreamControl control = new StreamControl(null, "delayed", false);
+        STREAM_CONTROLS.put("delayed", control);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=delayed", sseHeaders());
+            await("SSE sink creation", control.sinkCreated);
+
+            StreamCapture delayed = new StreamCapture();
+            delayed.accept(frames.next(1, "delayed SSE response headers"));
+            assertThat("The first delayed SSE frame must be HEADERS", delayed.responseHeaders, notNullValue());
+            assertThat("HEADERS must not prematurely end the stream", delayed.ended, is(false));
+
+            request(connection, 3, "/ping", WritableHeaders.create());
+            assertPing(frames, 3);
+            assertThat("No SSE frame may follow HEADERS before the release protocol event",
+                       frames.hasQueuedFrame(1), is(false));
+
+            control.release.countDown();
+            await("Delayed SSE completion", control.completed);
+            control.assertNoFailure("Delayed SSE handler");
+            delayed.readUntilEnd(frames, 1);
+            assertThat("Delayed SSE event framing", delayed.body(), is("data:delayed\n\n"));
+        } finally {
+            control.release.countDown();
+            STREAM_CONTROLS.remove("delayed");
+        }
+    }
+
+    @Test
+    void concurrentSseStreamsCompleteIndependentlyOnOneConnection(Http2TestClient client) throws InterruptedException {
+        StreamControl first = new StreamControl("open-one", "close-one", false);
+        StreamControl second = new StreamControl("open-two", "close-two", false);
+        STREAM_CONTROLS.put("one", first);
+        STREAM_CONTROLS.put("two", second);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=one", sseHeaders());
+            request(connection, 3, "/controlled?id=two", sseHeaders());
+
+            StreamCapture streamOne = new StreamCapture();
+            StreamCapture streamThree = new StreamCapture();
+            streamOne.readUntilBytes(frames, 1, sseBytes("open-one").length);
+            streamThree.readUntilBytes(frames, 3, sseBytes("open-two").length);
+
+            first.release.countDown();
+            streamOne.readUntilEnd(frames, 1);
+            assertThat("Stream 1 exact events", streamOne.body(), is("data:open-one\n\ndata:close-one\n\n"));
+            await("Stream 1 completion", first.completed);
+            first.assertNoFailure("Stream 1 handler");
+            assertThat("Stream 3 must remain open when stream 1 completes", streamThree.ended, is(false));
+
+            request(connection, 5, "/ping", WritableHeaders.create());
+            assertPing(frames, 5);
+            assertThat("Stream 3 must not complete while only stream 1 was released", frames.hasQueuedFrame(3), is(false));
+
+            second.release.countDown();
+            streamThree.readUntilEnd(frames, 3);
+            assertThat("Stream 3 exact events", streamThree.body(), is("data:open-two\n\ndata:close-two\n\n"));
+            await("Stream 3 completion", second.completed);
+            second.assertNoFailure("Stream 3 handler");
+        } finally {
+            first.release.countDown();
+            second.release.countDown();
+            STREAM_CONTROLS.remove("one");
+            STREAM_CONTROLS.remove("two");
+        }
+    }
+
+    @Test
+    void clientCancelDoesNotAffectSiblingStreamOrConnection(Http2TestClient client) throws InterruptedException {
+        StreamControl canceled = new StreamControl("open-cancel", "late-cancel", false);
+        StreamControl sibling = new StreamControl("open-sibling", "close-sibling", false);
+        STREAM_CONTROLS.put("cancel", canceled);
+        STREAM_CONTROLS.put("sibling", sibling);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=cancel", sseHeaders());
+            request(connection, 3, "/controlled?id=sibling", sseHeaders());
+
+            new StreamCapture().readUntilBytes(frames, 1, sseBytes("open-cancel").length);
+            StreamCapture siblingCapture = new StreamCapture();
+            siblingCapture.readUntilBytes(frames, 3, sseBytes("open-sibling").length);
+
+            connection.writer().write(new Http2RstStream(Http2ErrorCode.CANCEL)
+                                              .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            canceled.release.countDown();
+            sibling.release.countDown();
+
+            siblingCapture.readUntilEnd(frames, 3);
+            assertThat("Sibling stream survives client RST_STREAM CANCEL",
+                       siblingCapture.body(), is("data:open-sibling\n\ndata:close-sibling\n\n"));
+            request(connection, 5, "/ping", WritableHeaders.create());
+            assertPing(frames, 5);
+            await("Canceled handler completion", canceled.completed);
+        } finally {
+            canceled.release.countDown();
+            sibling.release.countDown();
+            STREAM_CONTROLS.remove("cancel");
+            STREAM_CONTROLS.remove("sibling");
+        }
+    }
+
+    @Test
+    void sustainedSseHonorsStreamFlowControl(Http2TestClient client) throws InterruptedException {
+        String payload = "x".repeat(1024);
+        StreamControl control = new StreamControl(payload, null, true);
+        STREAM_CONTROLS.put("flow", control);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            connection.sendSettings(Http2Settings.builder()
+                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, (long) FLOW_WINDOW)
+                                            .build());
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=flow", sseHeaders());
+            Http2FrameData settingsAck = frames.next(0, "small-window SETTINGS acknowledgment").frame();
+            assertThat("Small-window response frame type", settingsAck.header().type(), is(Http2FrameType.SETTINGS));
+            assertThat("Small-window SETTINGS must be acknowledged before response data",
+                       settingsAck.header().flags(Http2FrameTypes.SETTINGS).ack(), is(true));
+
+            StreamCapture capture = new StreamCapture();
+            capture.readUntilBytes(frames, 1, FLOW_WINDOW);
+            assertThat("Server must consume exactly the advertised stream credit", capture.data.size(), is(FLOW_WINDOW));
+            assertThat("SSE handler must remain flow-control blocked before WINDOW_UPDATE",
+                       control.completed.getCount(), is(1L));
+
+            int expectedLength = sseBytes(payload).length;
+            while (capture.data.size() < expectedLength) {
+                int credit = Math.min(FLOW_WINDOW, expectedLength - capture.data.size());
+                connection.writer().write(new Http2WindowUpdate(credit)
+                                                  .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+                capture.readUntilBytes(frames, 1, capture.data.size() + credit);
+            }
+            capture.readUntilEnd(frames, 1);
+            assertThat("Flow-controlled SSE framing", capture.body(), is("data:" + payload + "\n\n"));
+            await("Flow-controlled SSE completion", control.completed);
+            control.assertNoFailure("Flow-controlled SSE handler");
+        } finally {
+            control.release.countDown();
+            STREAM_CONTROLS.remove("flow");
+        }
+    }
+
+    @Test
+    void encodingFiltersTrailersAndCallbacksFinalizeBeforeEndStream(Http2TestClient client)
+            throws IOException, InterruptedException {
+        LifecycleProbe probe = new LifecycleProbe();
+        LIFECYCLE_PROBES.put("lifecycle", probe);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            WritableHeaders<?> headers = sseHeaders();
+            headers.add(HeaderNames.ACCEPT_ENCODING, "gzip");
+            headers.add(HeaderValues.TE_TRAILERS);
+            request(connection, 1, "/lifecycle?id=lifecycle", headers);
+
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            StreamCapture capture = new StreamCapture();
+            capture.readUntilEnd(frames, 1);
+            await("SSE lifecycle completion", probe.completed);
+
+            assertThat("HTTP/2 response status", capture.responseHeaders.status(), is(Status.OK_200));
+            assertThat("SSE gzip content encoding",
+                       capture.responseHeaders.httpHeaders().get(HeaderNames.CONTENT_ENCODING).get(), is("gzip"));
+            assertThat("Declared trailer value", capture.trailers.httpHeaders().get(SSE_TRAILER).get(), is("done"));
+            assertThat("END_STREAM must be on trailers after gzip and filter finalization",
+                       capture.terminalFrameType, is(Http2FrameType.HEADERS));
+            assertThat("Decompressed SSE data includes the stream-filter close marker",
+                       gunzip(capture.data.toByteArray()), is("data:payload\n\nfilter-closed"));
+            assertThat("beforeSend callback count", probe.beforeSend.get(), is(1));
+            assertThat("beforeTrailers callback count", probe.beforeTrailers.get(), is(1));
+            assertThat("whenSent callback count", probe.whenSent.get(), is(1));
+            assertThat("stream filter close count", probe.filterClose.get(), is(1));
+        } finally {
+            LIFECYCLE_PROBES.remove("lifecycle");
+        }
+    }
+
+    private static void configureRoutes(HttpRouting.Builder router) {
+        router.route(Http2Route.route(Method.GET, "/sse", (req, res) -> {
+                    res.header(SOCKET_ID, req.socketId());
+                    try (SseSink sink = res.sink(SseSink.TYPE)) {
+                        sink.emit(SseEvent.create("first")).emit(SseEvent.create("second"));
+                    }
+                }))
+                .route(Http2Route.route(Method.GET, "/ping", (req, res) -> {
+                    res.header(SOCKET_ID, req.socketId());
+                    res.send("ok");
+                }))
+                .route(Http2Route.route(Method.GET, "/controlled", (req, res) -> controlled(req.query().get("id"), res)))
+                .route(Http2Route.route(Method.GET, "/lifecycle", (req, res) -> lifecycle(req.query().get("id"), res)));
+    }
+
+    private static void controlled(String id, ServerResponse response) {
+        StreamControl control = STREAM_CONTROLS.get(id);
+        if (control == null) {
+            throw new IllegalStateException("Missing SSE stream control " + id);
+        }
+        response.header(HeaderNames.TRAILER, CONTROL_TRAILER.defaultCase());
+        response.beforeTrailers(trailers -> trailers.set(CONTROL_TRAILER, "done"));
+        try (SseSink sink = response.sink(SseSink.TYPE)) {
+            control.sinkCreated.countDown();
+            if (control.firstEvent != null) {
+                sink.emit(SseEvent.create(control.firstEvent));
+            }
+            control.awaitRelease();
+            if (control.lastEvent != null) {
+                sink.emit(SseEvent.create(control.lastEvent));
+            }
+        } catch (Throwable t) {
+            control.failure.compareAndSet(null, t);
+        } finally {
+            control.completed.countDown();
+        }
+    }
+
+    private static void lifecycle(String id, ServerResponse response) {
+        LifecycleProbe probe = LIFECYCLE_PROBES.get(id);
+        if (probe == null) {
+            throw new IllegalStateException("Missing SSE lifecycle probe " + id);
+        }
+        response.header(HeaderNames.TRAILER, SSE_TRAILER.defaultCase());
+        response.beforeSend(probe.beforeSend::incrementAndGet);
+        response.beforeTrailers(trailers -> {
+            probe.beforeTrailers.incrementAndGet();
+            trailers.set(SSE_TRAILER, "done");
+        });
+        response.whenSent(probe.whenSent::incrementAndGet);
+        response.streamFilter(delegate -> new FilterOutputStream(delegate) {
+            private boolean closed;
+
+            @Override
+            public void close() throws IOException {
+                if (!closed) {
+                    closed = true;
+                    probe.filterClose.incrementAndGet();
+                    write(FILTER_CLOSE_MARKER);
+                }
+                super.close();
+            }
+        });
+        try (SseSink sink = response.sink(SseSink.TYPE)) {
+            sink.emit(SseEvent.create("payload"));
+        } finally {
+            probe.completed.countDown();
+        }
+    }
+
+    private static HttpRequest request(URI uri) {
+        return HttpRequest.newBuilder()
+                .uri(uri)
+                .timeout(TIMEOUT)
+                .header(HeaderNames.ACCEPT.lowerCase(), "text/event-stream")
+                .GET()
                 .build();
+    }
 
-        HttpResponse<String> sseResponse = client.send(HttpRequest.newBuilder()
-                                                               .uri(uri.resolve("/sse"))
-                                                               .timeout(TIMEOUT)
-                                                               .header(HeaderNames.ACCEPT.lowerCase(), "text/event-stream")
-                                                               .GET()
-                                                               .build(),
-                                                       HttpResponse.BodyHandlers.ofString());
+    private static void request(Http2TestConnection connection,
+                                int streamId,
+                                String path,
+                                WritableHeaders<?> headers) {
+        connection.request(streamId, Method.GET, path, headers, BufferData.empty());
+    }
 
-        assertThat(sseResponse.statusCode(), is(Status.OK_200.code()));
-        assertThat(sseResponse.version(), is(HttpClient.Version.HTTP_2));
-        assertThat(sseResponse.headers().firstValue(HeaderNames.CONTENT_TYPE.lowerCase()).orElseThrow(),
-                   is("text/event-stream"));
-        assertThat(sseResponse.body(), is("data:first\n\ndata:second\n\n"));
+    private static WritableHeaders<?> sseHeaders() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.ACCEPT, "text/event-stream");
+        return headers;
+    }
 
-        // verify the SSE sink closed only the HTTP/2 stream and left the connection usable
-        HttpResponse<String> pingResponse = client.send(HttpRequest.newBuilder()
-                                                                .uri(uri.resolve("/ping"))
-                                                                .timeout(TIMEOUT)
-                                                                .GET()
-                                                                .build(),
-                                                        HttpResponse.BodyHandlers.ofString());
+    private static void assertPing(FrameDemultiplexer frames, int streamId) {
+        StreamCapture ping = new StreamCapture();
+        ping.readUntilEnd(frames, streamId);
+        assertThat("Ping status on stream " + streamId, ping.responseHeaders.status(), is(Status.OK_200));
+        assertThat("Ping body on stream " + streamId, ping.body(), is("ok"));
+    }
 
-        assertThat(pingResponse.statusCode(), is(Status.OK_200.code()));
-        assertThat(pingResponse.version(), is(HttpClient.Version.HTTP_2));
-        assertThat(pingResponse.body(), is("ok"));
+    private static byte[] sseBytes(String value) {
+        return ("data:" + value + "\n\n").getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String gunzip(byte[] bytes) throws IOException {
+        try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
+            return new String(gzip.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void await(String reason, CountDownLatch latch) throws InterruptedException {
+        assertThat("Timed out waiting for " + reason, latch.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+    }
+
+    private record InboundFrame(Http2FrameData frame, Http2Headers headers) {
+    }
+
+    private static final class FrameDemultiplexer {
+        private final Http2TestConnection connection;
+        private final Map<Integer, ArrayDeque<InboundFrame>> queued = new HashMap<>();
+        private final Http2Headers.DynamicTable dynamicTable =
+                Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+        private final Http2HuffmanDecoder huffman = Http2HuffmanDecoder.create();
+
+        private FrameDemultiplexer(Http2TestConnection connection) {
+            this.connection = connection;
+        }
+
+        private InboundFrame next(int streamId, String reason) {
+            ArrayDeque<InboundFrame> streamFrames = queued.get(streamId);
+            if (streamFrames != null && !streamFrames.isEmpty()) {
+                return streamFrames.removeFirst();
+            }
+            for (;;) {
+                Http2FrameData frame = connection.awaitNextFrame(TIMEOUT);
+                assertThat("Timed out waiting for " + reason, frame, notNullValue());
+                if (frame.header().type() == Http2FrameType.GO_AWAY) {
+                    Http2GoAway goAway = Http2GoAway.create(frame.data());
+                    assertThat("Unexpected GOAWAY " + goAway.errorCode() + ": " + goAway.details(), false, is(true));
+                }
+                Http2Headers headers = frame.header().type() == Http2FrameType.HEADERS
+                        ? Http2Headers.create(null, dynamicTable, huffman, frame)
+                        : null;
+                InboundFrame inbound = new InboundFrame(frame, headers);
+                if (frame.header().streamId() == streamId) {
+                    return inbound;
+                }
+                queued.computeIfAbsent(frame.header().streamId(), _ -> new ArrayDeque<>()).addLast(inbound);
+            }
+        }
+
+        private boolean hasQueuedFrame(int streamId) {
+            ArrayDeque<InboundFrame> frames = queued.get(streamId);
+            return frames != null && !frames.isEmpty();
+        }
+    }
+
+    private static final class StreamCapture {
+        private final ByteArrayOutputStream data = new ByteArrayOutputStream();
+        private Http2Headers responseHeaders;
+        private Http2Headers trailers;
+        private Http2FrameType terminalFrameType;
+        private boolean ended;
+
+        private void readUntilBytes(FrameDemultiplexer frames, int streamId, int byteCount) {
+            while (data.size() < byteCount) {
+                accept(frames.next(streamId, "stream " + streamId + " data byte " + byteCount));
+                assertThat("Stream " + streamId + " ended before receiving " + byteCount + " bytes", ended, is(false));
+            }
+            assertThat("Stream " + streamId + " must stop at the exact flow/event boundary", data.size(), is(byteCount));
+        }
+
+        private void readUntilEnd(FrameDemultiplexer frames, int streamId) {
+            while (!ended) {
+                accept(frames.next(streamId, "stream " + streamId + " END_STREAM"));
+            }
+        }
+
+        private void accept(InboundFrame inbound) {
+            Http2FrameData frame = inbound.frame();
+            Http2FrameType type = frame.header().type();
+            assertThat("Unexpected frame " + type + " on stream " + frame.header().streamId(),
+                       type == Http2FrameType.HEADERS || type == Http2FrameType.DATA, is(true));
+            if (type == Http2FrameType.HEADERS) {
+                if (responseHeaders == null) {
+                    responseHeaders = inbound.headers();
+                } else {
+                    trailers = inbound.headers();
+                }
+                if (frame.header().flags(Http2FrameTypes.HEADERS).endOfStream()) {
+                    ended = true;
+                    terminalFrameType = type;
+                }
+            } else {
+                data.writeBytes(frame.data().readBytes());
+                if (frame.header().flags(Http2FrameTypes.DATA).endOfStream()) {
+                    ended = true;
+                    terminalFrameType = type;
+                }
+            }
+        }
+
+        private String body() {
+            return data.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    private static final class StreamControl {
+        private final String firstEvent;
+        private final String lastEvent;
+        private final CountDownLatch sinkCreated = new CountDownLatch(1);
+        private final CountDownLatch release;
+        private final CountDownLatch completed = new CountDownLatch(1);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        private StreamControl(String firstEvent, String lastEvent, boolean initiallyReleased) {
+            this.firstEvent = firstEvent;
+            this.lastEvent = lastEvent;
+            release = new CountDownLatch(initiallyReleased ? 0 : 1);
+        }
+
+        private void awaitRelease() {
+            try {
+                if (!release.await(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release controlled SSE stream");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted waiting to release controlled SSE stream", e);
+            }
+        }
+
+        private void assertNoFailure(String reason) {
+            assertThat(reason + " failed", failure.get(), nullValue());
+        }
+    }
+
+    private static final class LifecycleProbe {
+        private final AtomicInteger beforeSend = new AtomicInteger();
+        private final AtomicInteger beforeTrailers = new AtomicInteger();
+        private final AtomicInteger whenSent = new AtomicInteger();
+        private final AtomicInteger filterClose = new AtomicInteger();
+        private final CountDownLatch completed = new CountDownLatch(1);
     }
 }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -49,10 +49,12 @@ import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.encoding.gzip.GzipEncoding;
+import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
 import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
@@ -348,6 +350,63 @@ class SseHttp2Test {
         } finally {
             canceled.release.countDown();
             STREAM_CONTROLS.remove("zero-window-cancel");
+        }
+    }
+
+    @Test
+    void invalidContentLengthResetReleasesBlockedZeroWindowSseHandler(Http2TestClient client)
+            throws InterruptedException {
+        String payload = "x".repeat(FLOW_WINDOW);
+        StreamControl reset = new StreamControl(payload, null, false);
+        STREAM_CONTROLS.put("zero-window-local-reset", reset);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            connection.sendSettings(Http2Settings.builder()
+                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, (long) FLOW_WINDOW)
+                                            .build());
+
+            WritableHeaders<?> headers = sseHeaders();
+            headers.add(HeaderNames.CONTENT_LENGTH, 0);
+            Http2Headers requestHeaders = Http2Headers.create(headers);
+            requestHeaders.method(Method.GET);
+            requestHeaders.path("/controlled?id=zero-window-local-reset");
+            requestHeaders.scheme(connection.clientUri().scheme());
+            requestHeaders.authority(connection.clientUri().authority());
+            connection.writer().writeHeaders(requestHeaders,
+                                              1,
+                                              Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS),
+                                              FlowControl.Outbound.NOOP);
+
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            Http2FrameData settingsAck = frames.next(0, "local-reset SETTINGS acknowledgment").frame();
+            assertThat("Local-reset response frame type", settingsAck.header().type(), is(Http2FrameType.SETTINGS));
+            assertThat("Local-reset SETTINGS must be acknowledged before response headers",
+                       settingsAck.header().flags(Http2FrameTypes.SETTINGS).ack(), is(true));
+
+            StreamCapture resetCapture = new StreamCapture();
+            resetCapture.readUntilBytes(frames, 1, FLOW_WINDOW);
+            assertThat("SSE handler must consume all advertised stream credit before local reset",
+                       resetCapture.data.size(), is(FLOW_WINDOW));
+            assertThat("SSE handler must remain blocked before local reset", reset.completed.getCount(), is(1L));
+
+            BufferData invalidData = BufferData.create("x");
+            Http2FrameHeader invalidDataHeader = Http2FrameHeader.create(invalidData.available(),
+                                                                          Http2FrameTypes.DATA,
+                                                                          Http2Flag.DataFlags.create(Http2Flag.END_OF_STREAM),
+                                                                          1);
+            connection.writer().writeData(new Http2FrameData(invalidDataHeader, invalidData),
+                                          FlowControl.Outbound.NOOP);
+
+            assertThat(connection.assertRstStream(1, TIMEOUT).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            await("Locally reset zero-window SSE handler completion", reset.completed);
+            assertThat(reset.failure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) reset.failure.get()).code(), is(Http2ErrorCode.CANCEL));
+
+            request(connection, 3, "/ping", WritableHeaders.create());
+            assertPing(frames, 3);
+        } finally {
+            reset.release.countDown();
+            STREAM_CONTROLS.remove("zero-window-local-reset");
         }
     }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -210,6 +210,33 @@ class SseHttp2Test {
     }
 
     @Test
+    void tlsSseRemovesContentLengthFromBeforeSendFilter() throws IOException, InterruptedException {
+        URI uri = URI.create("https://localhost:" + tlsPort);
+        try (HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(TIMEOUT)
+                .sslContext(clientTls.sslContext())
+                .build()) {
+            HttpResponse<String> sse = client.send(request(uri.resolve("/filtered")),
+                                                   HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> ping = client.send(request(uri.resolve("/ping")),
+                                                    HttpResponse.BodyHandlers.ofString());
+
+            assertThat("SSE response must use HTTP/2", sse.version(), is(HttpClient.Version.HTTP_2));
+            assertThat("SSE response status", sse.statusCode(), is(Status.OK_200.code()));
+            assertThat("SSE response must not retain filter-supplied Content-Length",
+                       sse.headers().firstValue(HeaderNames.CONTENT_LENGTH.lowerCase()).isEmpty(),
+                       is(true));
+            assertThat("SSE response must preserve exact event framing", sse.body(), is("data:x\n\n"));
+            assertThat("Ping response must use HTTP/2", ping.version(), is(HttpClient.Version.HTTP_2));
+            assertThat("Ping response status", ping.statusCode(), is(Status.OK_200.code()));
+            assertThat("SSE and ping must use the same physical server socket",
+                       ping.headers().firstValue(SOCKET_ID.lowerCase()).orElseThrow(),
+                       is(sse.headers().firstValue(SOCKET_ID.lowerCase()).orElseThrow()));
+        }
+    }
+
+    @Test
     void concurrentSseStreamsCompleteIndependentlyOnOneConnection(Http2TestClient client) throws InterruptedException {
         StreamControl first = new StreamControl("open-one", "close-one", false);
         StreamControl second = new StreamControl("open-two", "close-two", false);
@@ -420,6 +447,13 @@ class SseHttp2Test {
                 .route(Http2Route.route(Method.HEAD, "/sse-head", (_, res) -> {
                     try (SseSink _ = res.sink(SseSink.TYPE)) {
                         // A HEAD response completes without an SSE entity.
+                    }
+                }))
+                .route(Http2Route.route(Method.GET, "/filtered", (req, res) -> {
+                    res.header(SOCKET_ID, req.socketId());
+                    res.beforeSend(() -> res.header(HeaderNames.CONTENT_LENGTH, "13"));
+                    try (SseSink sink = res.sink(SseSink.TYPE)) {
+                        sink.emit(SseEvent.create("x"));
                     }
                 }))
                 .route(Http2Route.route(Method.GET, "/controlled", (req, res) -> controlled(req.query().get("id"), res)))

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -60,6 +60,7 @@ import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2GoAway;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanDecoder;
+import io.helidon.http.http2.Http2Ping;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
@@ -283,7 +284,7 @@ class SseHttp2Test {
 
     @Test
     void clientCancelDoesNotAffectSiblingStreamOrConnection(Http2TestClient client) throws InterruptedException {
-        StreamControl canceled = new StreamControl("open-cancel", "late-cancel", false);
+        StreamControl canceled = new StreamControl("open-cancel", "late-cancel", false, true);
         StreamControl sibling = new StreamControl("open-sibling", "close-sibling", false);
         STREAM_CONTROLS.put("cancel", canceled);
         STREAM_CONTROLS.put("sibling", sibling);
@@ -299,6 +300,11 @@ class SseHttp2Test {
 
             connection.writer().write(new Http2RstStream(Http2ErrorCode.CANCEL)
                                               .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+            connection.writer().write(Http2Ping.create().toFrameData());
+            Http2FrameData pingAck = frames.next(0, "peer-reset processing barrier").frame();
+            assertThat("Peer-reset barrier frame type", pingAck.header().type(), is(Http2FrameType.PING));
+            assertThat("Peer-reset barrier must be acknowledged",
+                       pingAck.header().flags(Http2FrameTypes.PING).ack(), is(true));
             canceled.release.countDown();
             sibling.release.countDown();
 
@@ -308,6 +314,19 @@ class SseHttp2Test {
             request(connection, 5, "/ping", WritableHeaders.create());
             assertPing(frames, 5);
             await("Canceled handler completion", canceled.completed);
+
+            Http2FrameData postResetFrame = frames.pollQueuedFrame(1);
+            if (postResetFrame == null) {
+                postResetFrame = connection.awaitNextFrame(Duration.ofMillis(500));
+            }
+            String postResetFrameDescription = postResetFrame == null
+                    ? "none"
+                    : postResetFrame.header().type() + " on stream " + postResetFrame.header().streamId()
+                            + (postResetFrame.header().type() == Http2FrameType.RST_STREAM
+                            ? " with error " + Http2RstStream.create(postResetFrame.data()).errorCode()
+                            : "");
+            assertThat("Unexpected frame after peer RST_STREAM: " + postResetFrameDescription,
+                       postResetFrame, nullValue());
         } finally {
             canceled.release.countDown();
             sibling.release.countDown();
@@ -613,8 +632,11 @@ class SseHttp2Test {
             if (control.lastEvent != null) {
                 sink.emit(SseEvent.create(control.lastEvent));
             }
-        } catch (Throwable t) {
+        } catch (RuntimeException | Error t) {
             control.failure.compareAndSet(null, t);
+            if (control.propagateFailure) {
+                throw t;
+            }
         } finally {
             control.completed.countDown();
         }
@@ -736,6 +758,11 @@ class SseHttp2Test {
             ArrayDeque<InboundFrame> frames = queued.get(streamId);
             return frames != null && !frames.isEmpty();
         }
+
+        private Http2FrameData pollQueuedFrame(int streamId) {
+            ArrayDeque<InboundFrame> frames = queued.get(streamId);
+            return frames == null || frames.isEmpty() ? null : frames.removeFirst().frame();
+        }
     }
 
     private static final class StreamCapture {
@@ -791,14 +818,23 @@ class SseHttp2Test {
     private static final class StreamControl {
         private final String firstEvent;
         private final String lastEvent;
+        private final boolean propagateFailure;
         private final CountDownLatch sinkCreated = new CountDownLatch(1);
         private final CountDownLatch release;
         private final CountDownLatch completed = new CountDownLatch(1);
         private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
         private StreamControl(String firstEvent, String lastEvent, boolean initiallyReleased) {
+            this(firstEvent, lastEvent, initiallyReleased, false);
+        }
+
+        private StreamControl(String firstEvent,
+                              String lastEvent,
+                              boolean initiallyReleased,
+                              boolean propagateFailure) {
             this.firstEvent = firstEvent;
             this.lastEvent = lastEvent;
+            this.propagateFailure = propagateFailure;
             release = new CountDownLatch(initiallyReleased ? 0 : 1);
         }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -189,6 +189,27 @@ class SseHttp2Test {
     }
 
     @Test
+    void headSseSendsOneHeaderBlockAndKeepsConnectionUsable(Http2TestClient client) {
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            connection.request(1, Method.HEAD, "/sse-head", sseHeaders(), BufferData.empty());
+
+            StreamCapture head = new StreamCapture();
+            head.readUntilEnd(frames, 1);
+            assertThat("HEAD SSE response status", head.responseHeaders.status(), is(Status.OK_200));
+            assertThat("HEAD SSE must contain no entity", head.body(), is(""));
+            assertThat("HEAD SSE must end on its only HEADERS block",
+                       head.terminalFrameType, is(Http2FrameType.HEADERS));
+
+            request(connection, 3, "/ping", WritableHeaders.create());
+            assertPing(frames, 3);
+            assertThat("HEAD SSE must not emit a second response header block",
+                       frames.hasQueuedFrame(1), is(false));
+        }
+    }
+
+    @Test
     void concurrentSseStreamsCompleteIndependentlyOnOneConnection(Http2TestClient client) throws InterruptedException {
         StreamControl first = new StreamControl("open-one", "close-one", false);
         StreamControl second = new StreamControl("open-two", "close-two", false);
@@ -348,6 +369,11 @@ class SseHttp2Test {
                 .route(Http2Route.route(Method.GET, "/ping", (req, res) -> {
                     res.header(SOCKET_ID, req.socketId());
                     res.send("ok");
+                }))
+                .route(Http2Route.route(Method.HEAD, "/sse-head", (_, res) -> {
+                    try (SseSink _ = res.sink(SseSink.TYPE)) {
+                        // A HEAD response completes without an SSE entity.
+                    }
                 }))
                 .route(Http2Route.route(Method.GET, "/controlled", (req, res) -> controlled(req.query().get("id"), res)))
                 .route(Http2Route.route(Method.GET, "/lifecycle", (req, res) -> lifecycle(req.query().get("id"), res)));

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -411,6 +411,50 @@ class SseHttp2Test {
     }
 
     @Test
+    void invalidWindowUpdateResetReleasesBlockedZeroWindowSseHandler(Http2TestClient client)
+            throws InterruptedException {
+        String payload = "x".repeat(FLOW_WINDOW);
+        StreamControl reset = new StreamControl(payload, null, false);
+        STREAM_CONTROLS.put("zero-window-update-reset", reset);
+        try (Http2TestConnection connection = client.createConnection()) {
+            connection.completeHandshake(TIMEOUT);
+            connection.sendSettings(Http2Settings.builder()
+                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, (long) FLOW_WINDOW)
+                                            .build());
+
+            FrameDemultiplexer frames = new FrameDemultiplexer(connection);
+            request(connection, 1, "/controlled?id=zero-window-update-reset", sseHeaders());
+
+            Http2FrameData settingsAck = frames.next(0, "window-update-reset SETTINGS acknowledgment").frame();
+            assertThat("Window-update-reset response frame type",
+                       settingsAck.header().type(), is(Http2FrameType.SETTINGS));
+            assertThat("Window-update-reset SETTINGS must be acknowledged before response headers",
+                       settingsAck.header().flags(Http2FrameTypes.SETTINGS).ack(), is(true));
+
+            StreamCapture resetCapture = new StreamCapture();
+            resetCapture.readUntilBytes(frames, 1, FLOW_WINDOW);
+            assertThat("SSE handler must consume all advertised stream credit before invalid WINDOW_UPDATE",
+                       resetCapture.data.size(), is(FLOW_WINDOW));
+            assertThat("SSE handler must remain blocked before invalid WINDOW_UPDATE",
+                       reset.completed.getCount(), is(1L));
+
+            connection.writer().write(new Http2WindowUpdate(0)
+                                              .toFrameData(null, 1, Http2Flag.NoFlags.create()));
+
+            assertThat(connection.assertRstStream(1, TIMEOUT).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            await("Invalid-window-update zero-window SSE handler completion", reset.completed);
+            assertThat(reset.failure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) reset.failure.get()).code(), is(Http2ErrorCode.CANCEL));
+
+            request(connection, 3, "/ping", WritableHeaders.create());
+            assertPing(frames, 3);
+        } finally {
+            reset.release.countDown();
+            STREAM_CONTROLS.remove("zero-window-update-reset");
+        }
+    }
+
+    @Test
     void sustainedSseHonorsStreamFlowControl(Http2TestClient client) throws InterruptedException {
         String payload = "x".repeat(1024);
         StreamControl control = new StreamControl(payload, null, true);

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -284,7 +284,7 @@ class SseHttp2Test {
 
     @Test
     void clientCancelDoesNotAffectSiblingStreamOrConnection(Http2TestClient client) throws InterruptedException {
-        StreamControl canceled = new StreamControl("open-cancel", "late-cancel", false, true);
+        StreamControl canceled = new StreamControl("open-cancel", "late-cancel", false);
         StreamControl sibling = new StreamControl("open-sibling", "close-sibling", false);
         STREAM_CONTROLS.put("cancel", canceled);
         STREAM_CONTROLS.put("sibling", sibling);
@@ -314,19 +314,7 @@ class SseHttp2Test {
             request(connection, 5, "/ping", WritableHeaders.create());
             assertPing(frames, 5);
             await("Canceled handler completion", canceled.completed);
-
-            Http2FrameData postResetFrame = frames.pollQueuedFrame(1);
-            if (postResetFrame == null) {
-                postResetFrame = connection.awaitNextFrame(Duration.ofMillis(500));
-            }
-            String postResetFrameDescription = postResetFrame == null
-                    ? "none"
-                    : postResetFrame.header().type() + " on stream " + postResetFrame.header().streamId()
-                            + (postResetFrame.header().type() == Http2FrameType.RST_STREAM
-                            ? " with error " + Http2RstStream.create(postResetFrame.data()).errorCode()
-                            : "");
-            assertThat("Unexpected frame after peer RST_STREAM: " + postResetFrameDescription,
-                       postResetFrame, nullValue());
+            assertThat("Canceled SSE write must fail after peer RST_STREAM", canceled.failure.get(), notNullValue());
         } finally {
             canceled.release.countDown();
             sibling.release.countDown();
@@ -632,11 +620,8 @@ class SseHttp2Test {
             if (control.lastEvent != null) {
                 sink.emit(SseEvent.create(control.lastEvent));
             }
-        } catch (RuntimeException | Error t) {
+        } catch (Throwable t) {
             control.failure.compareAndSet(null, t);
-            if (control.propagateFailure) {
-                throw t;
-            }
         } finally {
             control.completed.countDown();
         }
@@ -758,11 +743,6 @@ class SseHttp2Test {
             ArrayDeque<InboundFrame> frames = queued.get(streamId);
             return frames != null && !frames.isEmpty();
         }
-
-        private Http2FrameData pollQueuedFrame(int streamId) {
-            ArrayDeque<InboundFrame> frames = queued.get(streamId);
-            return frames == null || frames.isEmpty() ? null : frames.removeFirst().frame();
-        }
     }
 
     private static final class StreamCapture {
@@ -818,23 +798,14 @@ class SseHttp2Test {
     private static final class StreamControl {
         private final String firstEvent;
         private final String lastEvent;
-        private final boolean propagateFailure;
         private final CountDownLatch sinkCreated = new CountDownLatch(1);
         private final CountDownLatch release;
         private final CountDownLatch completed = new CountDownLatch(1);
         private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
         private StreamControl(String firstEvent, String lastEvent, boolean initiallyReleased) {
-            this(firstEvent, lastEvent, initiallyReleased, false);
-        }
-
-        private StreamControl(String firstEvent,
-                              String lastEvent,
-                              boolean initiallyReleased,
-                              boolean propagateFailure) {
             this.firstEvent = firstEvent;
             this.lastEvent = lastEvent;
-            this.propagateFailure = propagateFailure;
             release = new CountDownLatch(initiallyReleased ? 0 : 1);
         }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SseHttp2Test.java
@@ -50,6 +50,7 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.encoding.gzip.GzipEncoding;
 import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameType;
@@ -77,6 +78,7 @@ import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -313,13 +315,14 @@ class SseHttp2Test {
     }
 
     @Test
-    void clientCancelReleasesZeroWindowSseHandler(Http2TestClient client) throws InterruptedException {
-        StreamControl canceled = new StreamControl(null, "late-cancel", false);
+    void clientCancelReleasesBlockedZeroWindowSseHandler(Http2TestClient client) throws InterruptedException {
+        String payload = "x".repeat(FLOW_WINDOW);
+        StreamControl canceled = new StreamControl(payload, null, false);
         STREAM_CONTROLS.put("zero-window-cancel", canceled);
         try (Http2TestConnection connection = client.createConnection()) {
             connection.completeHandshake(TIMEOUT);
             connection.sendSettings(Http2Settings.builder()
-                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, 0L)
+                                            .add(Http2Setting.INITIAL_WINDOW_SIZE, (long) FLOW_WINDOW)
                                             .build());
             FrameDemultiplexer frames = new FrameDemultiplexer(connection);
             request(connection, 1, "/controlled?id=zero-window-cancel", sseHeaders());
@@ -330,29 +333,18 @@ class SseHttp2Test {
                        settingsAck.header().flags(Http2FrameTypes.SETTINGS).ack(), is(true));
 
             StreamCapture canceledCapture = new StreamCapture();
-            canceledCapture.accept(frames.next(1, "zero-window SSE response headers"));
-            assertThat("Zero-window SSE response must start with HEADERS",
-                       canceledCapture.responseHeaders, notNullValue());
-            assertThat("Zero-window SSE response must remain open after HEADERS", canceledCapture.ended, is(false));
+            canceledCapture.readUntilBytes(frames, 1, FLOW_WINDOW);
+            assertThat("SSE handler must consume all advertised stream credit before reset",
+                       canceledCapture.data.size(), is(FLOW_WINDOW));
+            assertThat("SSE handler must remain blocked before reset", canceled.completed.getCount(), is(1L));
 
             connection.writer().write(new Http2RstStream(Http2ErrorCode.CANCEL)
                                               .toFrameData(null, 1, Http2Flag.NoFlags.create()));
             request(connection, 3, "/ping", WritableHeaders.create());
-
-            StreamCapture ping = new StreamCapture();
-            ping.accept(frames.next(3, "sibling ping response headers after client reset"));
-            assertThat("Sibling ping response status", ping.responseHeaders.status(), is(Status.OK_200));
-            assertThat("Sibling ping must remain flow-control blocked before WINDOW_UPDATE", ping.ended, is(false));
-
-            canceled.release.countDown();
+            assertPing(frames, 3);
             await("Canceled zero-window SSE handler completion", canceled.completed);
-            assertThat("Canceled zero-window SSE handler must observe stream cancellation",
-                       canceled.failure.get(), notNullValue());
-
-            connection.writer().write(new Http2WindowUpdate(2)
-                                              .toFrameData(null, 3, Http2Flag.NoFlags.create()));
-            ping.readUntilEnd(frames, 3);
-            assertThat("Sibling ping survives zero-window SSE cancellation", ping.body(), is("ok"));
+            assertThat(canceled.failure.get(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) canceled.failure.get()).code(), is(Http2ErrorCode.CANCEL));
         } finally {
             canceled.release.countDown();
             STREAM_CONTROLS.remove("zero-window-cancel");

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseClientTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import jakarta.json.JsonObject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.http.HeaderValues.ACCEPT_EVENT_STREAM;
@@ -42,7 +41,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
-@Disabled
 class SseClientTest extends SseBaseTest {
 
     private final Http1Client client;

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
@@ -35,10 +35,12 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.sse.SseEvent;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.sse.SseSink;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +65,11 @@ class SseHttp1TransportTest {
         this.webServer = webServer;
     }
 
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.putSocket("unbuffered", socket -> socket.writeBufferSize(0));
+    }
+
     @SetUpRoute
     static void routing(HttpRules rules) {
         rules.get("/sse", (req, res) -> {
@@ -78,6 +85,19 @@ class SseHttp1TransportTest {
             res.header(SOCKET_ID, req.socketId());
             try (SseSink _ = res.sink(SseSink.TYPE)) {
                 // A HEAD response completes without an SSE entity.
+            }
+        });
+        rules.get("/connection", (req, res) -> res.send(req.socketId()));
+    }
+
+    @SetUpRoute("unbuffered")
+    static void unbufferedRouting(HttpRules rules) {
+        rules.get("/sse-empty", (req, res) -> {
+            res.header(SOCKET_ID, req.socketId());
+            res.header(HeaderNames.TRAILER, SSE_TRAILER.defaultCase());
+            res.beforeTrailers(trailers -> trailers.set(SSE_TRAILER, COMPLETE));
+            try (SseSink sink = res.sink(SseSink.TYPE)) {
+                sink.emit(SseEvent.create(""));
             }
         });
         rules.get("/connection", (req, res) -> res.send(req.socketId()));
@@ -100,6 +120,25 @@ class SseHttp1TransportTest {
             assertThat("SSE response must contain at least one data chunk",
                        response.chunkSizes().size(),
                        greaterThan(0));
+
+            assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
+        }
+    }
+
+    @Test
+    void emptyDataValueDoesNotTerminateChunkedBody() throws Exception {
+        try (SocketHttpClient client = socketClient("unbuffered")) {
+            client.request(Method.GET,
+                           "/sse-empty",
+                           null,
+                           List.of("Accept: text/event-stream", "TE: trailers"));
+            InputStream input = client.socketInputStream();
+            RawResponse response = readResponse(input);
+
+            assertSseResponse(response);
+            assertThat("Empty SSE data value must preserve complete event framing",
+                       new String(response.entity(), StandardCharsets.UTF_8),
+                       is("data:\n\n"));
 
             assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
         }
@@ -316,6 +355,10 @@ class SseHttp1TransportTest {
 
     private SocketHttpClient socketClient() {
         return SocketHttpClient.create("localhost", webServer.port(), SOCKET_TIMEOUT);
+    }
+
+    private SocketHttpClient socketClient(String socketName) {
+        return SocketHttpClient.create("localhost", webServer.port(socketName), SOCKET_TIMEOUT);
     }
 
     private record RawResponse(int statusCode,

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -79,6 +80,13 @@ class SseHttp1TransportTest {
             try (SseSink sink = res.sink(SseSink.TYPE)) {
                 sink.emit(SseEvent.create("hello"));
                 sink.emit(SseEvent.create("world"));
+            }
+        });
+        rules.get("/content-length-sse", (req, res) -> {
+            res.header(SOCKET_ID, req.socketId());
+            res.beforeSend(() -> res.header(HeaderNames.CONTENT_LENGTH, "13"));
+            try (SseSink sink = res.sink(SseSink.TYPE)) {
+                sink.emit(SseEvent.create("x"));
             }
         });
         rules.any("/sse-head", (req, res) -> {
@@ -141,6 +149,36 @@ class SseHttp1TransportTest {
                        is("data:\n\n"));
 
             assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
+        }
+    }
+
+    @Test
+    void sseRemovesContentLengthBeforeReusingConnection() throws Exception {
+        try (SocketHttpClient client = socketClient()) {
+            client.request(Method.GET,
+                           "/content-length-sse",
+                           null,
+                           List.of("Accept: text/event-stream"));
+            client.request(Method.GET, "/connection", null, List.of("Accept: text/plain"));
+            InputStream input = client.socketInputStream();
+
+            RawResponse sse = readResponse(input);
+            assertThat("SSE response must not retain filter-supplied Content-Length",
+                       sse.header("content-length"), nullValue());
+            assertThat("SSE response must use streaming HTTP/1 framing",
+                       sse.header("transfer-encoding").toLowerCase(Locale.ROOT),
+                       containsString("chunked"));
+            assertThat("SSE response must preserve exact event framing",
+                       new String(sse.entity(), StandardCharsets.UTF_8),
+                       is("data:x\n\n"));
+
+            String socketId = sse.header(SOCKET_ID.defaultCase());
+            assertThat("SSE response must expose its physical socket id", socketId, notNullValue());
+            RawResponse probe = readResponse(input);
+            assertThat("Connection probe status", probe.statusCode(), is(200));
+            assertThat("Probe must use the same physical server socket after SSE completion",
+                       new String(probe.entity(), StandardCharsets.UTF_8),
+                       is(socketId));
         }
     }
 

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
@@ -74,6 +74,12 @@ class SseHttp1TransportTest {
                 sink.emit(SseEvent.create("world"));
             }
         });
+        rules.any("/sse-head", (req, res) -> {
+            res.header(SOCKET_ID, req.socketId());
+            try (SseSink _ = res.sink(SseSink.TYPE)) {
+                // A HEAD response completes without an SSE entity.
+            }
+        });
         rules.get("/connection", (req, res) -> res.send(req.socketId()));
     }
 
@@ -120,6 +126,25 @@ class SseHttp1TransportTest {
             assertThat("Gzip footer must record the complete uncompressed SSE entity",
                        gzipInputSize(response.entity()),
                        is((long) SSE_ENTITY.getBytes(StandardCharsets.UTF_8).length));
+
+            assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
+        }
+    }
+
+    @Test
+    void headSseSendsOneHeaderBlockAndKeepsConnectionReusable() throws Exception {
+        try (SocketHttpClient client = socketClient()) {
+            client.request(Method.HEAD,
+                           "/sse-head",
+                           null,
+                           List.of("Accept: text/event-stream"));
+            InputStream input = client.socketInputStream();
+            RawResponse response = readHeadResponse(input);
+
+            assertThat("HEAD SSE response status", response.statusCode(), is(200));
+            assertThat("HEAD SSE must contain no entity", response.entity().length, is(0));
+            assertThat("HEAD SSE response must expose its physical socket id",
+                       response.header(SOCKET_ID.defaultCase()), notNullValue());
 
             assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
         }
@@ -182,6 +207,21 @@ class SseHttp1TransportTest {
         assertThat("Non-chunked response must declare Content-Length", contentLength, notNullValue());
         byte[] entity = readBytes(input, Integer.parseInt(contentLength));
         return new RawResponse(statusCode, headers, Map.of(), entity, List.of(), null);
+    }
+
+    private static RawResponse readHeadResponse(InputStream input) throws IOException {
+        String statusLine = readCrlfLine(input);
+        assertThat("HTTP response must start with a status line", statusLine, notNullValue());
+        String[] statusParts = statusLine.split(" ", 3);
+        assertThat("HTTP status line must contain a numeric status code: " + statusLine,
+                   statusParts.length,
+                   greaterThan(1));
+        return new RawResponse(Integer.parseInt(statusParts[1]),
+                               readFields(input),
+                               Map.of(),
+                               new byte[0],
+                               List.of(),
+                               null);
     }
 
     private static RawResponse readChunkedResponse(int statusCode,

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
@@ -27,13 +27,19 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.sse.SseEvent;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webclient.sse.SseSource;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRules;
@@ -44,6 +50,7 @@ import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.http.HeaderValues.ACCEPT_EVENT_STREAM;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -59,11 +66,14 @@ class SseHttp1TransportTest {
     private static final String COMPLETE = "complete";
     private static final HeaderName SOCKET_ID = HeaderNames.create("x-socket-id");
     private static final HeaderName SSE_TRAILER = HeaderNames.create("x-sse-complete");
+    private static final HeaderName STREAM_RESULT = HeaderNames.create("stream-result");
 
     private final WebServer webServer;
+    private final Http1Client http1Client;
 
-    SseHttp1TransportTest(WebServer webServer) {
+    SseHttp1TransportTest(WebServer webServer, Http1Client http1Client) {
         this.webServer = webServer;
+        this.http1Client = http1Client;
     }
 
     @SetUpServer
@@ -178,6 +188,44 @@ class SseHttp1TransportTest {
             assertThat("Connection probe status", probe.statusCode(), is(200));
             assertThat("Probe must use the same physical server socket after SSE completion",
                        new String(probe.entity(), StandardCharsets.UTF_8),
+                       is(socketId));
+        }
+    }
+
+    @Test
+    void teTrailersWithoutRouteTrailerKeepsHelidonClientConnectionReusable() throws InterruptedException {
+        CountDownLatch complete = new CountDownLatch(1);
+        String socketId;
+        try (Http1ClientResponse response = http1Client.get("/content-length-sse")
+                .header(ACCEPT_EVENT_STREAM)
+                .header(HeaderValues.TE_TRAILERS)
+                .request()) {
+            socketId = response.headers().first(SOCKET_ID).orElse(null);
+            assertThat("SSE response must expose its physical socket id", socketId, notNullValue());
+            assertThat("SSE response must declare the stream-result trailer",
+                       response.headers().first(HeaderNames.TRAILER).orElse(null),
+                       is("stream-result"));
+            response.source(SseSource.TYPE, new SseSource() {
+                @Override
+                public void onEvent(SseEvent event) {
+                }
+
+                @Override
+                public void onClose() {
+                    complete.countDown();
+                }
+            });
+            assertThat("Helidon client must consume the complete SSE response",
+                       complete.await(SOCKET_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                       is(true));
+            assertThat("Helidon client must consume the declared stream-result trailer",
+                       response.trailers().first(STREAM_RESULT).orElse(null),
+                       is(""));
+        }
+
+        try (Http1ClientResponse response = http1Client.get("/connection").request()) {
+            assertThat("Helidon client must reuse the same physical server socket after SSE completion",
+                       response.as(String.class),
                        is(socketId));
         }
     }

--- a/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
+++ b/webserver/tests/sse/src/test/java/io/helidon/webserver/tests/sse/SseHttp1TransportTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.sse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.sse.SseEvent;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.sse.SseSink;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ServerTest
+class SseHttp1TransportTest {
+    private static final Duration SOCKET_TIMEOUT = Duration.ofSeconds(10);
+    private static final String SSE_ENTITY = "data:hello\n\ndata:world\n\n";
+    private static final String COMPLETE = "complete";
+    private static final HeaderName SOCKET_ID = HeaderNames.create("x-socket-id");
+    private static final HeaderName SSE_TRAILER = HeaderNames.create("x-sse-complete");
+
+    private final WebServer webServer;
+
+    SseHttp1TransportTest(WebServer webServer) {
+        this.webServer = webServer;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/sse", (req, res) -> {
+            res.header(SOCKET_ID, req.socketId());
+            res.header(HeaderNames.TRAILER, SSE_TRAILER.defaultCase());
+            res.beforeTrailers(trailers -> trailers.set(SSE_TRAILER, COMPLETE));
+            try (SseSink sink = res.sink(SseSink.TYPE)) {
+                sink.emit(SseEvent.create("hello"));
+                sink.emit(SseEvent.create("world"));
+            }
+        });
+        rules.get("/connection", (req, res) -> res.send(req.socketId()));
+    }
+
+    @Test
+    void plainSseUsesChunkedFramingAndKeepsConnectionReusable() throws Exception {
+        try (SocketHttpClient client = socketClient()) {
+            client.request(Method.GET,
+                           "/sse",
+                           null,
+                           List.of("Accept: text/event-stream", "TE: trailers"));
+            InputStream input = client.socketInputStream();
+            RawResponse response = readResponse(input);
+
+            assertSseResponse(response);
+            assertThat("SSE wire entity must preserve exact field and event framing",
+                       new String(response.entity(), StandardCharsets.UTF_8),
+                       is(SSE_ENTITY));
+            assertThat("SSE response must contain at least one data chunk",
+                       response.chunkSizes().size(),
+                       greaterThan(0));
+
+            assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
+        }
+    }
+
+    @Test
+    void gzipSseFinalizesEncoderBeforeTerminatingChunkAndKeepsConnectionReusable() throws Exception {
+        try (SocketHttpClient client = socketClient()) {
+            client.request(Method.GET,
+                           "/sse",
+                           null,
+                           List.of("Accept: text/event-stream", "Accept-Encoding: gzip", "TE: trailers"));
+            InputStream input = client.socketInputStream();
+            RawResponse response = readResponse(input);
+
+            assertSseResponse(response);
+            assertThat("SSE response content encoding", response.header("content-encoding"), is("gzip"));
+            assertThat("Gzip entity must include its header and footer", response.entity().length, greaterThan(18));
+            assertThat("Gzip magic byte 1", response.entity()[0] & 0xff, is(0x1f));
+            assertThat("Gzip magic byte 2", response.entity()[1] & 0xff, is(0x8b));
+            assertThat("Complete gzip stream must be available before the terminating HTTP chunk",
+                       gunzip(response.entity()),
+                       is(SSE_ENTITY));
+            assertThat("Gzip footer must record the complete uncompressed SSE entity",
+                       gzipInputSize(response.entity()),
+                       is((long) SSE_ENTITY.getBytes(StandardCharsets.UTF_8).length));
+
+            assertConnectionReuse(client, input, response.header(SOCKET_ID.defaultCase()));
+        }
+    }
+
+    private static void assertSseResponse(RawResponse response) {
+        String contentType = response.header("content-type");
+        String transferEncoding = response.header("transfer-encoding");
+        String trailer = response.header("trailer");
+
+        assertThat("SSE response status", response.statusCode(), is(200));
+        assertThat("SSE response content type", contentType, notNullValue());
+        assertThat("SSE response content type",
+                   contentType.toLowerCase(Locale.ROOT),
+                   startsWith("text/event-stream"));
+        assertThat("SSE response transfer encoding", transferEncoding, notNullValue());
+        assertThat("SSE response transfer encoding",
+                   transferEncoding.toLowerCase(Locale.ROOT),
+                   containsString("chunked"));
+        assertThat("SSE response trailer declaration", trailer, notNullValue());
+        assertThat("SSE response must declare its trailer",
+                   trailer.toLowerCase(Locale.ROOT),
+                   containsString(SSE_TRAILER.lowerCase()));
+        assertThat("SSE response must end with the HTTP/1 zero chunk", response.terminatingChunkLine(), is("0"));
+        assertThat("SSE response trailer value",
+                   response.trailer(SSE_TRAILER.defaultCase()),
+                   is(COMPLETE));
+    }
+
+    private static void assertConnectionReuse(SocketHttpClient client,
+                                              InputStream input,
+                                              String expectedSocketId) throws IOException {
+        assertThat("SSE response must expose its physical socket id", expectedSocketId, notNullValue());
+
+        client.request(Method.GET, "/connection", null, List.of("Accept: text/plain"));
+        RawResponse response = readResponse(input);
+
+        assertThat("Connection probe status", response.statusCode(), is(200));
+        assertThat("Probe must use the same physical server socket as the completed SSE response",
+                   new String(response.entity(), StandardCharsets.UTF_8),
+                   is(expectedSocketId));
+    }
+
+    private static RawResponse readResponse(InputStream input) throws IOException {
+        String statusLine = readCrlfLine(input);
+        assertThat("HTTP response must start with a status line", statusLine, notNullValue());
+        String[] statusParts = statusLine.split(" ", 3);
+        assertThat("HTTP status line must contain a numeric status code: " + statusLine,
+                   statusParts.length,
+                   greaterThan(1));
+        int statusCode = Integer.parseInt(statusParts[1]);
+
+        Map<String, List<String>> headers = readFields(input);
+        String transferEncoding = firstValue(headers, "transfer-encoding");
+        if (transferEncoding != null && transferEncoding.toLowerCase(Locale.ROOT).contains("chunked")) {
+            return readChunkedResponse(statusCode, headers, input);
+        }
+
+        String contentLength = firstValue(headers, "content-length");
+        assertThat("Non-chunked response must declare Content-Length", contentLength, notNullValue());
+        byte[] entity = readBytes(input, Integer.parseInt(contentLength));
+        return new RawResponse(statusCode, headers, Map.of(), entity, List.of(), null);
+    }
+
+    private static RawResponse readChunkedResponse(int statusCode,
+                                                   Map<String, List<String>> headers,
+                                                   InputStream input) throws IOException {
+        ByteArrayOutputStream entity = new ByteArrayOutputStream();
+        List<Integer> chunkSizes = new ArrayList<>();
+
+        while (true) {
+            String chunkLine = readCrlfLine(input);
+            assertThat("Chunked response must contain a chunk-size line", chunkLine, notNullValue());
+            String chunkSizeText = chunkLine.split(";", 2)[0].trim();
+            int chunkSize = Integer.parseInt(chunkSizeText, 16);
+            if (chunkSize == 0) {
+                Map<String, List<String>> trailers = readFields(input);
+                return new RawResponse(statusCode, headers, trailers, entity.toByteArray(), chunkSizes, chunkLine);
+            }
+
+            byte[] chunk = readBytes(input, chunkSize);
+            entity.writeBytes(chunk);
+            chunkSizes.add(chunkSize);
+            expectCrlf(input, "data chunk of size " + chunkSize);
+        }
+    }
+
+    private static Map<String, List<String>> readFields(InputStream input) throws IOException {
+        Map<String, List<String>> fields = new LinkedHashMap<>();
+        while (true) {
+            String line = readCrlfLine(input);
+            assertThat("HTTP field block ended before its terminating empty line", line, notNullValue());
+            if (line.isEmpty()) {
+                return fields;
+            }
+            int colon = line.indexOf(':');
+            assertThat("HTTP field must contain a colon: " + line, colon, greaterThan(0));
+            String name = line.substring(0, colon).toLowerCase(Locale.ROOT);
+            String value = line.substring(colon + 1).trim();
+            fields.computeIfAbsent(name, _ -> new ArrayList<>()).add(value);
+        }
+    }
+
+    private static String firstValue(Map<String, List<String>> fields, String name) {
+        List<String> values = fields.get(name.toLowerCase(Locale.ROOT));
+        return values == null || values.isEmpty() ? null : values.get(0);
+    }
+
+    private static String readCrlfLine(InputStream input) throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream();
+        int previous = -1;
+        while (true) {
+            int next = input.read();
+            if (next == -1) {
+                if (previous != -1) {
+                    line.write(previous);
+                }
+                return line.size() == 0 ? null : line.toString(StandardCharsets.US_ASCII);
+            }
+            if (previous == '\r' && next == '\n') {
+                return line.toString(StandardCharsets.US_ASCII);
+            }
+            if (previous != -1) {
+                line.write(previous);
+            }
+            previous = next;
+        }
+    }
+
+    private static byte[] readBytes(InputStream input, int length) throws IOException {
+        byte[] bytes = input.readNBytes(length);
+        assertThat("HTTP entity ended before " + length + " bytes were read", bytes.length, is(length));
+        return bytes;
+    }
+
+    private static void expectCrlf(InputStream input, String after) throws IOException {
+        assertThat("Expected CR after " + after, input.read(), is((int) '\r'));
+        assertThat("Expected LF after " + after, input.read(), is((int) '\n'));
+    }
+
+    private static String gunzip(byte[] entity) throws IOException {
+        try (GZIPInputStream input = new GZIPInputStream(new ByteArrayInputStream(entity))) {
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static long gzipInputSize(byte[] entity) {
+        int offset = entity.length - Integer.BYTES;
+        return (entity[offset] & 0xffL)
+                | ((entity[offset + 1] & 0xffL) << 8)
+                | ((entity[offset + 2] & 0xffL) << 16)
+                | ((entity[offset + 3] & 0xffL) << 24);
+    }
+
+    private SocketHttpClient socketClient() {
+        return SocketHttpClient.create("localhost", webServer.port(), SOCKET_TIMEOUT);
+    }
+
+    private record RawResponse(int statusCode,
+                               Map<String, List<String>> headers,
+                               Map<String, List<String>> trailers,
+                               byte[] entity,
+                               List<Integer> chunkSizes,
+                               String terminatingChunkLine) {
+
+        private String header(String name) {
+            return firstValue(headers, name);
+        }
+
+        private String trailer(String name) {
+            return firstValue(trailers, name);
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -22,11 +22,15 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import io.helidon.common.Api;
 import io.helidon.common.GenericType;
+import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
@@ -47,6 +51,9 @@ import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.UnsupportedTypeException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerConnectionException;
+import io.helidon.webserver.http.spi.Sink;
+import io.helidon.webserver.http.spi.SinkProvider;
+import io.helidon.webserver.http.spi.SinkProviderContext;
 
 /**
  * Base class for common server response tasks that can be shared across HTTP versions.
@@ -76,6 +83,9 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private static final HeaderName REPR_DIGEST_NAME = HeaderNames.create("Repr-Digest");
     private static final Header VARY_ACCEPT_ENCODING =
             HeaderValues.createCached(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING_NAME);
+    @SuppressWarnings("rawtypes")
+    private static final List<SinkProvider> SINK_PROVIDERS =
+            HelidonServiceLoader.builder(ServiceLoader.load(SinkProvider.class)).build().asList();
     private final ContentEncodingContext contentEncodingContext;
     private final MediaContext mediaContext;
     private final ServerRequestHeaders requestHeaders;
@@ -296,6 +306,74 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      */
     protected Consumer<ServerResponseTrailers> beforeTrailers() {
         return beforeTrailers;
+    }
+
+    /**
+     * Find a sink provider for the requested sink type.
+     *
+     * @param sinkType sink type
+     * @param request server request
+     * @return matching sink provider
+     */
+    protected final SinkProvider<?> findSinkProvider(GenericType<? extends Sink<?>> sinkType, ServerRequest request) {
+        for (SinkProvider<?> provider : SINK_PROVIDERS) {
+            if (provider.supports(sinkType, request)) {
+                return provider;
+            }
+        }
+        throw new HttpException("Unable to find sink provider for request", Status.NOT_ACCEPTABLE_406);
+    }
+
+    /**
+     * Create a sink using the shared provider context and protocol-specific callbacks.
+     *
+     * @param provider sink provider
+     * @param request server request
+     * @param connectionContext connection context
+     * @param entityOutputStreamProvider protocol entity stream provider
+     * @param closeRunnable protocol close callback
+     * @param flushHeadersRunnable protocol header flush callback
+     * @param <X> sink type
+     * @return created sink
+     */
+    @SuppressWarnings("unchecked")
+    protected final <X extends Sink<?>> X createSink(SinkProvider<?> provider,
+                                                     ServerRequest request,
+                                                     ConnectionContext connectionContext,
+                                                     Function<Runnable, Optional<OutputStream>> entityOutputStreamProvider,
+                                                     Runnable closeRunnable,
+                                                     Runnable flushHeadersRunnable) {
+        return (X) provider.create(new SinkProviderContext() {
+            @Override
+            public ServerResponse serverResponse() {
+                return ServerResponseBase.this;
+            }
+
+            @Override
+            public ServerRequest serverRequest() {
+                return request;
+            }
+
+            @Override
+            public ConnectionContext connectionContext() {
+                return connectionContext;
+            }
+
+            @Override
+            public Optional<OutputStream> entityOutputStream(Runnable responsePreparation) {
+                return entityOutputStreamProvider.apply(responsePreparation);
+            }
+
+            @Override
+            public Runnable closeRunnable() {
+                return closeRunnable;
+            }
+
+            @Override
+            public void flushHeaders() {
+                flushHeadersRunnable.run();
+            }
+        });
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -390,7 +390,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         return Optional.of(outputStream(false));
     }
 
-    private void flushHeaders() {
+    void flushHeaders() {
         if (outputStream != null) {
             outputStream.flushHeaders();
         }
@@ -720,13 +720,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                                 || headers.contains(HeaderNames.TRAILER));
 
             if (noEntityResponse && !headResponseSent) {
-                sendListener.status(ctx, usedStatus);
-                sendListener.headers(ctx, headers);
-                BufferData bufferData = BufferData.growing(256);
-                nonEntityBytes(headers, usedStatus, bufferData, keepAlive, validateHeaders);
-                sendListener.data(ctx, bufferData);
-                responseBytesTotal += bufferData.available();
-                writeResponse(dataWriter, bufferData, "Failed to write response");
+                sendNoEntityResponse(usedStatus);
             } else if (headRequest) {
                 if (!headResponseSent) {
                     if (sendTrailers && beforeTrailers != null) {
@@ -789,6 +783,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 firstByte = false;
                 return;
             }
+            Status usedStatus = status.get();
+            if (isNoEntityStatus(usedStatus)) {
+                normalizeNoEntityHeaders(headers, usedStatus);
+                sendNoEntityResponse(usedStatus);
+                firstByte = false;
+                responseSentRunnable.run();
+                return;
+            }
             if (firstBuffer != null) {
                 try {
                     write(BufferData.empty());
@@ -804,6 +806,17 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             sendHeadersAndPrepare();
             firstByte = false;
             responseSentRunnable.run();
+        }
+
+        private void sendNoEntityResponse(Status usedStatus) {
+            sendListener.status(ctx, usedStatus);
+            sendListener.headers(ctx, headers);
+            BufferData bufferData = BufferData.growing(256);
+            nonEntityBytes(headers, usedStatus, bufferData, keepAlive, validateHeaders);
+            sendListener.data(ctx, bufferData);
+            responseBytesTotal += bufferData.available();
+            writeResponse(dataWriter, bufferData, "Failed to write response");
+            headResponseSent = true;
         }
 
         long totalBytesWritten() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -1188,13 +1188,17 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
 
         private void failedWrite(IOException e) {
-            discardWrites = true;
-            writeFailure = new UncheckedIOException(e);
+            if (!discardWrites) {
+                discardWrites = true;
+                writeFailure = new UncheckedIOException(e);
+            }
         }
 
         private void failedWrite(RuntimeException e) {
-            discardWrites = true;
-            writeFailure = e;
+            if (!discardWrites) {
+                discardWrites = true;
+                writeFailure = e;
+            }
         }
 
         void commit() {
@@ -1239,30 +1243,70 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         @Override
         public void write(int b) throws IOException {
             responseOutputStream.checkApplicationWrite(1);
-            delegate.write(b);
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b) throws IOException {
             responseOutputStream.checkApplicationWrite(b.length);
-            delegate.write(b);
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             responseOutputStream.checkApplicationWrite(len);
-            delegate.write(b, off, len);
+            try {
+                delegate.write(b, off, len);
+            } catch (IOException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void flush() throws IOException {
             responseOutputStream.checkApplicationWrite(0);
-            delegate.flush();
+            try {
+                delegate.flush();
+            } catch (IOException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void close() throws IOException {
-            delegate.close();
+            try {
+                delegate.close();
+            } catch (IOException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                responseOutputStream.failedWrite(e);
+                throw e;
+            }
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -1002,6 +1002,9 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         private void writeChunked(BufferData buffer) {
             int available = buffer.available();
+            if (available == 0) {
+                return;
+            }
             byte[] hex = Integer.toHexString(available).getBytes(StandardCharsets.US_ASCII);
 
             BufferData toWrite = BufferData.create(available + hex.length + 4); // \r\n after size, another after chunk

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -21,15 +21,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.helidon.common.GenericType;
-import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.media.type.MediaType;
@@ -40,7 +37,6 @@ import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
-import io.helidon.http.HttpException;
 import io.helidon.http.Method;
 import io.helidon.http.ServerResponseHeaders;
 import io.helidon.http.ServerResponseTrailers;
@@ -50,12 +46,9 @@ import io.helidon.http.media.EntityWriter;
 import io.helidon.http.media.MediaContext;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ServerConnectionException;
-import io.helidon.webserver.http.ServerRequest;
-import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http.ServerResponseBase;
 import io.helidon.webserver.http.spi.Sink;
 import io.helidon.webserver.http.spi.SinkProvider;
-import io.helidon.webserver.http.spi.SinkProviderContext;
 import io.helidon.webserver.http1.spi.Http1UpgradeResponse;
 
 /**
@@ -69,9 +62,6 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     private static final byte[] TERMINATING_CHUNK = "0\r\n\r\n".getBytes(StandardCharsets.UTF_8);
     private static final byte[] TERMINATING_CHUNK_TRAILERS = "0\r\n".getBytes(StandardCharsets.UTF_8);
 
-    @SuppressWarnings("rawtypes")
-    private static final List<SinkProvider> SINK_PROVIDERS
-            = HelidonServiceLoader.builder(ServiceLoader.load(SinkProvider.class)).build().asList();
     private static final WritableHeaders<?> EMPTY_HEADERS = WritableHeaders.create();
 
     private final ConnectionContext ctx;
@@ -373,56 +363,24 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     }
 
     final SinkProvider<?> findSinkProvider(GenericType<? extends Sink<?>> sinkType) {
-        for (SinkProvider<?> p : SINK_PROVIDERS) {
-            if (p.supports(sinkType, request)) {
-                return p;
-            }
-        }
-        // Request not acceptable if provider not found
-        throw new HttpException("Unable to find sink provider for request", Status.NOT_ACCEPTABLE_406);
+        return findSinkProvider(sinkType, request);
     }
 
-    @SuppressWarnings("unchecked")
     final <X extends Sink<?>> X createSink(SinkProvider<?> provider) {
-        return (X) provider.create(new SinkProviderContext() {
-            @Override
-            public ServerResponse serverResponse() {
-                return Http1ServerResponse.this;
-            }
-
-            @Override
-            public ServerRequest serverRequest() {
-                return Http1ServerResponse.this.request;
-            }
-
-            @Override
-            public ConnectionContext connectionContext() {
-                return Http1ServerResponse.this.ctx;
-            }
-
-            @Override
-            public Optional<OutputStream> entityOutputStream(Runnable responsePreparation) {
-                return Http1ServerResponse.this.sinkEntityOutputStream(responsePreparation);
-            }
-
-            @Override
-            public Runnable closeRunnable() {
-                return () -> {
-                    if (outputStream == null) {
-                        Http1ServerResponse.this.isSent = true;
-                        afterSend();
-                        request.reset();
-                    } else {
-                        commit();
-                    }
-                };
-            }
-
-            @Override
-            public void flushHeaders() {
-                Http1ServerResponse.this.flushHeaders();
-            }
-        });
+        return createSink(provider,
+                          request,
+                          ctx,
+                          this::sinkEntityOutputStream,
+                          () -> {
+                              if (outputStream == null) {
+                                  this.isSent = true;
+                                  afterSend();
+                                  request.reset();
+                              } else {
+                                  commit();
+                              }
+                          },
+                          this::flushHeaders);
     }
 
     protected Optional<OutputStream> sinkEntityOutputStream(Runnable responsePreparation) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -408,10 +408,19 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             @Override
             public Runnable closeRunnable() {
                 return () -> {
-                    Http1ServerResponse.this.isSent = true;
-                    afterSend();
-                    request.reset();
+                    if (outputStream == null) {
+                        Http1ServerResponse.this.isSent = true;
+                        afterSend();
+                        request.reset();
+                    } else {
+                        commit();
+                    }
                 };
+            }
+
+            @Override
+            public void flushHeaders() {
+                Http1ServerResponse.this.flushHeaders();
             }
         });
     }
@@ -419,7 +428,14 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
     protected Optional<OutputStream> sinkEntityOutputStream(Runnable responsePreparation) {
         Objects.requireNonNull(responsePreparation);
         beforeSend();
-        return Optional.empty();
+        responsePreparation.run();
+        return Optional.of(outputStream(false));
+    }
+
+    private void flushHeaders() {
+        if (outputStream != null) {
+            outputStream.flushHeaders();
+        }
     }
 
     private void handleSinkData(Object data, MediaType mediaType) {
@@ -795,6 +811,35 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             }
         }
 
+        /**
+         * Emits the HTTP/1.1 status line and headers while keeping the response stream open.
+         * <p>
+         * If the first body chunk was already buffered, this delegates to the normal first-write
+         * path so header emission and chunk framing stay identical to the regular streaming logic.
+         * Otherwise it sends only the headers and leaves payload writes for later.
+         */
+        void flushHeaders() {
+            if (closed) {
+                return;
+            }
+            if (!firstByte) {
+                responseSentRunnable.run();
+                return;
+            }
+            if (firstBuffer != null) {
+                try {
+                    write(BufferData.empty());
+                } catch (IOException e) {
+                    throw new ServerConnectionException("Failed to flush server response headers.", e);
+                }
+                responseSentRunnable.run();
+                return;
+            }
+            sendHeadersAndPrepare();
+            firstByte = false;
+            responseSentRunnable.run();
+        }
+
         long totalBytesWritten() {
             return responseBytesTotal;
         }
@@ -1104,6 +1149,15 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 closingDelegate.commit();
             } catch (IOException | UncheckedIOException | SocketWriterException e) {
                 throw new ServerConnectionException("Failed to flush server output stream", e);
+            }
+        }
+
+        void flushHeaders() {
+            try {
+                flush();
+                closingDelegate.flushHeaders();
+            } catch (IOException | UncheckedIOException e) {
+                throw new ServerConnectionException("Failed to flush server response headers", e);
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -531,7 +531,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
             outputStream.applicationFacing();
             return outputStream;
         }
-        return new ApplicationOutputStream(applicationOutputStream, bos);
+        return new ApplicationOutputStream(applicationOutputStream, outputStream);
     }
 
     boolean keepConnectionOpen() {
@@ -1067,6 +1067,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         private final BlockingOutputStream closingDelegate;
         private final OutputStream delegate;
         private boolean applicationFacing;
+        private boolean discardWrites;
+        private RuntimeException writeFailure;
 
         ClosingBufferedOutputStream(BlockingOutputStream out, int size) {
             this.closingDelegate = out;
@@ -1075,34 +1077,94 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
         @Override
         public void write(int b) throws IOException {
-            checkApplicationWrite(1);
-            delegate.write(b);
+            if (applicationFacing) {
+                checkApplicationWrite(1);
+            }
+            if (discardWrites) {
+                return;
+            }
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b) throws IOException {
-            checkApplicationWrite(b.length);
-            delegate.write(b);
+            if (applicationFacing) {
+                checkApplicationWrite(b.length);
+            }
+            if (discardWrites) {
+                return;
+            }
+            try {
+                delegate.write(b);
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            checkApplicationWrite(len);
-            delegate.write(b, off, len);
+            if (applicationFacing) {
+                checkApplicationWrite(len);
+            }
+            if (discardWrites) {
+                return;
+            }
+            try {
+                delegate.write(b, off, len);
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void flush() throws IOException {
-            delegate.flush();
+            if (applicationFacing) {
+                checkApplicationWrite(0);
+            }
+            if (discardWrites) {
+                return;
+            }
+            try {
+                delegate.flush();
+            } catch (IOException e) {
+                failedWrite(e);
+                throw e;
+            } catch (RuntimeException e) {
+                failedWrite(e);
+                throw e;
+            }
         }
 
         @Override
         public void close() {
             closingDelegate.closing();     // inform of imminent call to close for last flush
+            if (discardWrites) {
+                closingDelegate.close();
+                return;
+            }
             try {
                 delegate.close();
             } catch (IOException | UncheckedIOException | SocketWriterException e) {
-                throw new ServerConnectionException("Failed to close server output stream", e);
+                ServerConnectionException failure =
+                        new ServerConnectionException("Failed to close server output stream", e);
+                failedWrite(failure);
+                throw failure;
             }
         }
 
@@ -1119,18 +1181,39 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
         }
 
         private void checkApplicationWrite(int length) throws IOException {
-            if (applicationFacing) {
-                closingDelegate.checkWriteAllowed(length);
+            if (writeFailure != null) {
+                throw writeFailure;
             }
+            closingDelegate.checkWriteAllowed(length);
+        }
+
+        private void failedWrite(IOException e) {
+            discardWrites = true;
+            writeFailure = new UncheckedIOException(e);
+        }
+
+        private void failedWrite(RuntimeException e) {
+            discardWrites = true;
+            writeFailure = e;
         }
 
         void commit() {
+            if (discardWrites) {
+                closingDelegate.close();
+                if (writeFailure != null) {
+                    throw writeFailure;
+                }
+                return;
+            }
             closingDelegate.committing();
             try {
                 flush();
                 closingDelegate.commit();
             } catch (IOException | UncheckedIOException | SocketWriterException e) {
-                throw new ServerConnectionException("Failed to flush server output stream", e);
+                ServerConnectionException failure =
+                        new ServerConnectionException("Failed to flush server output stream", e);
+                failedWrite(failure);
+                throw failure;
             }
         }
 
@@ -1146,33 +1229,34 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
 
     private static class ApplicationOutputStream extends OutputStream {
         private final OutputStream delegate;
-        private final BlockingOutputStream blockingOutputStream;
+        private final ClosingBufferedOutputStream responseOutputStream;
 
-        private ApplicationOutputStream(OutputStream delegate, BlockingOutputStream blockingOutputStream) {
+        private ApplicationOutputStream(OutputStream delegate, ClosingBufferedOutputStream responseOutputStream) {
             this.delegate = delegate;
-            this.blockingOutputStream = blockingOutputStream;
+            this.responseOutputStream = responseOutputStream;
         }
 
         @Override
         public void write(int b) throws IOException {
-            blockingOutputStream.checkWriteAllowed(1);
+            responseOutputStream.checkApplicationWrite(1);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b) throws IOException {
-            blockingOutputStream.checkWriteAllowed(b.length);
+            responseOutputStream.checkApplicationWrite(b.length);
             delegate.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            blockingOutputStream.checkWriteAllowed(len);
+            responseOutputStream.checkApplicationWrite(len);
             delegate.write(b, off, len);
         }
 
         @Override
         public void flush() throws IOException {
+            responseOutputStream.checkApplicationWrite(0);
             delegate.flush();
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -798,6 +798,9 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 responseSentRunnable.run();
                 return;
             }
+            if (request.headers().containsToken(HeaderValues.TE_TRAILERS)) {
+                headers.add(STREAM_TRAILERS);
+            }
             sendHeadersAndPrepare();
             firstByte = false;
             responseSentRunnable.run();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerResponse.java
@@ -826,6 +826,11 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> implem
                 responseSentRunnable.run();
                 return;
             }
+            if (headRequest) {
+                sendHeadResponse(false);
+                firstByte = false;
+                return;
+            }
             if (firstBuffer != null) {
                 try {
                     write(BufferData.empty());

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -265,6 +265,79 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void failedFilterWriteDiscardsEncoderCloseBytes() throws IOException {
+        AtomicInteger writes = new AtomicInteger();
+        DataWriter writer = mock(DataWriter.class);
+        doAnswer(_ -> {
+            writes.incrementAndGet();
+            return null;
+        }).when(writer).write(any(BufferData.class));
+
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder(() -> { }, true));
+
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        IllegalStateException filterFailure = new IllegalStateException("Filter write failed.");
+        response.streamFilter(delegate -> new FilterOutputStream(delegate) {
+            @Override
+            public void write(int value) {
+                throw filterFailure;
+            }
+
+            @Override
+            public void write(byte[] bytes, int offset, int length) {
+                throw filterFailure;
+            }
+        });
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                                                     () -> outputStream.write("hello".getBytes(StandardCharsets.UTF_8)));
+        outputStream.close();
+        IllegalStateException commitFailure = assertThrows(IllegalStateException.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure, sameInstance(filterFailure)),
+                () -> assertThat(commitFailure, sameInstance(filterFailure)),
+                () -> assertThat(writes.get(), is(1))
+        );
+    }
+
+    @Test
+    void failedFilterCloseDoesNotCompleteResponse() throws IOException {
+        AtomicInteger writes = new AtomicInteger();
+        DataWriter writer = mock(DataWriter.class);
+        doAnswer(_ -> {
+            writes.incrementAndGet();
+            return null;
+        }).when(writer).write(any(BufferData.class));
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        IllegalStateException filterFailure = new IllegalStateException("Filter close failed.");
+        response.streamFilter(delegate -> new FilterOutputStream(delegate) {
+            @Override
+            public void close() {
+                throw filterFailure;
+            }
+        });
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, outputStream::close);
+        IllegalStateException commitFailure = assertThrows(IllegalStateException.class, response::commit);
+
+        assertAll(
+                () -> assertThat(failure, sameInstance(filterFailure)),
+                () -> assertThat(commitFailure, sameInstance(filterFailure)),
+                () -> assertThat(writes.get(), is(1))
+        );
+    }
+
+    @Test
     void lateNoEntityStatusSuppressesBufferedEntity() throws IOException {
         for (Status status : NO_ENTITY_STATUSES) {
             ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLException;
 
@@ -60,10 +61,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -230,6 +233,34 @@ class Http1ServerResponseTest {
                 () -> assertThat(exception.getCause(), instanceOf(SocketWriterException.class)),
                 () -> assertThat(exception.getCause().getCause(), instanceOf(UncheckedIOException.class)),
                 () -> assertThat(exception.getCause().getCause().getCause(), instanceOf(SocketException.class))
+        );
+    }
+
+    @Test
+    void failedStreamingWriteDiscardsEncoderCloseBytes() throws IOException {
+        AtomicInteger writes = new AtomicInteger();
+        DataWriter writer = mock(DataWriter.class);
+        doThrowingWrite(writer, writes);
+
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(contentEncodingContext.contentEncodingEnabled()).thenReturn(true);
+        when(contentEncodingContext.encoder(any(Headers.class))).thenReturn(testEncoder(() -> { }, true));
+
+        Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+        OutputStream outputStream = response.outputStream();
+        response.flushHeaders();
+        outputStream.write("hello".getBytes(StandardCharsets.UTF_8));
+
+        ServerConnectionException failure = assertThrows(ServerConnectionException.class, outputStream::flush);
+        ServerConnectionException repeatedFailure = assertThrows(ServerConnectionException.class,
+                                                                  () -> outputStream.write('y'));
+        outputStream.close();
+        ServerConnectionException commitFailure = assertThrows(ServerConnectionException.class, response::commit);
+
+        assertAll(
+                () -> assertThat(repeatedFailure, sameInstance(failure)),
+                () -> assertThat(commitFailure, sameInstance(failure)),
+                () -> assertThat(writes.get(), is(2))
         );
     }
 
@@ -864,6 +895,10 @@ class Http1ServerResponseTest {
     }
 
     private static ContentEncoder testEncoder(Runnable onWrite) {
+        return testEncoder(onWrite, false);
+    }
+
+    private static ContentEncoder testEncoder(Runnable onWrite, boolean writeOnClose) {
         return new ContentEncoder() {
             @Override
             public OutputStream apply(OutputStream network) {
@@ -883,7 +918,15 @@ class Http1ServerResponseTest {
                     }
 
                     @Override
+                    public void flush() throws IOException {
+                        network.flush();
+                    }
+
+                    @Override
                     public void close() throws IOException {
+                        if (writeOnClose) {
+                            network.write('z');
+                        }
                         network.close();
                     }
                 };
@@ -895,6 +938,15 @@ class Http1ServerResponseTest {
                 headers.remove(HeaderNames.CONTENT_LENGTH);
             }
         };
+    }
+
+    private static void doThrowingWrite(DataWriter dataWriter, AtomicInteger writes) {
+        doAnswer(_ -> {
+            if (writes.incrementAndGet() == 1) {
+                return null;
+            }
+            throw new SocketWriterException(new UncheckedIOException(new SocketException("Connection reset by peer")));
+        }).when(dataWriter).write(any(BufferData.class));
     }
 
     private static Http1ServerResponse createResponse(DataWriter dataWriter,

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ServerResponseTest.java
@@ -358,6 +358,33 @@ class Http1ServerResponseTest {
     }
 
     @Test
+    void eagerlyFlushedNoEntityStatusIsSentOnce() {
+        for (Status status : NO_ENTITY_STATUSES) {
+            ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+            when(contentEncodingContext.contentEncodingEnabled()).thenReturn(false);
+            DataWriter writer = mock(DataWriter.class);
+            Http1ServerResponse response = createResponse(writer, Method.GET, contentEncodingContext);
+            response.status(status);
+            response.contentLength(23);
+            response.header(HeaderValues.TRANSFER_ENCODING_CHUNKED);
+            response.header(HeaderNames.TRAILER, "test-trailer");
+
+            response.outputStream();
+            response.flushHeaders();
+            response.commit();
+
+            var responseBuffer = ArgumentCaptor.forClass(BufferData.class);
+            verify(writer).write(responseBuffer.capture());
+            String responseText = responseText(responseBuffer);
+            assertAll(
+                    () -> assertThat(responseText, containsString("HTTP/1.1 " + status + "\r\n")),
+                    () -> assertNoEntityHeaders(status, responseText),
+                    () -> assertThat(responseText, endsWith("\r\n\r\n"))
+            );
+        }
+    }
+
+    @Test
     void headRejectsEntityBeforeSendingResponse() {
         byte[] entity = "entity".getBytes(StandardCharsets.UTF_8);
         ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);


### PR DESCRIPTION
Resolves #12360

Carries the SSE-over-HTTP/2 behavior from #11506 forward to `main`, adapting it to the current protocol-owned response entity-stream lifecycle. HTTP/2 responses now create `SseSink` instances through `SinkProviderContext`, flush headers without ending the stream, and finalize encoding, filters, trailers, and lifecycle callbacks when the sink closes.

Adds deterministic HTTP/2 transport coverage for ALPN, multiplexed streams and connection reuse, cancellation isolation, flow control, delayed events, trailers, and finalization; preserves HTTP/1 chunking, compression, and connection reuse; and re-enables the SSE client tests.

This is a source-faithful carry-forward with target-line adaptation. It does not attempt to resolve inherited findings from the source implementation.
