### PR TITLE
Protect OpenAPI service routes when authorization is required

### DIFF
--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -196,12 +196,12 @@ class OpenApiHttpFeature implements HttpFeature {
     }
 
     private static final class SecuredLocator implements HttpServiceLocator {
-        private final Map<HttpService, HttpService> securedServices = new IdentityHashMap<>();
         private final HttpServiceLocator delegate;
         private final SecureHandler secureHandler;
         private final ReentrantLock lock = new ReentrantLock();
         private final int maxServiceCacheSize;
-        private boolean stopped;
+        private volatile Map<HttpService, HttpService> securedServices = new IdentityHashMap<>();
+        private volatile boolean stopped;
 
         private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
             this.delegate = delegate;
@@ -214,23 +214,13 @@ class OpenApiHttpFeature implements HttpFeature {
 
         @Override
         public Optional<HttpService> locate(ServerRequest request) {
-            lock.lock();
-            try {
-                checkRunning();
-            } finally {
-                lock.unlock();
-            }
+            checkRunning();
 
             Optional<HttpService> service = Objects.requireNonNull(delegate.locate(request),
                                                                    "HttpServiceLocator must not return null");
 
-            lock.lock();
-            try {
-                checkRunning();
-                return service.map(this::securedService);
-            } finally {
-                lock.unlock();
-            }
+            checkRunning();
+            return service.map(this::securedService);
         }
 
         @Override
@@ -259,7 +249,7 @@ class OpenApiHttpFeature implements HttpFeature {
             lock.lock();
             try {
                 stopped = true;
-                securedServices.clear();
+                securedServices = new IdentityHashMap<>();
             } finally {
                 lock.unlock();
             }
@@ -267,23 +257,42 @@ class OpenApiHttpFeature implements HttpFeature {
         }
 
         private HttpService securedService(HttpService service) {
-            HttpService securedService = securedServices.get(service);
+            Map<HttpService, HttpService> currentServices = securedServices;
+            HttpService securedService = currentServices.get(service);
             if (securedService != null) {
+                checkRunning();
                 return securedService;
             }
-            if (securedServices.size() >= maxServiceCacheSize) {
-                throw serviceUnavailable("size of " + maxServiceCacheSize + " exceeded");
+
+            lock.lock();
+            try {
+                checkRunning();
+                currentServices = securedServices;
+                securedService = currentServices.get(service);
+                if (securedService != null) {
+                    return securedService;
+                }
+                if (currentServices.size() >= maxServiceCacheSize) {
+                    throw serviceUnavailable("size of " + maxServiceCacheSize + " exceeded");
+                }
+                securedService = new SecuredService(service, secureHandler, this);
+                Map<HttpService, HttpService> updatedServices = new IdentityHashMap<>(currentServices);
+                updatedServices.put(service, securedService);
+                securedServices = updatedServices;
+                return securedService;
+            } finally {
+                lock.unlock();
             }
-            securedService = new SecuredService(service, secureHandler, this);
-            securedServices.put(service, securedService);
-            return securedService;
         }
 
         private void removeFailedService(HttpService service, HttpService securedService) {
             lock.lock();
             try {
-                if (securedServices.get(service) == securedService) {
-                    securedServices.remove(service);
+                Map<HttpService, HttpService> currentServices = securedServices;
+                if (currentServices.get(service) == securedService) {
+                    Map<HttpService, HttpService> updatedServices = new IdentityHashMap<>(currentServices);
+                    updatedServices.remove(service);
+                    securedServices = updatedServices;
                 }
             } finally {
                 lock.unlock();

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -16,7 +16,10 @@
 
 package io.helidon.openapi;
 
-import java.util.IdentityHashMap;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -199,8 +202,9 @@ class OpenApiHttpFeature implements HttpFeature {
         private final HttpServiceLocator delegate;
         private final SecureHandler secureHandler;
         private final ReentrantLock lock = new ReentrantLock();
+        private final ReferenceQueue<HttpService> staleServices = new ReferenceQueue<>();
         private final int maxServiceCacheSize;
-        private volatile Map<HttpService, HttpService> securedServices = new IdentityHashMap<>();
+        private volatile Map<WeakIdentityKey, WeakReference<SecuredService>> securedServices = new HashMap<>();
         private volatile boolean stopped;
 
         private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
@@ -249,7 +253,7 @@ class OpenApiHttpFeature implements HttpFeature {
             lock.lock();
             try {
                 stopped = true;
-                securedServices = new IdentityHashMap<>();
+                securedServices = new HashMap<>();
             } finally {
                 lock.unlock();
             }
@@ -257,8 +261,10 @@ class OpenApiHttpFeature implements HttpFeature {
         }
 
         private HttpService securedService(HttpService service) {
-            Map<HttpService, HttpService> currentServices = securedServices;
-            HttpService securedService = currentServices.get(service);
+            var lookupKey = new WeakIdentityKey(service);
+            Map<WeakIdentityKey, WeakReference<SecuredService>> currentServices = securedServices;
+            WeakReference<SecuredService> securedServiceReference = currentServices.get(lookupKey);
+            SecuredService securedService = securedServiceReference == null ? null : securedServiceReference.get();
             if (securedService != null) {
                 checkRunning();
                 return securedService;
@@ -268,16 +274,14 @@ class OpenApiHttpFeature implements HttpFeature {
             try {
                 checkRunning();
                 currentServices = securedServices;
-                securedService = currentServices.get(service);
+                securedServiceReference = currentServices.get(lookupKey);
+                securedService = securedServiceReference == null ? null : securedServiceReference.get();
                 if (securedService != null) {
                     return securedService;
                 }
-                if (currentServices.size() >= maxServiceCacheSize) {
-                    throw serviceUnavailable("size of " + maxServiceCacheSize + " exceeded");
-                }
-                securedService = new SecuredService(service, secureHandler, this);
-                Map<HttpService, HttpService> updatedServices = new IdentityHashMap<>(currentServices);
-                updatedServices.put(service, securedService);
+                securedService = new SecuredService(service, secureHandler);
+                Map<WeakIdentityKey, WeakReference<SecuredService>> updatedServices = copyWithoutStale(currentServices);
+                updatedServices.put(new WeakIdentityKey(service, staleServices), new WeakReference<>(securedService));
                 securedServices = updatedServices;
                 return securedService;
             } finally {
@@ -285,18 +289,15 @@ class OpenApiHttpFeature implements HttpFeature {
             }
         }
 
-        private void removeFailedService(HttpService service, HttpService securedService) {
-            lock.lock();
-            try {
-                Map<HttpService, HttpService> currentServices = securedServices;
-                if (currentServices.get(service) == securedService) {
-                    Map<HttpService, HttpService> updatedServices = new IdentityHashMap<>(currentServices);
-                    updatedServices.remove(service);
-                    securedServices = updatedServices;
-                }
-            } finally {
-                lock.unlock();
+        private Map<WeakIdentityKey, WeakReference<SecuredService>> copyWithoutStale(
+                Map<WeakIdentityKey, WeakReference<SecuredService>> currentServices) {
+            Map<WeakIdentityKey, WeakReference<SecuredService>> updatedServices = new HashMap<>(currentServices);
+            Reference<? extends HttpService> staleService;
+            while ((staleService = staleServices.poll()) != null) {
+                updatedServices.remove(staleService);
             }
+            updatedServices.entrySet().removeIf(entry -> entry.getKey().get() == null || entry.getValue().get() == null);
+            return updatedServices;
         }
 
         private void checkRunning() {
@@ -310,62 +311,62 @@ class OpenApiHttpFeature implements HttpFeature {
                                      Status.SERVICE_UNAVAILABLE_503,
                                      true);
         }
+
+        private static final class WeakIdentityKey extends WeakReference<HttpService> {
+            private final int hashCode;
+
+            private WeakIdentityKey(HttpService service) {
+                super(service);
+                this.hashCode = System.identityHashCode(service);
+            }
+
+            private WeakIdentityKey(HttpService service, ReferenceQueue<HttpService> queue) {
+                super(service, queue);
+                this.hashCode = System.identityHashCode(service);
+            }
+
+            @Override
+            public int hashCode() {
+                return hashCode;
+            }
+
+            @Override
+            public boolean equals(Object object) {
+                if (this == object) {
+                    return true;
+                }
+                return object instanceof WeakIdentityKey that && get() != null && get() == that.get();
+            }
+        }
     }
 
     private static final class SecuredService implements HttpService {
         private final HttpService delegate;
         private final SecureHandler secureHandler;
-        private final SecuredLocator locator;
 
         private SecuredService(HttpService delegate, SecureHandler secureHandler) {
-            this(delegate, secureHandler, null);
-        }
-
-        private SecuredService(HttpService delegate, SecureHandler secureHandler, SecuredLocator locator) {
             this.delegate = delegate;
             this.secureHandler = secureHandler;
-            this.locator = locator;
         }
 
         @Override
         public void routing(HttpRules rules) {
-            try {
-                delegate.routing(new SecuredRules(rules, secureHandler));
-            } catch (RuntimeException | Error e) {
-                initializationFailed();
-                throw e;
-            }
+            delegate.routing(new SecuredRules(rules, secureHandler));
         }
 
         @Override
         public void beforeStart() {
-            try {
-                delegate.beforeStart();
-            } catch (RuntimeException | Error e) {
-                initializationFailed();
-                throw e;
-            }
+            delegate.beforeStart();
         }
 
         @Override
         public void afterStart(WebServer webServer) {
-            try {
-                delegate.afterStart(webServer);
-            } catch (RuntimeException | Error e) {
-                initializationFailed();
-                throw e;
-            }
+            delegate.afterStart(webServer);
         }
 
         @Override
         public void afterStop() {
             delegate.afterStop();
-        }
-
-        private void initializationFailed() {
-            if (locator != null) {
-                locator.removeFailedService(delegate, this);
-            }
         }
     }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -16,18 +16,20 @@
 
 package io.helidon.openapi;
 
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.BadRequestException;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatcher;
@@ -194,29 +196,56 @@ class OpenApiHttpFeature implements HttpFeature {
     }
 
     private static final class SecuredLocator implements HttpServiceLocator {
-        private final Map<HttpService, HttpService> securedServices = Collections.synchronizedMap(new IdentityHashMap<>());
+        private final Map<HttpService, HttpService> securedServices = new IdentityHashMap<>();
         private final HttpServiceLocator delegate;
         private final SecureHandler secureHandler;
+        private final ReentrantLock lock = new ReentrantLock();
+        private final int maxServiceCacheSize;
+        private boolean stopped;
 
         private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
             this.delegate = delegate;
             this.secureHandler = secureHandler;
+            this.maxServiceCacheSize = delegate.maxServiceCacheSize();
+            if (maxServiceCacheSize < 1) {
+                throw new IllegalArgumentException("HttpServiceLocator maxServiceCacheSize must be greater than zero");
+            }
         }
 
         @Override
         public Optional<HttpService> locate(ServerRequest request) {
-            return delegate.locate(request)
-                    .map(service -> securedServices.computeIfAbsent(service,
-                                                                    key -> new SecuredService(key, secureHandler)));
+            lock.lock();
+            try {
+                checkRunning();
+            } finally {
+                lock.unlock();
+            }
+
+            Optional<HttpService> service = Objects.requireNonNull(delegate.locate(request),
+                                                                   "HttpServiceLocator must not return null");
+
+            lock.lock();
+            try {
+                checkRunning();
+                return service.map(this::securedService);
+            } finally {
+                lock.unlock();
+            }
         }
 
         @Override
         public int maxServiceCacheSize() {
-            return delegate.maxServiceCacheSize();
+            return maxServiceCacheSize;
         }
 
         @Override
         public void beforeStart() {
+            lock.lock();
+            try {
+                stopped = false;
+            } finally {
+                lock.unlock();
+            }
             delegate.beforeStart();
         }
 
@@ -227,8 +256,39 @@ class OpenApiHttpFeature implements HttpFeature {
 
         @Override
         public void afterStop() {
+            lock.lock();
+            try {
+                stopped = true;
+                securedServices.clear();
+            } finally {
+                lock.unlock();
+            }
             delegate.afterStop();
-            securedServices.clear();
+        }
+
+        private HttpService securedService(HttpService service) {
+            HttpService securedService = securedServices.get(service);
+            if (securedService != null) {
+                return securedService;
+            }
+            if (securedServices.size() >= maxServiceCacheSize) {
+                throw serviceUnavailable("size of " + maxServiceCacheSize + " exceeded");
+            }
+            securedService = new SecuredService(service, secureHandler);
+            securedServices.put(service, securedService);
+            return securedService;
+        }
+
+        private void checkRunning() {
+            if (stopped) {
+                throw serviceUnavailable("is stopped");
+            }
+        }
+
+        private HttpException serviceUnavailable(String reason) {
+            return new HttpException("HttpServiceLocator service cache " + reason,
+                                     Status.SERVICE_UNAVAILABLE_503,
+                                     true);
         }
     }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -16,6 +16,10 @@
 
 package io.helidon.openapi;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -25,9 +29,19 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.BadRequestException;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.HttpMediaType;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.PathMatcher;
+import io.helidon.http.PathMatchers;
+import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.Status;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.Handler;
 import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRoute;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.HttpServiceLocator;
 import io.helidon.webserver.http.SecureHandler;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
@@ -63,11 +77,15 @@ class OpenApiHttpFeature implements HttpFeature {
     @Override
     public void setup(HttpRouting.Builder routing) {
         String path = config.webContext();
+        HttpRules openApiServiceRules = routing;
         if (!config.permitAll()) {
-            routing.any(path, SecureHandler.authorize(config.roles().toArray(new String[0])));
+            SecureHandler secureHandler = SecureHandler.authorize(config.roles().toArray(new String[0]));
+            routing.any(path, secureHandler);
+            openApiServiceRules = new SecuredRules(routing, secureHandler);
         }
         routing.get(path, this::handle);
-        config.services().forEach(service -> service.setup(routing, path, this::content));
+        HttpRules serviceRules = openApiServiceRules;
+        config.services().forEach(service -> service.setup(serviceRules, path, this::content));
     }
 
     @SuppressWarnings("unchecked")
@@ -125,6 +143,168 @@ class OpenApiHttpFeature implements HttpFeature {
             }
         }
         return cachedDocuments.computeIfAbsent(format, fmt -> format(manager, fmt, model.get()));
+    }
+
+    private static final class SecuredRules implements HttpRules {
+        private final HttpRules delegate;
+        private final SecureHandler secureHandler;
+
+        private SecuredRules(HttpRules delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.secureHandler = secureHandler;
+        }
+
+        @Override
+        public HttpRules register(HttpService... service) {
+            delegate.register(securedServices(service));
+            return this;
+        }
+
+        @Override
+        public HttpRules register(String pathPattern, HttpService... service) {
+            delegate.register(pathPattern, securedServices(service));
+            return this;
+        }
+
+        @Override
+        public HttpRules registerLocator(HttpServiceLocator locator) {
+            delegate.registerLocator(new SecuredLocator(locator, secureHandler));
+            return this;
+        }
+
+        @Override
+        public HttpRules registerLocator(String pathPattern, HttpServiceLocator locator) {
+            delegate.registerLocator(pathPattern, new SecuredLocator(locator, secureHandler));
+            return this;
+        }
+
+        @Override
+        public HttpRules route(HttpRoute route) {
+            delegate.route(new SecuredRoute(route, secureHandler));
+            return this;
+        }
+
+        private HttpService[] securedServices(HttpService[] services) {
+            HttpService[] securedServices = new HttpService[services.length];
+            for (int i = 0; i < services.length; i++) {
+                securedServices[i] = new SecuredService(services[i], secureHandler);
+            }
+            return securedServices;
+        }
+    }
+
+    private static final class SecuredLocator implements HttpServiceLocator {
+        private final Map<HttpService, HttpService> securedServices = Collections.synchronizedMap(new IdentityHashMap<>());
+        private final HttpServiceLocator delegate;
+        private final SecureHandler secureHandler;
+
+        private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.secureHandler = secureHandler;
+        }
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            return delegate.locate(request)
+                    .map(service -> securedServices.computeIfAbsent(service,
+                                                                    key -> new SecuredService(key, secureHandler)));
+        }
+
+        @Override
+        public int maxServiceCacheSize() {
+            return delegate.maxServiceCacheSize();
+        }
+
+        @Override
+        public void beforeStart() {
+            delegate.beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.afterStart(webServer);
+        }
+
+        @Override
+        public void afterStop() {
+            delegate.afterStop();
+            securedServices.clear();
+        }
+    }
+
+    private static final class SecuredService implements HttpService {
+        private final HttpService delegate;
+        private final SecureHandler secureHandler;
+
+        private SecuredService(HttpService delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.secureHandler = secureHandler;
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+            delegate.routing(new SecuredRules(rules, secureHandler));
+        }
+
+        @Override
+        public void beforeStart() {
+            delegate.beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.afterStart(webServer);
+        }
+
+        @Override
+        public void afterStop() {
+            delegate.afterStop();
+        }
+    }
+
+    private static final class SecuredRoute implements HttpRoute {
+        private final HttpRoute delegate;
+        private final Handler handler;
+
+        private SecuredRoute(HttpRoute delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.handler = secureHandler.wrap(delegate.handler());
+        }
+
+        @Override
+        public PathMatchers.MatchResult accepts(HttpPrologue prologue) {
+            return delegate.accepts(prologue);
+        }
+
+        @Override
+        public PathMatchers.MatchResult accepts(HttpPrologue prologue, ServerRequestHeaders headers) {
+            return delegate.accepts(prologue, headers);
+        }
+
+        @Override
+        public Handler handler() {
+            return handler;
+        }
+
+        @Override
+        public Optional<PathMatcher> pathMatcher() {
+            return delegate.pathMatcher();
+        }
+
+        @Override
+        public void beforeStart() {
+            delegate.beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.afterStart(webServer);
+        }
+
+        @Override
+        public void afterStop() {
+            delegate.afterStop();
+        }
     }
 
 }

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -16,19 +16,15 @@
 
 package io.helidon.openapi;
 
-import java.lang.ref.WeakReference;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.BadRequestException;
 import io.helidon.http.HeaderValues;
-import io.helidon.http.HttpException;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatcher;
@@ -169,13 +165,13 @@ class OpenApiHttpFeature implements HttpFeature {
 
         @Override
         public HttpRules registerLocator(HttpServiceLocator locator) {
-            delegate.registerLocator(new SecuredLocator(locator, secureHandler));
+            delegate.registerLocator(secureHandler.wrap(locator));
             return this;
         }
 
         @Override
         public HttpRules registerLocator(String pathPattern, HttpServiceLocator locator) {
-            delegate.registerLocator(pathPattern, new SecuredLocator(locator, secureHandler));
+            delegate.registerLocator(pathPattern, secureHandler.wrap(locator));
             return this;
         }
 
@@ -191,193 +187,6 @@ class OpenApiHttpFeature implements HttpFeature {
                 securedServices[i] = new SecuredService(services[i], secureHandler);
             }
             return securedServices;
-        }
-    }
-
-    private static final class SecuredLocator implements HttpServiceLocator {
-        private final HttpServiceLocator delegate;
-        private final SecureHandler secureHandler;
-        private final ReentrantLock lock = new ReentrantLock();
-        private final int maxServiceCacheSize;
-        private volatile WeakIdentityTable securedServices = WeakIdentityTable.empty();
-        private volatile boolean stopped;
-
-        private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
-            this.delegate = delegate;
-            this.secureHandler = secureHandler;
-            this.maxServiceCacheSize = delegate.maxServiceCacheSize();
-            if (maxServiceCacheSize < 1) {
-                throw new IllegalArgumentException("HttpServiceLocator maxServiceCacheSize must be greater than zero");
-            }
-        }
-
-        @Override
-        public Optional<HttpService> locate(ServerRequest request) {
-            checkRunning();
-
-            Optional<HttpService> service = Objects.requireNonNull(delegate.locate(request),
-                                                                   "HttpServiceLocator must not return null");
-
-            checkRunning();
-            return service.map(this::securedService);
-        }
-
-        @Override
-        public int maxServiceCacheSize() {
-            return maxServiceCacheSize;
-        }
-
-        @Override
-        public void beforeStart() {
-            lock.lock();
-            try {
-                stopped = false;
-            } finally {
-                lock.unlock();
-            }
-            delegate.beforeStart();
-        }
-
-        @Override
-        public void afterStart(WebServer webServer) {
-            delegate.afterStart(webServer);
-        }
-
-        @Override
-        public void afterStop() {
-            lock.lock();
-            try {
-                stopped = true;
-                securedServices = WeakIdentityTable.empty();
-            } finally {
-                lock.unlock();
-            }
-            delegate.afterStop();
-        }
-
-        private HttpService securedService(HttpService service) {
-            WeakIdentityTable currentServices = securedServices;
-            SecuredService securedService = currentServices.get(service);
-            if (securedService != null) {
-                checkRunning();
-                return securedService;
-            }
-
-            lock.lock();
-            try {
-                checkRunning();
-                currentServices = securedServices;
-                securedService = currentServices.get(service);
-                if (securedService != null) {
-                    return securedService;
-                }
-                securedService = new SecuredService(service, secureHandler);
-                securedServices = currentServices.with(service, securedService);
-                return securedService;
-            } finally {
-                lock.unlock();
-            }
-        }
-
-        private void checkRunning() {
-            if (stopped) {
-                throw serviceUnavailable("is stopped");
-            }
-        }
-
-        private HttpException serviceUnavailable(String reason) {
-            return new HttpException("HttpServiceLocator service cache " + reason,
-                                     Status.SERVICE_UNAVAILABLE_503,
-                                     true);
-        }
-
-        private static final class WeakIdentityTable {
-            private static final WeakIdentityTable EMPTY = new WeakIdentityTable(new WeakServiceEntry[0]);
-
-            private final WeakServiceEntry[] entries;
-
-            private WeakIdentityTable(WeakServiceEntry[] entries) {
-                this.entries = entries;
-            }
-
-            private static WeakIdentityTable empty() {
-                return EMPTY;
-            }
-
-            private static boolean isLive(WeakServiceEntry entry, HttpService replacedService) {
-                if (entry == null) {
-                    return false;
-                }
-                HttpService service = entry.service.get();
-                return service != null && service != replacedService && entry.securedService.get() != null;
-            }
-
-            private static void insert(WeakServiceEntry[] entries, WeakServiceEntry entry) {
-                int index = index(entry.identityHash, entries.length);
-                while (entries[index] != null) {
-                    index = (index + 1) & (entries.length - 1);
-                }
-                entries[index] = entry;
-            }
-
-            private static int index(int identityHash, int tableLength) {
-                return (identityHash ^ (identityHash >>> 16)) & (tableLength - 1);
-            }
-
-            private SecuredService get(HttpService service) {
-                if (entries.length == 0) {
-                    return null;
-                }
-
-                int identityHash = System.identityHashCode(service);
-                int index = index(identityHash, entries.length);
-                for (int i = 0; i < entries.length; i++) {
-                    WeakServiceEntry entry = entries[index];
-                    if (entry == null) {
-                        return null;
-                    }
-                    if (entry.identityHash == identityHash && entry.service.get() == service) {
-                        return entry.securedService.get();
-                    }
-                    index = (index + 1) & (entries.length - 1);
-                }
-                return null;
-            }
-
-            private WeakIdentityTable with(HttpService service, SecuredService securedService) {
-                int liveEntries = 1;
-                for (WeakServiceEntry entry : entries) {
-                    if (isLive(entry, service)) {
-                        liveEntries++;
-                    }
-                }
-
-                int capacity = 4;
-                while (capacity < liveEntries * 2) {
-                    capacity <<= 1;
-                }
-
-                WeakServiceEntry[] updatedEntries = new WeakServiceEntry[capacity];
-                for (WeakServiceEntry entry : entries) {
-                    if (isLive(entry, service)) {
-                        insert(updatedEntries, entry);
-                    }
-                }
-                insert(updatedEntries, new WeakServiceEntry(service, securedService));
-                return new WeakIdentityTable(updatedEntries);
-            }
-        }
-
-        private static final class WeakServiceEntry {
-            private final int identityHash;
-            private final WeakReference<HttpService> service;
-            private final WeakReference<SecuredService> securedService;
-
-            private WeakServiceEntry(HttpService service, SecuredService securedService) {
-                this.identityHash = System.identityHashCode(service);
-                this.service = new WeakReference<>(service);
-                this.securedService = new WeakReference<>(securedService);
-            }
         }
     }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -274,9 +274,20 @@ class OpenApiHttpFeature implements HttpFeature {
             if (securedServices.size() >= maxServiceCacheSize) {
                 throw serviceUnavailable("size of " + maxServiceCacheSize + " exceeded");
             }
-            securedService = new SecuredService(service, secureHandler);
+            securedService = new SecuredService(service, secureHandler, this);
             securedServices.put(service, securedService);
             return securedService;
+        }
+
+        private void removeFailedService(HttpService service, HttpService securedService) {
+            lock.lock();
+            try {
+                if (securedServices.get(service) == securedService) {
+                    securedServices.remove(service);
+                }
+            } finally {
+                lock.unlock();
+            }
         }
 
         private void checkRunning() {
@@ -295,30 +306,57 @@ class OpenApiHttpFeature implements HttpFeature {
     private static final class SecuredService implements HttpService {
         private final HttpService delegate;
         private final SecureHandler secureHandler;
+        private final SecuredLocator locator;
 
         private SecuredService(HttpService delegate, SecureHandler secureHandler) {
+            this(delegate, secureHandler, null);
+        }
+
+        private SecuredService(HttpService delegate, SecureHandler secureHandler, SecuredLocator locator) {
             this.delegate = delegate;
             this.secureHandler = secureHandler;
+            this.locator = locator;
         }
 
         @Override
         public void routing(HttpRules rules) {
-            delegate.routing(new SecuredRules(rules, secureHandler));
+            try {
+                delegate.routing(new SecuredRules(rules, secureHandler));
+            } catch (RuntimeException | Error e) {
+                initializationFailed();
+                throw e;
+            }
         }
 
         @Override
         public void beforeStart() {
-            delegate.beforeStart();
+            try {
+                delegate.beforeStart();
+            } catch (RuntimeException | Error e) {
+                initializationFailed();
+                throw e;
+            }
         }
 
         @Override
         public void afterStart(WebServer webServer) {
-            delegate.afterStart(webServer);
+            try {
+                delegate.afterStart(webServer);
+            } catch (RuntimeException | Error e) {
+                initializationFailed();
+                throw e;
+            }
         }
 
         @Override
         public void afterStop() {
             delegate.afterStop();
+        }
+
+        private void initializationFailed() {
+            if (locator != null) {
+                locator.removeFailedService(delegate, this);
+            }
         }
     }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -304,6 +304,26 @@ class OpenApiHttpFeature implements HttpFeature {
                 return EMPTY;
             }
 
+            private static boolean isLive(WeakServiceEntry entry, HttpService replacedService) {
+                if (entry == null) {
+                    return false;
+                }
+                HttpService service = entry.service.get();
+                return service != null && service != replacedService && entry.securedService.get() != null;
+            }
+
+            private static void insert(WeakServiceEntry[] entries, WeakServiceEntry entry) {
+                int index = index(entry.identityHash, entries.length);
+                while (entries[index] != null) {
+                    index = (index + 1) & (entries.length - 1);
+                }
+                entries[index] = entry;
+            }
+
+            private static int index(int identityHash, int tableLength) {
+                return (identityHash ^ (identityHash >>> 16)) & (tableLength - 1);
+            }
+
             private SecuredService get(HttpService service) {
                 if (entries.length == 0) {
                     return null;
@@ -345,26 +365,6 @@ class OpenApiHttpFeature implements HttpFeature {
                 }
                 insert(updatedEntries, new WeakServiceEntry(service, securedService));
                 return new WeakIdentityTable(updatedEntries);
-            }
-
-            private static boolean isLive(WeakServiceEntry entry, HttpService replacedService) {
-                if (entry == null) {
-                    return false;
-                }
-                HttpService service = entry.service.get();
-                return service != null && service != replacedService && entry.securedService.get() != null;
-            }
-
-            private static void insert(WeakServiceEntry[] entries, WeakServiceEntry entry) {
-                int index = index(entry.identityHash, entries.length);
-                while (entries[index] != null) {
-                    index = (index + 1) & (entries.length - 1);
-                }
-                entries[index] = entry;
-            }
-
-            private static int index(int identityHash, int tableLength) {
-                return (identityHash ^ (identityHash >>> 16)) & (tableLength - 1);
             }
         }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -165,13 +165,13 @@ class OpenApiHttpFeature implements HttpFeature {
 
         @Override
         public HttpRules registerLocator(HttpServiceLocator locator) {
-            delegate.registerLocator(secureHandler.wrap(locator));
+            delegate.registerLocator(secureHandler.wrapLocator(locator));
             return this;
         }
 
         @Override
         public HttpRules registerLocator(String pathPattern, HttpServiceLocator locator) {
-            delegate.registerLocator(pathPattern, secureHandler.wrap(locator));
+            delegate.registerLocator(pathPattern, secureHandler.wrapLocator(locator));
             return this;
         }
 

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiHttpFeature.java
@@ -16,11 +16,7 @@
 
 package io.helidon.openapi;
 
-import java.lang.ref.Reference;
-import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -202,9 +198,8 @@ class OpenApiHttpFeature implements HttpFeature {
         private final HttpServiceLocator delegate;
         private final SecureHandler secureHandler;
         private final ReentrantLock lock = new ReentrantLock();
-        private final ReferenceQueue<HttpService> staleServices = new ReferenceQueue<>();
         private final int maxServiceCacheSize;
-        private volatile Map<WeakIdentityKey, WeakReference<SecuredService>> securedServices = new HashMap<>();
+        private volatile WeakIdentityTable securedServices = WeakIdentityTable.empty();
         private volatile boolean stopped;
 
         private SecuredLocator(HttpServiceLocator delegate, SecureHandler secureHandler) {
@@ -253,7 +248,7 @@ class OpenApiHttpFeature implements HttpFeature {
             lock.lock();
             try {
                 stopped = true;
-                securedServices = new HashMap<>();
+                securedServices = WeakIdentityTable.empty();
             } finally {
                 lock.unlock();
             }
@@ -261,10 +256,8 @@ class OpenApiHttpFeature implements HttpFeature {
         }
 
         private HttpService securedService(HttpService service) {
-            var lookupKey = new WeakIdentityKey(service);
-            Map<WeakIdentityKey, WeakReference<SecuredService>> currentServices = securedServices;
-            WeakReference<SecuredService> securedServiceReference = currentServices.get(lookupKey);
-            SecuredService securedService = securedServiceReference == null ? null : securedServiceReference.get();
+            WeakIdentityTable currentServices = securedServices;
+            SecuredService securedService = currentServices.get(service);
             if (securedService != null) {
                 checkRunning();
                 return securedService;
@@ -274,30 +267,16 @@ class OpenApiHttpFeature implements HttpFeature {
             try {
                 checkRunning();
                 currentServices = securedServices;
-                securedServiceReference = currentServices.get(lookupKey);
-                securedService = securedServiceReference == null ? null : securedServiceReference.get();
+                securedService = currentServices.get(service);
                 if (securedService != null) {
                     return securedService;
                 }
                 securedService = new SecuredService(service, secureHandler);
-                Map<WeakIdentityKey, WeakReference<SecuredService>> updatedServices = copyWithoutStale(currentServices);
-                updatedServices.put(new WeakIdentityKey(service, staleServices), new WeakReference<>(securedService));
-                securedServices = updatedServices;
+                securedServices = currentServices.with(service, securedService);
                 return securedService;
             } finally {
                 lock.unlock();
             }
-        }
-
-        private Map<WeakIdentityKey, WeakReference<SecuredService>> copyWithoutStale(
-                Map<WeakIdentityKey, WeakReference<SecuredService>> currentServices) {
-            Map<WeakIdentityKey, WeakReference<SecuredService>> updatedServices = new HashMap<>(currentServices);
-            Reference<? extends HttpService> staleService;
-            while ((staleService = staleServices.poll()) != null) {
-                updatedServices.remove(staleService);
-            }
-            updatedServices.entrySet().removeIf(entry -> entry.getKey().get() == null || entry.getValue().get() == null);
-            return updatedServices;
         }
 
         private void checkRunning() {
@@ -312,30 +291,92 @@ class OpenApiHttpFeature implements HttpFeature {
                                      true);
         }
 
-        private static final class WeakIdentityKey extends WeakReference<HttpService> {
-            private final int hashCode;
+        private static final class WeakIdentityTable {
+            private static final WeakIdentityTable EMPTY = new WeakIdentityTable(new WeakServiceEntry[0]);
 
-            private WeakIdentityKey(HttpService service) {
-                super(service);
-                this.hashCode = System.identityHashCode(service);
+            private final WeakServiceEntry[] entries;
+
+            private WeakIdentityTable(WeakServiceEntry[] entries) {
+                this.entries = entries;
             }
 
-            private WeakIdentityKey(HttpService service, ReferenceQueue<HttpService> queue) {
-                super(service, queue);
-                this.hashCode = System.identityHashCode(service);
+            private static WeakIdentityTable empty() {
+                return EMPTY;
             }
 
-            @Override
-            public int hashCode() {
-                return hashCode;
-            }
-
-            @Override
-            public boolean equals(Object object) {
-                if (this == object) {
-                    return true;
+            private SecuredService get(HttpService service) {
+                if (entries.length == 0) {
+                    return null;
                 }
-                return object instanceof WeakIdentityKey that && get() != null && get() == that.get();
+
+                int identityHash = System.identityHashCode(service);
+                int index = index(identityHash, entries.length);
+                for (int i = 0; i < entries.length; i++) {
+                    WeakServiceEntry entry = entries[index];
+                    if (entry == null) {
+                        return null;
+                    }
+                    if (entry.identityHash == identityHash && entry.service.get() == service) {
+                        return entry.securedService.get();
+                    }
+                    index = (index + 1) & (entries.length - 1);
+                }
+                return null;
+            }
+
+            private WeakIdentityTable with(HttpService service, SecuredService securedService) {
+                int liveEntries = 1;
+                for (WeakServiceEntry entry : entries) {
+                    if (isLive(entry, service)) {
+                        liveEntries++;
+                    }
+                }
+
+                int capacity = 4;
+                while (capacity < liveEntries * 2) {
+                    capacity <<= 1;
+                }
+
+                WeakServiceEntry[] updatedEntries = new WeakServiceEntry[capacity];
+                for (WeakServiceEntry entry : entries) {
+                    if (isLive(entry, service)) {
+                        insert(updatedEntries, entry);
+                    }
+                }
+                insert(updatedEntries, new WeakServiceEntry(service, securedService));
+                return new WeakIdentityTable(updatedEntries);
+            }
+
+            private static boolean isLive(WeakServiceEntry entry, HttpService replacedService) {
+                if (entry == null) {
+                    return false;
+                }
+                HttpService service = entry.service.get();
+                return service != null && service != replacedService && entry.securedService.get() != null;
+            }
+
+            private static void insert(WeakServiceEntry[] entries, WeakServiceEntry entry) {
+                int index = index(entry.identityHash, entries.length);
+                while (entries[index] != null) {
+                    index = (index + 1) & (entries.length - 1);
+                }
+                entries[index] = entry;
+            }
+
+            private static int index(int identityHash, int tableLength) {
+                return (identityHash ^ (identityHash >>> 16)) & (tableLength - 1);
+            }
+        }
+
+        private static final class WeakServiceEntry {
+            private final int identityHash;
+            private final WeakReference<HttpService> service;
+            private final WeakReference<SecuredService> securedService;
+
+            private WeakServiceEntry(HttpService service, SecuredService securedService) {
+                this.identityHash = System.identityHashCode(service);
+                this.service = new WeakReference<>(service);
+                this.securedService = new WeakReference<>(securedService);
             }
         }
     }

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.openapi;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.testing.junit5.RoutingTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RoutingTest
+class OpenApiServiceAuthorizationTest {
+    private static final HeaderName HEADER_PREDICATE = HeaderNames.create("X-OpenAPI-Service-Route");
+
+    private final WebClient client;
+
+    OpenApiServiceAuthorizationTest(WebClient client) {
+        this.client = client;
+    }
+
+    @SetUpServer
+    static void setupServer(WebServerConfig.Builder server) {
+        server.addFeature(OpenApiFeature.builder()
+                                  .servicesDiscoverServices(false)
+                                  .staticFile("src/test/resources/greeting.yml")
+                                  .permitAll(false)
+                                  .addService(new TestOpenApiService())
+                                  .build());
+    }
+
+    @SetUpRoute
+    static void setup(HttpRouting.Builder routing) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/openapi",
+            "/openapi/",
+            "/openapi/ui",
+            "/openapi/ui/index.html",
+            "/openapi/ui/logo.svg",
+            "/located/resource"
+    })
+    void serviceRoutesRequireAuthorization(String path) {
+        ClientResponseTyped<String> response = client.get(path)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.FORBIDDEN_403));
+    }
+
+    @Test
+    void headerPredicateServiceIgnoresRequestsWithoutHeader() {
+        ClientResponseTyped<String> response = client.get("/header-service")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.NOT_FOUND_404));
+    }
+
+    @Test
+    void headerPredicateServiceRequiresAuthorization() {
+        ClientResponseTyped<String> response = client.get("/header-service")
+                .header(HEADER_PREDICATE, "present")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.FORBIDDEN_403));
+    }
+
+    private static final class TestOpenApiService implements OpenApiService {
+        @Override
+        public boolean supports(ServerRequestHeaders headers) {
+            return false;
+        }
+
+        @Override
+        public void setup(HttpRules routing, String docPath, Function<MediaType, String> content) {
+            String uiPath = docPath + "/ui";
+            routing.get(docPath + "[/]", (req, res) -> res.send("unprotected"))
+                    .get(uiPath + "[/]", (req, res) -> res.send("unprotected"))
+                    .get(uiPath + "/index.html", (req, res) -> res.send("unprotected"))
+                    .register(uiPath, rules -> rules.get("/logo.svg", (req, res) -> res.send("unprotected")))
+                    .registerLocator("/located", request -> Optional.of(
+                            (HttpService) rules -> rules.get("/resource", (req, res) -> res.send("unprotected"))))
+                    .route(HttpRoute.builder()
+                                   .methods(Method.GET)
+                                   .path("/header-service")
+                                   .headers(headers -> headers.contains(HEADER_PREDICATE))
+                                   .handler((req, res) -> res.send("unprotected"))
+                                   .build());
+        }
+
+        @Override
+        public String name() {
+            return "test-openapi-service";
+        }
+
+        @Override
+        public String type() {
+            return "test-openapi-service";
+        }
+    }
+}

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpException;
 import io.helidon.http.Method;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.Status;
@@ -157,6 +158,28 @@ class OpenApiServiceAuthorizationTest {
     }
 
     @Test
+    void failedLocatedServiceDoesNotConsumeWrapperCapacity() {
+        var locator = new RecoveringLocator();
+        WebServer server = testServer(new LocatorOpenApiService("/recover/{service}", locator));
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+
+            assertThat("cold initialization failure status",
+                       serverClient.get("/recover/failing/resource").request(String.class).status(),
+                       is(Status.I_AM_A_TEAPOT_418));
+            assertThat("healthy service remains admissible after the failure",
+                       serverClient.get("/recover/healthy/resource").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+        } finally {
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+    }
+
+    @Test
     void locatorAndLocatedServiceRetainLifecycle() {
         var service = new LifecycleService("/resource");
         var locator = new LifecycleLocator(service);
@@ -277,6 +300,24 @@ class OpenApiServiceAuthorizationTest {
         @Override
         public String type() {
             return "locator-test-openapi-service";
+        }
+    }
+
+    private static final class RecoveringLocator implements HttpServiceLocator {
+        private final Map<String, HttpService> services = Map.of(
+                "failing", rules -> {
+                    throw new HttpException("cold initialization failed", Status.I_AM_A_TEAPOT_418, true);
+                },
+                "healthy", rules -> rules.get("/resource", (req, res) -> res.send("unprotected")));
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            return request.path().pathParameters().first("service").map(services::get);
+        }
+
+        @Override
+        public int maxServiceCacheSize() {
+            return 1;
         }
     }
 

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 @RoutingTest
 class OpenApiServiceAuthorizationTest {
@@ -184,6 +185,69 @@ class OpenApiServiceAuthorizationTest {
                 server.stop();
             }
         }
+    }
+
+    @Test
+    void concurrentTransientFailureDoesNotSplitWrapperIdentity() throws Exception {
+        var cleanupStarted = new CountDownLatch(1);
+        var releaseCleanup = new CountDownLatch(1);
+        var duplicateRoutingStarted = new CountDownLatch(1);
+        var locatedTwice = new CountDownLatch(2);
+        var service = new TransientFailureService(cleanupStarted, releaseCleanup, duplicateRoutingStarted);
+        var locator = new TransientFailureLocator(service, locatedTwice);
+        WebServer server = testServer(new LocatorOpenApiService("/transient/{service}", locator));
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+
+            try (var executor = Executors.newFixedThreadPool(2)) {
+                Future<Status> failedRequest = executor.submit(
+                        () -> serverClient.get("/transient/transient/resource").request(String.class).status());
+
+                assertThat("failed wrapper cleanup started",
+                           cleanupStarted.await(5, TimeUnit.SECONDS),
+                           is(true));
+
+                Future<Status> concurrentRetry = executor.submit(
+                        () -> serverClient.get("/transient/transient/resource").request(String.class).status());
+
+                try {
+                    assertThat("both requests located the same raw service",
+                               locatedTwice.await(5, TimeUnit.SECONDS),
+                               is(true));
+                    assertThat("no duplicate wrapper initialized while the failed wrapper remained in use",
+                               duplicateRoutingStarted.await(1, TimeUnit.SECONDS),
+                               is(false));
+                } finally {
+                    releaseCleanup.countDown();
+                }
+
+                assertThat("transient initialization failure status",
+                           failedRequest.get(5, TimeUnit.SECONDS),
+                           is(Status.I_AM_A_TEAPOT_418));
+                assertThat("concurrent retry did not split wrapper capacity",
+                           concurrentRetry.get(5, TimeUnit.SECONDS),
+                           not(is(Status.SERVICE_UNAVAILABLE_503)));
+            }
+
+            assertThat("subsequent retry is healthy",
+                       serverClient.get("/transient/transient/resource").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+            assertThat("a second stable identity remains admissible",
+                       serverClient.get("/transient/healthy/resource").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+            assertThat("transient service routing count", service.routingCount.get(), is(2));
+            assertThat("transient service beforeStart count", service.beforeStartCount.get(), is(2));
+            assertThat("transient service afterStart count", service.afterStartCount.get(), is(1));
+        } finally {
+            releaseCleanup.countDown();
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+
+        assertThat("transient service afterStop count", service.afterStopCount.get(), is(2));
     }
 
     @Test
@@ -393,6 +457,82 @@ class OpenApiServiceAuthorizationTest {
         @Override
         public int maxServiceCacheSize() {
             return 1;
+        }
+    }
+
+    private static final class TransientFailureLocator implements HttpServiceLocator {
+        private final Map<String, HttpService> services;
+        private final CountDownLatch locateCalls;
+
+        private TransientFailureLocator(HttpService transientService, CountDownLatch locateCalls) {
+            this.services = Map.of(
+                    "transient", transientService,
+                    "healthy", rules -> rules.get("/resource", (req, res) -> res.send("unprotected")));
+            this.locateCalls = locateCalls;
+        }
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            locateCalls.countDown();
+            return request.path().pathParameters().first("service").map(services::get);
+        }
+
+        @Override
+        public int maxServiceCacheSize() {
+            return 2;
+        }
+    }
+
+    private static final class TransientFailureService implements HttpService {
+        private final CountDownLatch cleanupStarted;
+        private final CountDownLatch releaseCleanup;
+        private final CountDownLatch duplicateRoutingStarted;
+        private final AtomicInteger routingCount = new AtomicInteger();
+        private final AtomicInteger beforeStartCount = new AtomicInteger();
+        private final AtomicInteger afterStartCount = new AtomicInteger();
+        private final AtomicInteger afterStopCount = new AtomicInteger();
+
+        private TransientFailureService(CountDownLatch cleanupStarted,
+                                        CountDownLatch releaseCleanup,
+                                        CountDownLatch duplicateRoutingStarted) {
+            this.cleanupStarted = cleanupStarted;
+            this.releaseCleanup = releaseCleanup;
+            this.duplicateRoutingStarted = duplicateRoutingStarted;
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+            if (routingCount.incrementAndGet() > 1 && releaseCleanup.getCount() != 0) {
+                duplicateRoutingStarted.countDown();
+            }
+            rules.get("/resource", (req, res) -> res.send("unprotected"));
+        }
+
+        @Override
+        public void beforeStart() {
+            if (beforeStartCount.incrementAndGet() == 1) {
+                throw new HttpException("transient initialization failed", Status.I_AM_A_TEAPOT_418, true);
+            }
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            afterStartCount.incrementAndGet();
+        }
+
+        @Override
+        public void afterStop() {
+            if (afterStopCount.incrementAndGet() == 1) {
+                cleanupStarted.countDown();
+                try {
+                    if (!releaseCleanup.await(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Timed out waiting to release failed wrapper cleanup");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting to release failed wrapper cleanup", e);
+                }
+            }
         }
     }
 

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -15,8 +15,14 @@
  */
 package io.helidon.openapi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -50,6 +56,7 @@ import static org.hamcrest.Matchers.is;
 
 @RoutingTest
 class OpenApiServiceAuthorizationTest {
+    private static final int CONCURRENT_REQUESTS = 8;
     private static final HeaderName HEADER_PREDICATE = HeaderNames.create("X-OpenAPI-Service-Route");
 
     private final WebClient client;
@@ -177,6 +184,74 @@ class OpenApiServiceAuthorizationTest {
                 server.stop();
             }
         }
+    }
+
+    @Test
+    void concurrentLocatedServiceCacheHitsReuseSingleWrapper() throws Exception {
+        var allLocated = new CountDownLatch(CONCURRENT_REQUESTS);
+        var routingStarted = new CountDownLatch(1);
+        var releaseRouting = new CountDownLatch(1);
+        var service = new LifecycleService("/resource", routingStarted, releaseRouting);
+        var locator = new LifecycleLocator(service, allLocated);
+        WebServer server = testServer(new LocatorOpenApiService("/located", locator));
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+            var workersReady = new CountDownLatch(CONCURRENT_REQUESTS);
+            var startRequests = new CountDownLatch(1);
+
+            try (var executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS)) {
+                List<Future<Status>> requests = new ArrayList<>(CONCURRENT_REQUESTS);
+                for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+                    requests.add(executor.submit(() -> {
+                        workersReady.countDown();
+                        if (!startRequests.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("Timed out waiting to start concurrent request");
+                        }
+                        return serverClient.get("/located/resource").request(String.class).status();
+                    }));
+                }
+
+                try {
+                    assertThat("all request workers became ready",
+                               workersReady.await(5, TimeUnit.SECONDS),
+                               is(true));
+                    startRequests.countDown();
+                    assertThat("cold route initialization started",
+                               routingStarted.await(5, TimeUnit.SECONDS),
+                               is(true));
+                    assertThat("all concurrent requests resolved the stable service",
+                               allLocated.await(5, TimeUnit.SECONDS),
+                               is(true));
+                    releaseRouting.countDown();
+
+                    for (int i = 0; i < requests.size(); i++) {
+                        assertThat("secured response for concurrent request " + i,
+                                   requests.get(i).get(5, TimeUnit.SECONDS),
+                                   is(Status.FORBIDDEN_403));
+                    }
+                } finally {
+                    startRequests.countDown();
+                    releaseRouting.countDown();
+                }
+            }
+
+            assertThat("locator invocation count", locator.locateCount.get(), is(CONCURRENT_REQUESTS));
+            assertThat("locator beforeStart", locator.beforeStartCount.get(), is(1));
+            assertThat("locator afterStart", locator.afterStartCount.get(), is(1));
+            assertThat("located service routing", service.routingCount.get(), is(1));
+            assertThat("located service beforeStart", service.beforeStartCount.get(), is(1));
+            assertThat("located service afterStart", service.afterStartCount.get(), is(1));
+        } finally {
+            releaseRouting.countDown();
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+
+        assertThat("locator afterStop", locator.afterStopCount.get(), is(1));
+        assertThat("located service afterStop", service.afterStopCount.get(), is(1));
     }
 
     @Test
@@ -345,16 +420,25 @@ class OpenApiServiceAuthorizationTest {
 
     private static final class LifecycleLocator implements HttpServiceLocator {
         private final HttpService service;
+        private final CountDownLatch locateCalls;
+        private final AtomicInteger locateCount = new AtomicInteger();
         private final AtomicInteger beforeStartCount = new AtomicInteger();
         private final AtomicInteger afterStartCount = new AtomicInteger();
         private final AtomicInteger afterStopCount = new AtomicInteger();
 
         private LifecycleLocator(HttpService service) {
+            this(service, new CountDownLatch(0));
+        }
+
+        private LifecycleLocator(HttpService service, CountDownLatch locateCalls) {
             this.service = service;
+            this.locateCalls = locateCalls;
         }
 
         @Override
         public Optional<HttpService> locate(ServerRequest request) {
+            locateCount.incrementAndGet();
+            locateCalls.countDown();
             return Optional.of(service);
         }
 
@@ -376,18 +460,37 @@ class OpenApiServiceAuthorizationTest {
 
     private static final class LifecycleService implements HttpService {
         private final String routePath;
+        private final CountDownLatch routingStarted;
+        private final CountDownLatch releaseRouting;
         private final AtomicInteger routingCount = new AtomicInteger();
         private final AtomicInteger beforeStartCount = new AtomicInteger();
         private final AtomicInteger afterStartCount = new AtomicInteger();
         private final AtomicInteger afterStopCount = new AtomicInteger();
 
         private LifecycleService(String routePath) {
+            this(routePath, new CountDownLatch(0), new CountDownLatch(0));
+        }
+
+        private LifecycleService(String routePath,
+                                 CountDownLatch routingStarted,
+                                 CountDownLatch releaseRouting) {
             this.routePath = routePath;
+            this.routingStarted = routingStarted;
+            this.releaseRouting = releaseRouting;
         }
 
         @Override
         public void routing(HttpRules rules) {
             routingCount.incrementAndGet();
+            routingStarted.countDown();
+            try {
+                if (!releaseRouting.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release located service routing");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to release located service routing", e);
+            }
             rules.get(routePath, (req, res) -> res.send("unprotected"));
         }
 

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -144,7 +144,7 @@ class OpenApiServiceAuthorizationTest {
     }
 
     @Test
-    void locatedServiceWrapperCacheIsIdentityBounded() {
+    void locatedServiceCacheIsIdentityBounded() {
         var locator = new BoundedLocator();
         WebServer server = testServer(new LocatorOpenApiService("/bounded/{service}", locator));
 

--- a/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
+++ b/openapi/openapi/src/test/java/io/helidon/openapi/OpenApiServiceAuthorizationTest.java
@@ -15,7 +15,9 @@
  */
 package io.helidon.openapi;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import io.helidon.common.media.type.MediaType;
@@ -26,11 +28,14 @@ import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRoute;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.HttpServiceLocator;
+import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.testing.junit5.RoutingTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 import io.helidon.webserver.testing.junit5.SetUpServer;
@@ -83,20 +88,116 @@ class OpenApiServiceAuthorizationTest {
     }
 
     @Test
-    void headerPredicateServiceIgnoresRequestsWithoutHeader() {
-        ClientResponseTyped<String> response = client.get("/header-service")
+    void headerPredicateMissThenProtectedMatch() {
+        ClientResponseTyped<String> withoutHeader = client.get("/header-service")
                 .request(String.class);
 
-        assertThat(response.status(), is(Status.NOT_FOUND_404));
-    }
+        assertThat(withoutHeader.status(), is(Status.NOT_FOUND_404));
 
-    @Test
-    void headerPredicateServiceRequiresAuthorization() {
-        ClientResponseTyped<String> response = client.get("/header-service")
+        ClientResponseTyped<String> withHeader = client.get("/header-service")
                 .header(HEADER_PREDICATE, "present")
                 .request(String.class);
 
-        assertThat(response.status(), is(Status.FORBIDDEN_403));
+        assertThat(withHeader.status(), is(Status.FORBIDDEN_403));
+    }
+
+    @Test
+    void securityDoesNotApplyToUnrelatedRootRoute() {
+        WebServer server = WebServer.builder()
+                .port(0)
+                .routing(routing -> routing.get("/unrelated", (req, res) -> res.send("unrelated")))
+                .addFeature(OpenApiFeature.builder()
+                                    .servicesDiscoverServices(false)
+                                    .staticFile("src/test/resources/greeting.yml")
+                                    .webContext("/")
+                                    .permitAll(false)
+                                    .name("root-openapi")
+                                    .addService(new RootOpenApiService())
+                                    .build())
+                .build();
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+            ClientResponseTyped<String> response = serverClient.get("/unrelated")
+                    .request(String.class);
+
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity(), is("unrelated"));
+            assertThat(serverClient.get("/").request(String.class).status(), is(Status.FORBIDDEN_403));
+            assertThat(serverClient.get("/root-openapi-service").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+        } finally {
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+    }
+
+    @Test
+    void locatedServiceWrapperCacheIsIdentityBounded() {
+        var locator = new BoundedLocator();
+        WebServer server = testServer(new LocatorOpenApiService("/bounded/{service}", locator));
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+
+            assertThat(serverClient.get("/bounded/one/resource").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+            assertThat(serverClient.get("/bounded/one/resource").request(String.class).status(),
+                       is(Status.FORBIDDEN_403));
+            assertThat(serverClient.get("/bounded/two/resource").request(String.class).status(),
+                       is(Status.SERVICE_UNAVAILABLE_503));
+        } finally {
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+    }
+
+    @Test
+    void locatorAndLocatedServiceRetainLifecycle() {
+        var service = new LifecycleService("/resource");
+        var locator = new LifecycleLocator(service);
+        WebServer server = testServer(new LocatorOpenApiService("/located", locator));
+
+        try {
+            server.start();
+            WebClient serverClient = testClient(server);
+
+            assertThat(serverClient.get("/located/resource").request(String.class).status(), is(Status.FORBIDDEN_403));
+            assertThat("locator beforeStart", locator.beforeStartCount.get(), is(1));
+            assertThat("locator afterStart", locator.afterStartCount.get(), is(1));
+            assertThat("located service routing", service.routingCount.get(), is(1));
+            assertThat("located service beforeStart", service.beforeStartCount.get(), is(1));
+            assertThat("located service afterStart", service.afterStartCount.get(), is(1));
+        } finally {
+            if (server.isRunning()) {
+                server.stop();
+            }
+        }
+
+        assertThat("locator afterStop", locator.afterStopCount.get(), is(1));
+        assertThat("located service afterStop", service.afterStopCount.get(), is(1));
+    }
+
+    private static WebServer testServer(OpenApiService service) {
+        return WebServer.builder()
+                .port(0)
+                .addFeature(OpenApiFeature.builder()
+                                    .servicesDiscoverServices(false)
+                                    .staticFile("src/test/resources/greeting.yml")
+                                    .permitAll(false)
+                                    .addService(service)
+                                    .build())
+                .build();
+    }
+
+    private static WebClient testClient(WebServer server) {
+        return WebClient.builder()
+                .baseUri("http://localhost:" + server.port())
+                .build();
     }
 
     private static final class TestOpenApiService implements OpenApiService {
@@ -130,6 +231,138 @@ class OpenApiServiceAuthorizationTest {
         @Override
         public String type() {
             return "test-openapi-service";
+        }
+    }
+
+    private static final class BoundedLocator implements HttpServiceLocator {
+        private final Map<String, HttpService> services = Map.of(
+                "one", rules -> rules.get("/resource", (req, res) -> res.send("unprotected")),
+                "two", rules -> rules.get("/resource", (req, res) -> res.send("unprotected")));
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            return request.path().pathParameters().first("service").map(services::get);
+        }
+
+        @Override
+        public int maxServiceCacheSize() {
+            return 1;
+        }
+    }
+
+    private static final class LocatorOpenApiService implements OpenApiService {
+        private final String path;
+        private final HttpServiceLocator locator;
+
+        private LocatorOpenApiService(String path, HttpServiceLocator locator) {
+            this.path = path;
+            this.locator = locator;
+        }
+
+        @Override
+        public boolean supports(ServerRequestHeaders headers) {
+            return false;
+        }
+
+        @Override
+        public void setup(HttpRules routing, String docPath, Function<MediaType, String> content) {
+            routing.registerLocator(path, locator);
+        }
+
+        @Override
+        public String name() {
+            return "locator-test-openapi-service";
+        }
+
+        @Override
+        public String type() {
+            return "locator-test-openapi-service";
+        }
+    }
+
+    private static final class RootOpenApiService implements OpenApiService {
+        @Override
+        public boolean supports(ServerRequestHeaders headers) {
+            return false;
+        }
+
+        @Override
+        public void setup(HttpRules routing, String docPath, Function<MediaType, String> content) {
+            routing.get("/root-openapi-service", (req, res) -> res.send("unprotected"));
+        }
+
+        @Override
+        public String name() {
+            return "root-openapi-service";
+        }
+
+        @Override
+        public String type() {
+            return "root-openapi-service";
+        }
+    }
+
+    private static final class LifecycleLocator implements HttpServiceLocator {
+        private final HttpService service;
+        private final AtomicInteger beforeStartCount = new AtomicInteger();
+        private final AtomicInteger afterStartCount = new AtomicInteger();
+        private final AtomicInteger afterStopCount = new AtomicInteger();
+
+        private LifecycleLocator(HttpService service) {
+            this.service = service;
+        }
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            return Optional.of(service);
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStartCount.incrementAndGet();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            afterStartCount.incrementAndGet();
+        }
+
+        @Override
+        public void afterStop() {
+            afterStopCount.incrementAndGet();
+        }
+    }
+
+    private static final class LifecycleService implements HttpService {
+        private final String routePath;
+        private final AtomicInteger routingCount = new AtomicInteger();
+        private final AtomicInteger beforeStartCount = new AtomicInteger();
+        private final AtomicInteger afterStartCount = new AtomicInteger();
+        private final AtomicInteger afterStopCount = new AtomicInteger();
+
+        private LifecycleService(String routePath) {
+            this.routePath = routePath;
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+            routingCount.incrementAndGet();
+            rules.get(routePath, (req, res) -> res.send("unprotected"));
+        }
+
+        @Override
+        public void beforeStart() {
+            beforeStartCount.incrementAndGet();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            afterStartCount.incrementAndGet();
+        }
+
+        @Override
+        public void afterStop() {
+            afterStopCount.incrementAndGet();
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteWrap.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRouteWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
+import io.helidon.http.ServerRequestHeaders;
 import io.helidon.webserver.WebServer;
 
 class HttpRouteWrap extends HttpRouteBase {
@@ -48,6 +49,11 @@ class HttpRouteWrap extends HttpRouteBase {
     @Override
     public PathMatchers.MatchResult accepts(HttpPrologue prologue) {
         return route.accepts(prologue);
+    }
+
+    @Override
+    public PathMatchers.MatchResult accepts(HttpPrologue prologue, ServerRequestHeaders headers) {
+        return route.accepts(prologue, headers);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceCacheKey.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceCacheKey.java
@@ -17,5 +17,4 @@
 package io.helidon.webserver.http;
 
 interface LocatedServiceCacheKey {
-    HttpService cacheKey();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceCacheKey.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceCacheKey.java
@@ -16,6 +16,6 @@
 
 package io.helidon.webserver.http;
 
-interface LocatedServiceRouting {
-    void routing(HttpService service, HttpRules rules);
+interface LocatedServiceCacheKey {
+    HttpService cacheKey();
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/LocatedServiceRouting.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.http;
+
+interface LocatedServiceRouting {
+    void routing(HttpService service, HttpRules rules);
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
@@ -264,8 +264,25 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         }
 
         @Override
-        public HttpService cacheKey() {
-            return delegate instanceof LocatedServiceCacheKey locatedService ? locatedService.cacheKey() : delegate;
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof WrappedService that) || secureHandler != that.secureHandler) {
+                return false;
+            }
+            if (delegate instanceof WrappedService wrappedDelegate) {
+                return wrappedDelegate.equals(that.delegate);
+            }
+            return delegate == that.delegate;
+        }
+
+        @Override
+        public int hashCode() {
+            int delegateHash = delegate instanceof WrappedService wrappedDelegate
+                    ? wrappedDelegate.hashCode()
+                    : System.identityHashCode(delegate);
+            return 31 * delegateHash + System.identityHashCode(secureHandler);
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
@@ -16,10 +16,12 @@
 
 package io.helidon.webserver.http;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.Api;
 import io.helidon.common.security.SecurityContext;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.spi.ProtocolUpgradeHandler;
 
 /**
@@ -90,6 +92,19 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         return new WrappedHandler(this, handler);
     }
 
+    /**
+     * Creates a new service locator that applies the configured security requirements to each located service.
+     * <p>
+     * WebServer caches the located service's original identity and applies the security wrapper only after admitting that
+     * identity to the locator's service cache.
+     *
+     * @param locator service locator to wrap
+     * @return a new wrapped service locator
+     */
+    public HttpServiceLocator wrap(HttpServiceLocator locator) {
+        return new WrappedLocator(this, Objects.requireNonNull(locator));
+    }
+
     @Override
     public void handle(ServerRequest req, ServerResponse res) throws Exception {
         if (doHandle(req, res)) {
@@ -127,7 +142,152 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         return true;
     }
 
-    private static class WrappedHandler implements Handler, ProtocolUpgradeHandler {
+    private HttpService wrap(HttpService service) {
+        return new WrappedService(service, this);
+    }
+
+    private HttpRoute wrap(HttpRoute route) {
+        return new WrappedRoute(route, this);
+    }
+
+    private static final class WrappedLocator implements HttpServiceLocator, LocatedServiceRouting {
+        private final SecureHandler secureHandler;
+        private final HttpServiceLocator delegate;
+
+        private WrappedLocator(SecureHandler secureHandler, HttpServiceLocator delegate) {
+            this.secureHandler = secureHandler;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Optional<HttpService> locate(ServerRequest request) {
+            return delegate.locate(request);
+        }
+
+        @Override
+        public int maxServiceCacheSize() {
+            return delegate.maxServiceCacheSize();
+        }
+
+        @Override
+        public void beforeStart() {
+            delegate.beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.afterStart(webServer);
+        }
+
+        @Override
+        public void afterStop() {
+            delegate.afterStop();
+        }
+
+        @Override
+        public void routing(HttpService service, HttpRules rules) {
+            HttpRules securedRules = new WrappedRules(rules, secureHandler);
+            if (delegate instanceof LocatedServiceRouting locatedServiceRouting) {
+                locatedServiceRouting.routing(service, securedRules);
+            } else {
+                service.routing(securedRules);
+            }
+        }
+    }
+
+    private static final class WrappedRules implements HttpRules {
+        private final HttpRules delegate;
+        private final SecureHandler secureHandler;
+
+        private WrappedRules(HttpRules delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.secureHandler = secureHandler;
+        }
+
+        @Override
+        public HttpRules register(HttpService... services) {
+            delegate.register(wrappedServices(services));
+            return this;
+        }
+
+        @Override
+        public HttpRules register(String pathPattern, HttpService... services) {
+            delegate.register(pathPattern, wrappedServices(services));
+            return this;
+        }
+
+        @Override
+        public HttpRules registerLocator(HttpServiceLocator locator) {
+            delegate.registerLocator(secureHandler.wrap(locator));
+            return this;
+        }
+
+        @Override
+        public HttpRules registerLocator(String pathPattern, HttpServiceLocator locator) {
+            delegate.registerLocator(pathPattern, secureHandler.wrap(locator));
+            return this;
+        }
+
+        @Override
+        public HttpRules route(HttpRoute route) {
+            delegate.route(secureHandler.wrap(route));
+            return this;
+        }
+
+        private HttpService[] wrappedServices(HttpService[] services) {
+            HttpService[] wrappedServices = new HttpService[services.length];
+            for (int i = 0; i < services.length; i++) {
+                wrappedServices[i] = secureHandler.wrap(services[i]);
+            }
+            return wrappedServices;
+        }
+    }
+
+    private static final class WrappedService implements HttpService {
+        private final HttpService delegate;
+        private final SecureHandler secureHandler;
+
+        private WrappedService(HttpService delegate, SecureHandler secureHandler) {
+            this.delegate = delegate;
+            this.secureHandler = secureHandler;
+        }
+
+        @Override
+        public void routing(HttpRules rules) {
+            delegate.routing(new WrappedRules(rules, secureHandler));
+        }
+
+        @Override
+        public void beforeStart() {
+            delegate.beforeStart();
+        }
+
+        @Override
+        public void afterStart(WebServer webServer) {
+            delegate.afterStart(webServer);
+        }
+
+        @Override
+        public void afterStop() {
+            delegate.afterStop();
+        }
+    }
+
+    private static final class WrappedRoute extends HttpRouteWrap {
+        private final Handler handler;
+
+        private WrappedRoute(HttpRoute route, SecureHandler secureHandler) {
+            super(route);
+            this.handler = secureHandler.wrap(route.handler());
+        }
+
+        @Override
+        public Handler handler() {
+            return handler;
+        }
+    }
+
+    private static final class WrappedHandler implements Handler, ProtocolUpgradeHandler {
         private final SecureHandler secureHandler;
         private final Handler handler;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
@@ -150,7 +150,7 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         return new WrappedRoute(route, this);
     }
 
-    private static final class WrappedLocator implements HttpServiceLocator, LocatedServiceRouting {
+    private static final class WrappedLocator implements HttpServiceLocator {
         private final SecureHandler secureHandler;
         private final HttpServiceLocator delegate;
 
@@ -161,7 +161,7 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
 
         @Override
         public Optional<HttpService> locate(ServerRequest request) {
-            return delegate.locate(request);
+            return delegate.locate(request).map(secureHandler::wrap);
         }
 
         @Override
@@ -184,15 +184,6 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
             delegate.afterStop();
         }
 
-        @Override
-        public void routing(HttpService service, HttpRules rules) {
-            HttpRules securedRules = new WrappedRules(rules, secureHandler);
-            if (delegate instanceof LocatedServiceRouting locatedServiceRouting) {
-                locatedServiceRouting.routing(service, securedRules);
-            } else {
-                service.routing(securedRules);
-            }
-        }
     }
 
     private static final class WrappedRules implements HttpRules {
@@ -243,7 +234,7 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         }
     }
 
-    private static final class WrappedService implements HttpService {
+    private static final class WrappedService implements HttpService, LocatedServiceCacheKey {
         private final HttpService delegate;
         private final SecureHandler secureHandler;
 
@@ -270,6 +261,11 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
         @Override
         public void afterStop() {
             delegate.afterStop();
+        }
+
+        @Override
+        public HttpService cacheKey() {
+            return delegate instanceof LocatedServiceCacheKey locatedService ? locatedService.cacheKey() : delegate;
         }
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
@@ -95,8 +95,9 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
     /**
      * Creates a new service locator that applies the configured security requirements to each located service.
      * <p>
-     * WebServer caches the located service's original identity and applies the security wrapper only after admitting that
-     * identity to the locator's service cache.
+     * WebServer uses the located service's original identity together with the complete security handler chain as the
+     * cache identity. The same service wrapped by different security handler instances therefore uses separate entries in
+     * the locator's cache, all bounded by {@link HttpServiceLocator#maxServiceCacheSize()}.
      *
      * @param locator service locator to wrap
      * @return a new wrapped service locator

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/SecureHandler.java
@@ -102,7 +102,7 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
      * @param locator service locator to wrap
      * @return a new wrapped service locator
      */
-    public HttpServiceLocator wrap(HttpServiceLocator locator) {
+    public HttpServiceLocator wrapLocator(HttpServiceLocator locator) {
         return new WrappedLocator(this, Objects.requireNonNull(locator));
     }
 
@@ -210,13 +210,13 @@ public final class SecureHandler implements Handler, ProtocolUpgradeHandler {
 
         @Override
         public HttpRules registerLocator(HttpServiceLocator locator) {
-            delegate.registerLocator(secureHandler.wrap(locator));
+            delegate.registerLocator(secureHandler.wrapLocator(locator));
             return this;
         }
 
         @Override
         public HttpRules registerLocator(String pathPattern, HttpServiceLocator locator) {
-            delegate.registerLocator(pathPattern, secureHandler.wrap(locator));
+            delegate.registerLocator(pathPattern, secureHandler.wrapLocator(locator));
             return this;
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.http;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,8 +44,9 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
     private final ReentrantLock lock = new ReentrantLock();
     private final int maxServiceCacheSize;
 
-    // Published maps are not mutated. Cache changes copy the identity map while holding the lock.
+    // Published maps are not mutated. Cache changes copy the affected map while holding the lock.
     private volatile Map<HttpService, RouteEntry> routes = new IdentityHashMap<>();
+    private volatile Map<HttpService, RouteEntry> decoratedRoutes = new HashMap<>();
     private volatile Lifecycle lifecycle = Lifecycle.initial();
 
     ServiceLocatorRoute(HttpServiceLocator locator,
@@ -96,8 +99,10 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         try {
             transition = lifecycle.stopping();
             lifecycle = transition;
-            entries = List.copyOf(routes.values());
+            entries = new ArrayList<>(routes.values());
+            entries.addAll(decoratedRoutes.values());
             routes = new IdentityHashMap<>();
+            decoratedRoutes = new HashMap<>();
         } finally {
             lock.unlock();
         }
@@ -220,13 +225,11 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
 
     private LocatedRoutes route(HttpService service) {
         Objects.requireNonNull(service, "HttpServiceLocator must not locate a null service");
-        HttpService cacheKey = service instanceof LocatedServiceCacheKey locatedService ? locatedService.cacheKey() : service;
-        Objects.requireNonNull(cacheKey, "Located service cache key must not be null");
 
         if (!lifecycle.acceptsRoutes()) {
             return null;
         }
-        RouteEntry entry = routes.get(cacheKey);
+        RouteEntry entry = routeEntry(service);
 
         if (entry == null) {
             lock.lock();
@@ -234,9 +237,9 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                 if (!lifecycle.acceptsRoutes()) {
                     return null;
                 }
-                entry = routes.get(cacheKey);
+                entry = routeEntry(service);
                 if (entry == null) {
-                    if (routes.size() >= maxServiceCacheSize) {
+                    if (routes.size() + decoratedRoutes.size() >= maxServiceCacheSize) {
                         throw new HttpException("HttpServiceLocator service cache size of "
                                                         + maxServiceCacheSize
                                                         + " exceeded",
@@ -244,9 +247,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                                                 true);
                     }
                     entry = new RouteEntry();
-                    Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(routes);
-                    updatedRoutes.put(cacheKey, entry);
-                    routes = updatedRoutes;
+                    addRoute(service, entry);
                 }
             } finally {
                 lock.unlock();
@@ -254,11 +255,41 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         }
 
         try {
-            LocatedRoutes locatedRoutes = entry.routes(this, cacheKey, service);
+            LocatedRoutes locatedRoutes = entry.routes(this, service);
             return lifecycle.acceptsRoutes() ? locatedRoutes : null;
         } catch (RuntimeException | Error e) {
-            entry.removeIfEmpty(this, cacheKey);
+            entry.removeIfEmpty(this, service);
             throw e;
+        }
+    }
+
+    private RouteEntry routeEntry(HttpService service) {
+        return service instanceof LocatedServiceCacheKey ? decoratedRoutes.get(service) : routes.get(service);
+    }
+
+    private void addRoute(HttpService service, RouteEntry entry) {
+        if (service instanceof LocatedServiceCacheKey) {
+            Map<HttpService, RouteEntry> updatedRoutes = new HashMap<>(decoratedRoutes);
+            updatedRoutes.put(service, entry);
+            decoratedRoutes = updatedRoutes;
+        } else {
+            Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(routes);
+            updatedRoutes.put(service, entry);
+            routes = updatedRoutes;
+        }
+    }
+
+    private void removeRoute(HttpService service, RouteEntry entry) {
+        if (service instanceof LocatedServiceCacheKey) {
+            if (decoratedRoutes.get(service) == entry) {
+                Map<HttpService, RouteEntry> updatedRoutes = new HashMap<>(decoratedRoutes);
+                updatedRoutes.remove(service);
+                decoratedRoutes = updatedRoutes;
+            }
+        } else if (routes.get(service) == entry) {
+            Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(routes);
+            updatedRoutes.remove(service);
+            routes = updatedRoutes;
         }
     }
 
@@ -298,7 +329,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         private volatile boolean initialized;
         private volatile LifecycleStamp lifecycleStamp = LifecycleStamp.initial();
 
-        private LocatedRoutes routes(ServiceLocatorRoute owner, HttpService cacheKey, HttpService service) {
+        private LocatedRoutes routes(ServiceLocatorRoute owner, HttpService service) {
             LocatedRoutes current = routes;
             Lifecycle target = owner.lifecycle;
             if (initialized && current != null && lifecycleStamp.covers(target) && !lock.isLocked()) {
@@ -310,7 +341,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                 if (!initialized) {
                     owner.lock.lock();
                     try {
-                        if (!owner.lifecycle.acceptsRoutes() || owner.routes.get(cacheKey) != this) {
+                        if (!owner.lifecycle.acceptsRoutes() || owner.routeEntry(service) != this) {
                             return null;
                         }
                     } finally {
@@ -330,7 +361,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
             return owner.lifecycle.acceptsRoutes() ? routes : null;
         }
 
-        private void removeIfEmpty(ServiceLocatorRoute owner, HttpService cacheKey) {
+        private void removeIfEmpty(ServiceLocatorRoute owner, HttpService service) {
             lock.lock();
             try {
                 if (routes != null) {
@@ -339,11 +370,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
 
                 owner.lock.lock();
                 try {
-                    if (owner.routes.get(cacheKey) == this) {
-                        Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(owner.routes);
-                        updatedRoutes.remove(cacheKey);
-                        owner.routes = updatedRoutes;
-                    }
+                    owner.removeRoute(service, this);
                 } finally {
                     owner.lock.unlock();
                 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
@@ -220,11 +220,13 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
 
     private LocatedRoutes route(HttpService service) {
         Objects.requireNonNull(service, "HttpServiceLocator must not locate a null service");
+        HttpService cacheKey = service instanceof LocatedServiceCacheKey locatedService ? locatedService.cacheKey() : service;
+        Objects.requireNonNull(cacheKey, "Located service cache key must not be null");
 
         if (!lifecycle.acceptsRoutes()) {
             return null;
         }
-        RouteEntry entry = routes.get(service);
+        RouteEntry entry = routes.get(cacheKey);
 
         if (entry == null) {
             lock.lock();
@@ -232,7 +234,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                 if (!lifecycle.acceptsRoutes()) {
                     return null;
                 }
-                entry = routes.get(service);
+                entry = routes.get(cacheKey);
                 if (entry == null) {
                     if (routes.size() >= maxServiceCacheSize) {
                         throw new HttpException("HttpServiceLocator service cache size of "
@@ -243,7 +245,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                     }
                     entry = new RouteEntry();
                     Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(routes);
-                    updatedRoutes.put(service, entry);
+                    updatedRoutes.put(cacheKey, entry);
                     routes = updatedRoutes;
                 }
             } finally {
@@ -252,21 +254,17 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         }
 
         try {
-            LocatedRoutes locatedRoutes = entry.routes(this, service);
+            LocatedRoutes locatedRoutes = entry.routes(this, cacheKey, service);
             return lifecycle.acceptsRoutes() ? locatedRoutes : null;
         } catch (RuntimeException | Error e) {
-            entry.removeIfEmpty(this, service);
+            entry.removeIfEmpty(this, cacheKey);
             throw e;
         }
     }
 
     private LocatedRoutes createRoutes(HttpService service) {
         ServiceRules subRules = new ServiceRules(service, PathMatchers.any(), methodPredicate);
-        if (locator instanceof LocatedServiceRouting locatedServiceRouting) {
-            locatedServiceRouting.routing(service, subRules);
-        } else {
-            service.routing(subRules);
-        }
+        service.routing(subRules);
         return new LocatedRoutes(subRules.build(), subRules.buildProtocolUpgrade());
     }
 
@@ -300,7 +298,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         private volatile boolean initialized;
         private volatile LifecycleStamp lifecycleStamp = LifecycleStamp.initial();
 
-        private LocatedRoutes routes(ServiceLocatorRoute owner, HttpService service) {
+        private LocatedRoutes routes(ServiceLocatorRoute owner, HttpService cacheKey, HttpService service) {
             LocatedRoutes current = routes;
             Lifecycle target = owner.lifecycle;
             if (initialized && current != null && lifecycleStamp.covers(target) && !lock.isLocked()) {
@@ -312,7 +310,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                 if (!initialized) {
                     owner.lock.lock();
                     try {
-                        if (!owner.lifecycle.acceptsRoutes() || owner.routes.get(service) != this) {
+                        if (!owner.lifecycle.acceptsRoutes() || owner.routes.get(cacheKey) != this) {
                             return null;
                         }
                     } finally {
@@ -332,7 +330,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
             return owner.lifecycle.acceptsRoutes() ? routes : null;
         }
 
-        private void removeIfEmpty(ServiceLocatorRoute owner, HttpService service) {
+        private void removeIfEmpty(ServiceLocatorRoute owner, HttpService cacheKey) {
             lock.lock();
             try {
                 if (routes != null) {
@@ -341,9 +339,9 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
 
                 owner.lock.lock();
                 try {
-                    if (owner.routes.get(service) == this) {
+                    if (owner.routes.get(cacheKey) == this) {
                         Map<HttpService, RouteEntry> updatedRoutes = new IdentityHashMap<>(owner.routes);
-                        updatedRoutes.remove(service);
+                        updatedRoutes.remove(cacheKey);
                         owner.routes = updatedRoutes;
                     }
                 } finally {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
@@ -140,12 +140,6 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         }
     }
 
-    private List<RouteEntry> routeEntries() {
-        List<RouteEntry> entries = new ArrayList<>(routes.values());
-        entries.addAll(decoratedRoutes.values());
-        return entries;
-    }
-
     @Override
     public PathMatchers.MatchResult accepts(HttpPrologue prologue) {
         throw new IllegalStateException("List routes must use acceptsPrefix");
@@ -226,6 +220,12 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
     @Override
     public String toString() {
         return methodPredicate + " (" + pathMatcher + ") with service locator: " + locator;
+    }
+
+    private List<RouteEntry> routeEntries() {
+        List<RouteEntry> entries = new ArrayList<>(routes.values());
+        entries.addAll(decoratedRoutes.values());
+        return entries;
     }
 
     private LocatedRoutes route(HttpService service) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
@@ -99,8 +99,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         try {
             transition = lifecycle.stopping();
             lifecycle = transition;
-            entries = new ArrayList<>(routes.values());
-            entries.addAll(decoratedRoutes.values());
+            entries = routeEntries();
             routes = new IdentityHashMap<>();
             decoratedRoutes = new HashMap<>();
         } finally {
@@ -131,7 +130,7 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
                 return;
             }
             lifecycle = completed;
-            entries = List.copyOf(routes.values());
+            entries = routeEntries();
         } finally {
             lock.unlock();
         }
@@ -139,6 +138,12 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
         for (RouteEntry entry : entries) {
             entry.requestCatchUp(this);
         }
+    }
+
+    private List<RouteEntry> routeEntries() {
+        List<RouteEntry> entries = new ArrayList<>(routes.values());
+        entries.addAll(decoratedRoutes.values());
+        return entries;
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServiceLocatorRoute.java
@@ -262,7 +262,11 @@ class ServiceLocatorRoute extends HttpRouteBase implements HttpRoute {
 
     private LocatedRoutes createRoutes(HttpService service) {
         ServiceRules subRules = new ServiceRules(service, PathMatchers.any(), methodPredicate);
-        service.routing(subRules);
+        if (locator instanceof LocatedServiceRouting locatedServiceRouting) {
+            locatedServiceRouting.routing(service, subRules);
+        } else {
+            service.routing(subRules);
+        }
         return new LocatedRoutes(subRules.build(), subRules.buildProtocolUpgrade());
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -593,6 +593,51 @@ class HttpServiceLocatorTest {
     }
 
     @Test
+    void testSecureHandlerPoliciesRemainDistinctForSameLocatedService() throws Exception {
+        var rawHandlerInvoked = new AtomicBoolean();
+        HttpService service = rules -> rules.get("/resource", (req, res) -> rawHandlerInvoked.set(true));
+        HttpServiceLocator locator = request -> Optional.of(service);
+        HttpServiceLocator userLocator = SecureHandler.authorize("user").wrap(locator);
+        HttpServiceLocator adminLocator = SecureHandler.authorize("admin").wrap(locator);
+        HttpServiceLocator policyLocator = request -> request.path()
+                .pathParameters()
+                .first("item")
+                .filter("admin"::equals)
+                .map(_ -> adminLocator)
+                .orElse(userLocator)
+                .locate(request);
+        var route = locatorRoute(policyLocator);
+        Handler userHandler = locatedRoutes(route, "/user/resource").getFirst().handler();
+        Handler adminHandler = locatedRoutes(route, "/admin/resource").getFirst().handler();
+        ServerRequest request = mock(ServerRequest.class);
+        ServerResponse response = mock(ServerResponse.class);
+        var observedRole = new AtomicReference<String>();
+        HttpSecurity security = new HttpSecurity() {
+            @Override
+            public boolean authenticate(ServerRequest request, ServerResponse response, boolean requiredHint) {
+                return false;
+            }
+
+            @Override
+            public boolean authorize(ServerRequest request, ServerResponse response, String... roleHint) {
+                observedRole.set(roleHint[0]);
+                return false;
+            }
+        };
+
+        when(request.context()).thenReturn(Context.create());
+        when(request.security()).thenReturn(security);
+
+        userHandler.handle(request, response);
+        assertThat(observedRole.get(), is("user"));
+        observedRole.set(null);
+
+        adminHandler.handle(request, response);
+        assertThat(observedRole.get(), is("admin"));
+        assertThat(rawHandlerInvoked.get(), is(false));
+    }
+
+    @Test
     void testCachedLocatedServiceDoesNotWaitForColdServiceCreation() throws Exception {
         var fast = new LifecycleService();
         var slow = new BlockingRoutingService();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -491,6 +491,23 @@ class HttpServiceLocatorTest {
     }
 
     @Test
+    void testSecuredLocatedServiceCreatedDuringStartReceivesLifecycleOnce() {
+        var service = new LifecycleService();
+        HttpServiceLocator locator = SecureHandler.authorize("user").wrap(new LifecycleLocator(service));
+        var route = locatorRoute(locator);
+
+        route.beforeStart();
+        locate(route);
+        route.afterStart(mock(WebServer.class));
+        route.afterStop();
+
+        assertThat(service.routingCount.get(), is(1));
+        assertThat(service.beforeStartCount.get(), is(1));
+        assertThat(service.afterStartCount.get(), is(1));
+        assertThat(service.afterStopCount.get(), is(1));
+    }
+
+    @Test
     void testCachedLocatedServiceWaitsForAfterStartCompletion() throws Exception {
         var service = new BlockingAfterStartService();
         var locateCount = new AtomicInteger();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -28,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.common.context.Context;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
@@ -48,7 +50,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -57,6 +58,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class HttpServiceLocatorTest {
@@ -558,8 +560,6 @@ class HttpServiceLocatorTest {
         HttpServiceLocator securedLocator = SecureHandler.authorize().wrap(locator);
         var route = locatorRoute(securedLocator);
 
-        assertThat(securedLocator.locate(mock(ServerRequest.class)).orElseThrow(), sameInstance(first));
-
         locate(route);
         locate(route);
         locator.service(second);
@@ -568,6 +568,28 @@ class HttpServiceLocatorTest {
 
         assertThat(first.routingCount.get(), is(1));
         assertThat(second.routingCount.get(), is(0));
+    }
+
+    @Test
+    void testOuterLocatorDecoratorPreservesSecureHandlerWrap() throws Exception {
+        var rawHandlerInvoked = new AtomicBoolean();
+        HttpService service = rules -> rules.get("/resource", (req, res) -> rawHandlerInvoked.set(true));
+        HttpServiceLocator locator = request -> Optional.of(service);
+        HttpServiceLocator securedLocator = SecureHandler.authorize().wrap(locator);
+        HttpServiceLocator decoratedLocator = request -> securedLocator.locate(request);
+        var route = locatorRoute(decoratedLocator);
+        Handler handler = locatedRoutes(route, "/pipe/resource").getFirst().handler();
+        ServerRequest request = mock(ServerRequest.class);
+        ServerResponse response = mock(ServerResponse.class);
+        HttpSecurity security = mock(HttpSecurity.class);
+
+        when(request.context()).thenReturn(Context.create());
+        when(request.security()).thenReturn(security);
+
+        handler.handle(request, response);
+
+        assertThat(rawHandlerInvoked.get(), is(false));
+        verify(security).authorize(any(), any(), any(String[].class));
     }
 
     @Test
@@ -610,6 +632,10 @@ class HttpServiceLocatorTest {
     }
 
     private static void locate(ServiceLocatorRoute route, String path) {
+        locatedRoutes(route, path);
+    }
+
+    private static List<HttpRouteBase> locatedRoutes(ServiceLocatorRoute route, String path) {
         RoutingRequest request = mock(RoutingRequest.class);
         AtomicReference<RoutedPath> requestPath = new AtomicReference<>();
         PathMatchers.PrefixMatchResult match = route.acceptsPrefix(prologue(path));
@@ -620,7 +646,7 @@ class HttpServiceLocatorTest {
             return request;
         });
 
-        route.routes(mock(ConnectionContext.class), request, match.matchedPath(), "/{item}");
+        return route.routes(mock(ConnectionContext.class), request, match.matchedPath(), "/{item}");
     }
 
     private static HttpPrologue prologue(String path) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -493,7 +493,7 @@ class HttpServiceLocatorTest {
     @Test
     void testSecuredLocatedServiceCreatedDuringStartReceivesLifecycleOnce() {
         var service = new LifecycleService();
-        HttpServiceLocator locator = SecureHandler.authorize("user").wrap(new LifecycleLocator(service));
+        HttpServiceLocator locator = SecureHandler.authorize("user").wrapLocator(new LifecycleLocator(service));
         var route = locatorRoute(locator);
 
         route.beforeStart();
@@ -574,7 +574,7 @@ class HttpServiceLocatorTest {
         var first = new LifecycleService("first");
         var second = new LifecycleService("second");
         var locator = new SwitchingLocator(first, false, 1);
-        HttpServiceLocator securedLocator = SecureHandler.authorize().wrap(locator);
+        HttpServiceLocator securedLocator = SecureHandler.authorize().wrapLocator(locator);
         var route = locatorRoute(securedLocator);
 
         locate(route);
@@ -592,7 +592,7 @@ class HttpServiceLocatorTest {
         var rawHandlerInvoked = new AtomicBoolean();
         HttpService service = rules -> rules.get("/resource", (req, res) -> rawHandlerInvoked.set(true));
         HttpServiceLocator locator = request -> Optional.of(service);
-        HttpServiceLocator securedLocator = SecureHandler.authorize().wrap(locator);
+        HttpServiceLocator securedLocator = SecureHandler.authorize().wrapLocator(locator);
         HttpServiceLocator decoratedLocator = request -> securedLocator.locate(request);
         var route = locatorRoute(decoratedLocator);
         Handler handler = locatedRoutes(route, "/pipe/resource").getFirst().handler();
@@ -614,8 +614,8 @@ class HttpServiceLocatorTest {
         var rawHandlerInvoked = new AtomicBoolean();
         HttpService service = rules -> rules.get("/resource", (req, res) -> rawHandlerInvoked.set(true));
         HttpServiceLocator locator = request -> Optional.of(service);
-        HttpServiceLocator userLocator = SecureHandler.authorize("user").wrap(locator);
-        HttpServiceLocator adminLocator = SecureHandler.authorize("admin").wrap(locator);
+        HttpServiceLocator userLocator = SecureHandler.authorize("user").wrapLocator(locator);
+        HttpServiceLocator adminLocator = SecureHandler.authorize("admin").wrapLocator(locator);
         HttpServiceLocator policyLocator = request -> request.path()
                 .pathParameters()
                 .first("item")

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http/HttpServiceLocatorTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -545,6 +546,26 @@ class HttpServiceLocatorTest {
 
         assertThat(failure.status(), is(Status.SERVICE_UNAVAILABLE_503));
         assertThat(failure.getMessage(), is("HttpServiceLocator service cache size of 1 exceeded"));
+        assertThat(first.routingCount.get(), is(1));
+        assertThat(second.routingCount.get(), is(0));
+    }
+
+    @Test
+    void testSecureHandlerWrapPreservesLocatedServiceCacheIdentity() {
+        var first = new LifecycleService("first");
+        var second = new LifecycleService("second");
+        var locator = new SwitchingLocator(first, false, 1);
+        HttpServiceLocator securedLocator = SecureHandler.authorize().wrap(locator);
+        var route = locatorRoute(securedLocator);
+
+        assertThat(securedLocator.locate(mock(ServerRequest.class)).orElseThrow(), sameInstance(first));
+
+        locate(route);
+        locate(route);
+        locator.service(second);
+
+        assertThrows(HttpException.class, () -> locate(route));
+
         assertThat(first.routingCount.get(), is(1));
         assertThat(second.routingCount.get(), is(0));
     }


### PR DESCRIPTION
Resolves #12362

This is a source-faithful carry-forward of the OpenAPI service-route authorization fix from 4.x commit [`4114b24f`](https://github.com/helidon-io/helidon/commit/4114b24f4641ad77e622ad1caffcd116db90af7e) to main. It preserves the source behavior while adapting the implementation to the current `HttpServiceLocator` lifecycle and cache model; it is not a broader cleanup or an attempt to resolve unrelated findings.

Applies the authorization requirement to direct, nested, header-predicate, and located routes registered by `OpenApiService`. The current-line locator adaptation uses weak identity memoization while WebServer remains the sole cache-capacity owner, preserving lifecycle cleanup, fail-closed stop behavior, and allocation-free warm cache hits.

The actual OpenAPI UI integration coverage is tracked by helidon-io/helidon-extensions#121.
