### PR TITLE
Accept legacy const sampler type configuration (27.x)

### DIFF
--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -381,6 +381,8 @@ public final class Option {
      * Allowed values for this option.
      * The allowed value is always configured as a string, and is compared to {@link java.lang.String#valueOf(Object)} of the
      * value.
+     * For enum options, an allowed value that matches the lower-case {@link java.lang.Enum#name()} is also accepted. The
+     * explicitly declared allowed value is retained in generated configuration metadata.
      */
     @Target(ElementType.METHOD)
     @Inherited

--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -397,7 +397,9 @@ public final class Option {
     }
 
     /**
-     * Can be used to define a list of possible values of an option.
+     * Defines one possible value for an option.
+     * For enum options, an allowed value that matches the lower-case {@link java.lang.Enum#name()} is also accepted. The
+     * explicitly declared allowed value is retained in generated configuration metadata.
      */
     @Target(ElementType.METHOD)
     @Inherited

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -133,6 +133,10 @@ final class GenerateAbstractBuilder {
                      options,
                      true);
 
+            if (hasAllowedValues(options)) {
+                isAllowedValueMethod(builder);
+            }
+
             // before the builder class is finished, we also generate a protected implementation
             generatePrototypeImpl(extensions, builder, prototypeInfo, options, typeArguments, typeArgumentNames);
 
@@ -1095,7 +1099,8 @@ final class GenerateAbstractBuilder {
                 .addContentLine("}");
     }
 
-    private static void validatePrototypeMethod(List<BuilderCodegenExtension> extensions, InnerClass.Builder classBuilder,
+    private static void validatePrototypeMethod(List<BuilderCodegenExtension> extensions,
+                                                InnerClass.Builder classBuilder,
                                                 PrototypeInfo prototypeInfo,
                                                 List<OptionHandler> options) {
 
@@ -1144,9 +1149,8 @@ final class GenerateAbstractBuilder {
                 if (declaredType.isList() || declaredType.isSet()) {
                     String single = "single" + capitalize(propertyName);
                     validateBuilder.addContentLine("for (var " + single + " : " + propertyName + ") {");
-                    validateBuilder.addContentLine("if (!" + allowedValuesConstant + ".contains(String.valueOf(" + single + "))"
-                                                           + ") {")
-                            .addContent("collector.fatal(getClass(), \"Property \\\"")
+                    validateBuilder.addContentLine("if (!isAllowedValue(" + allowedValuesConstant + ", " + single + ")) {");
+                    validateBuilder.addContent("collector.fatal(getClass(), \"Property \\\"")
                             .addContent(propertyName)
                             .addContent("\\\" contains value that is not within allowed values. Configured: \\\"\" + "
                                                 + single + " + \"\\\"")
@@ -1158,9 +1162,8 @@ final class GenerateAbstractBuilder {
                     if (!declaredType.primitive()) {
                         validateBuilder.addContent(propertyName + " != null && ");
                     }
-                    validateBuilder.addContentLine("!" + allowedValuesConstant + ".contains(String.valueOf(" + propertyName
-                                                           + "))) {")
-                            .addContent("collector.fatal(getClass(), \"Property \\\"")
+                    validateBuilder.addContentLine("!isAllowedValue(" + allowedValuesConstant + ", " + propertyName + ")) {");
+                    validateBuilder.addContent("collector.fatal(getClass(), \"Property \\\"")
                             .addContent(propertyName)
                             .addContent("\\\" value is not within allowed values. Configured: \\\"\" + " + propertyName + " + "
                                                 + "\"\\\"")
@@ -1170,6 +1173,28 @@ final class GenerateAbstractBuilder {
             }
         }
         validateBuilder.addContentLine("collector.collect().checkValid();");
+    }
+
+    private static void isAllowedValueMethod(InnerClass.Builder classBuilder) {
+        classBuilder.addMethod(method -> method
+                .name("isAllowedValue")
+                .accessModifier(AccessModifier.PRIVATE)
+                .returnType(TypeName.create(boolean.class))
+                .addParameter(param -> param.name("allowedValues")
+                        .type(TypeName.builder(SET)
+                                      .addTypeArgument(TypeNames.STRING)
+                                      .build()))
+                .addParameter(param -> param.name("value")
+                        .type(Object.class))
+                .addContentLine("if (allowedValues.contains(String.valueOf(value))) {")
+                .addContentLine("return true;")
+                .addContentLine("}")
+                .addContentLine("if (!(value instanceof Enum<?> enumValue)) {")
+                .addContentLine("return false;")
+                .addContentLine("}")
+                .addContent("return allowedValues.contains(enumValue.name().toLowerCase(")
+                .addContent(Locale.class)
+                .addContentLine(".ROOT));"));
     }
 
     private static void generatePrototypeImpl(List<BuilderCodegenExtension> extensions,

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -390,6 +390,9 @@ class SchemaGenerator {
         if (optionInfo.prototypedBy().isPresent()) {
             return optionInfo.prototypedBy().get();
         }
+        if (!optionInfo.allowedValues().isEmpty()) {
+            return typeName.boxed();
+        }
 
         // check configured factory method
         var configuredDeclaredTypeName = optionInfo.configured()

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -240,14 +240,18 @@ class SchemaGenerator {
         if (typeInfo == null || typeInfo.kind() != ElementKind.ENUM) {
             return defaultValues;
         }
+        var allowedValues = optionInfo.allowedValues()
+                .stream()
+                .map(OptionAllowedValue::value)
+                .toList();
         return defaultValues.stream()
-                .map(defaultValue -> optionInfo.allowedValues()
-                        .stream()
-                        .map(OptionAllowedValue::value)
-                        .filter(value -> value.equals(value.toLowerCase(Locale.ROOT)))
-                        .filter(value -> value.equals(defaultValue.toLowerCase(Locale.ROOT)))
-                        .findFirst()
-                        .orElse(defaultValue))
+                .map(defaultValue -> allowedValues.contains(defaultValue)
+                        ? defaultValue
+                        : allowedValues.stream()
+                                .filter(value -> value.equals(value.toLowerCase(Locale.ROOT)))
+                                .filter(value -> value.equals(defaultValue.toLowerCase(Locale.ROOT)))
+                                .findFirst()
+                                .orElse(defaultValue))
                 .toList();
     }
 

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/SchemaGenerator.java
@@ -19,6 +19,7 @@ import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 
 import io.helidon.builder.api.Option;
 import io.helidon.codegen.CodegenContext;
@@ -187,7 +188,7 @@ class SchemaGenerator {
             builder.property("kind", enumValue);
         }
 
-        var defaultValue = defaultValue(optionInfo);
+        var defaultValue = defaultValue(typeInfo, optionInfo);
         if (defaultValue != null) {
             builder.property("value", defaultValue);
         }
@@ -211,7 +212,7 @@ class SchemaGenerator {
         return builder.build();
     }
 
-    private String defaultValue(OptionInfo optionInfo) {
+    private String defaultValue(TypeInfo typeInfo, OptionInfo optionInfo) {
         var key = optionInfo.configured().orElseThrow().configKey();
         if (key.endsWith("-discover-services")) {
             return optionInfo.interfaceMethod()
@@ -227,9 +228,27 @@ class SchemaGenerator {
                             .or(() -> it.findAnnotation(Types.OPTION_DEFAULT_LONG))
                             .or(() -> it.findAnnotation(Types.OPTION_DEFAULT_DOUBLE))
                             .flatMap(Annotation::stringValues))
+                    .map(defaultValues -> enumDefaultValues(typeInfo, optionInfo, defaultValues))
                     .map(it -> String.join(", ", it))
                     .orElse(null);
         }
+    }
+
+    private List<String> enumDefaultValues(TypeInfo typeInfo,
+                                           OptionInfo optionInfo,
+                                           List<String> defaultValues) {
+        if (typeInfo == null || typeInfo.kind() != ElementKind.ENUM) {
+            return defaultValues;
+        }
+        return defaultValues.stream()
+                .map(defaultValue -> optionInfo.allowedValues()
+                        .stream()
+                        .map(OptionAllowedValue::value)
+                        .filter(value -> value.equals(value.toLowerCase(Locale.ROOT)))
+                        .filter(value -> value.equals(defaultValue.toLowerCase(Locale.ROOT)))
+                        .findFirst()
+                        .orElse(defaultValue))
+                .toList();
     }
 
     private List<Annotation> allowedValues(TypeInfo typeInfo, OptionInfo optionInfo) {

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/AllowedValueEnum.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/AllowedValueEnum.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects;
+
+/**
+ * Enum used to test allowed value validation.
+ */
+public enum AllowedValueEnum {
+    /**
+     * First allowed value, represented by its lower-case name.
+     */
+    GOOD_1,
+
+    /**
+     * Second allowed value, represented by its exact name.
+     */
+    GOOD_2,
+
+    /**
+     * Value excluded from the allowed values.
+     */
+    BAD
+}

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/AllowedValuesBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/AllowedValuesBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,4 +38,25 @@ interface AllowedValuesBlueprint {
     @Option.Singular("restrictedOptionToList")
     @Option.Configured
     List<String> restrictedOptionsList();
+
+    /**
+     * Restricted enum option.
+     *
+     * @return restricted enum
+     */
+    @Option.AllowedValue(value = "good_1", description = "First good value")
+    @Option.AllowedValue(value = "GOOD_2", description = "Second good value")
+    @Option.Configured
+    Optional<AllowedValueEnum> restrictedEnum();
+
+    /**
+     * Restricted enum list option.
+     *
+     * @return restricted enum list
+     */
+    @Option.AllowedValue(value = "good_1", description = "First good value")
+    @Option.AllowedValue(value = "GOOD_2", description = "Second good value")
+    @Option.Singular("restrictedEnumToList")
+    @Option.Configured
+    List<AllowedValueEnum> restrictedEnums();
 }

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/AllowedValuesTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/AllowedValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.builder.test;
 
+import io.helidon.builder.test.testsubjects.AllowedValueEnum;
 import io.helidon.builder.test.testsubjects.AllowedValues;
 import io.helidon.common.Errors;
 
@@ -91,6 +92,66 @@ class AllowedValuesTest {
         // we use a set, may be different order
         assertThat(message, containsString("GOOD_1"));
         assertThat(message, containsString("GOOD_2"));
+    }
+
+    @Test
+    void testLowerCaseEnumValueAllowed() {
+        AllowedValues allowedValues = AllowedValues.builder()
+                .restrictedEnum(AllowedValueEnum.GOOD_1)
+                .build();
+
+        assertThat(allowedValues.restrictedEnum(), optionalValue(is(AllowedValueEnum.GOOD_1)));
+    }
+
+    @Test
+    void testExactEnumValueAllowed() {
+        AllowedValues allowedValues = AllowedValues.builder()
+                .restrictedEnum(AllowedValueEnum.GOOD_2)
+                .build();
+
+        assertThat(allowedValues.restrictedEnum(), optionalValue(is(AllowedValueEnum.GOOD_2)));
+    }
+
+    @Test
+    void testEnumValueNotAllowed() {
+        var thrown = assertThrows(Errors.ErrorMessagesException.class, () -> AllowedValues.builder()
+                .restrictedEnum(AllowedValueEnum.BAD)
+                .build());
+
+        String message = thrown.getMessage();
+        assertThat(message,
+                   containsString("Property \"restrictedEnum\" value is not within allowed values. "
+                                          + "Configured: \"BAD\", expected one of: \""));
+        assertThat(message, containsString("good_1"));
+        assertThat(message, containsString("GOOD_2"));
+    }
+
+    @Test
+    void testLowerCaseEnumListValueAllowed() {
+        AllowedValues allowedValues = AllowedValues.builder()
+                .addRestrictedEnumToList(AllowedValueEnum.GOOD_1)
+                .addRestrictedEnumToList(AllowedValueEnum.GOOD_2)
+                .build();
+
+        assertThat(allowedValues.restrictedEnums(), hasItems(AllowedValueEnum.GOOD_1, AllowedValueEnum.GOOD_2));
+    }
+
+    @Test
+    void testEnumListValueNotAllowed() {
+        var thrown = assertThrows(Errors.ErrorMessagesException.class, () -> AllowedValues.builder()
+                .addRestrictedEnumToList(AllowedValueEnum.BAD)
+                .build());
+
+        assertThat(thrown.getMessage(),
+                   containsString("Property \"restrictedEnums\" contains value that is not within allowed values. "
+                                          + "Configured: \"BAD\", expected one of: \""));
+    }
+
+    @Test
+    void testStringAllowedValuesRemainCaseSensitive() {
+        assertThrows(Errors.ErrorMessagesException.class, () -> AllowedValues.builder()
+                .restrictedOptions("good_1")
+                .build());
     }
 
 }

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -1134,6 +1134,7 @@ class SchemaGeneratorTest {
                              * @return option1
                              */
                             @Option.Configured
+                            @Option.Default("MODE1")
                             @Option.AllowedValue(value = "mode1", description = "Mode1")
                             @Option.AllowedValue(value = "MODE2", description = "Mode2")
                             AcmeMode option1();
@@ -1157,7 +1158,7 @@ class SchemaGeneratorTest {
                             key = "option1",
                             description = "Option1",
                             type = AcmeMode.class,
-                            required = true,
+                            value = "mode1",
                             allowedValues = {
                                 @ConfiguredValue(value = "mode1", description = "Mode1"),
                                 @ConfiguredValue(value = "MODE2", description = "Mode2")

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -1100,6 +1100,23 @@ class SchemaGeneratorTest {
                             MODE2,
                         }
                         """)
+                .addSource("AcmeCaseMode.java", """
+                        package com.acme;
+
+                        /**
+                         * ACME case-distinct mode.
+                         */
+                        enum AcmeCaseMode {
+                            /**
+                             * Upper-case mode.
+                             */
+                            MODE,
+                            /**
+                             * Lower-case mode.
+                             */
+                            mode,
+                        }
+                        """)
                 .addSource("AcmeConfigSupport.java", """
                         package com.acme;
 
@@ -1111,6 +1128,11 @@ class SchemaGeneratorTest {
                             @Prototype.ConfigFactoryMethod("option1")
                             static AcmeMode createMode(Config config) {
                                 return config.as(AcmeMode.class).get();
+                            }
+
+                            @Prototype.ConfigFactoryMethod("option2")
+                            static AcmeCaseMode createCaseMode(Config config) {
+                                return config.as(AcmeCaseMode.class).get();
                             }
                         }
                         """)
@@ -1138,6 +1160,17 @@ class SchemaGeneratorTest {
                             @Option.AllowedValue(value = "mode1", description = "Mode1")
                             @Option.AllowedValue(value = "MODE2", description = "Mode2")
                             AcmeMode option1();
+
+                            /**
+                             * Option2.
+                             *
+                             * @return option2
+                             */
+                            @Option.Configured
+                            @Option.Default("MODE")
+                            @Option.AllowedValue(value = "mode", description = "Lower-case mode")
+                            @Option.AllowedValue(value = "MODE", description = "Upper-case mode")
+                            AcmeCaseMode option2();
                         }
                         """)
                 .build()
@@ -1162,6 +1195,15 @@ class SchemaGeneratorTest {
                             allowedValues = {
                                 @ConfiguredValue(value = "mode1", description = "Mode1"),
                                 @ConfiguredValue(value = "MODE2", description = "Mode2")
+                            }),
+                        @ConfiguredOption(
+                            key = "option2",
+                            description = "Option2",
+                            type = AcmeCaseMode.class,
+                            value = "MODE",
+                            allowedValues = {
+                                @ConfiguredValue(value = "mode", description = "Lower-case mode"),
+                                @ConfiguredValue(value = "MODE", description = "Upper-case mode")
                             })
                     })
                 //...

--- a/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
+++ b/builder/tests/configured/src/test/java/io/helidon/builder/tests/configured/SchemaGeneratorTest.java
@@ -1077,6 +1077,100 @@ class SchemaGeneratorTest {
     }
 
     @Test
+    void testExplicitEnumAllowedValues() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .options(OPTS)
+                .addSource("AcmeMode.java", """
+                        package com.acme;
+
+                        /**
+                         * ACME mode.
+                         */
+                        enum AcmeMode {
+                            /**
+                             * Mode1.
+                             */
+                            MODE1,
+                            /**
+                             * Mode2.
+                             */
+                            MODE2,
+                        }
+                        """)
+                .addSource("AcmeConfigSupport.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+                        import io.helidon.config.Config;
+
+                        class AcmeConfigSupport {
+
+                            @Prototype.ConfigFactoryMethod("option1")
+                            static AcmeMode createMode(Config config) {
+                                return config.as(AcmeMode.class).get();
+                            }
+                        }
+                        """)
+                .addSource("AcmeConfigBlueprint.java", """
+                        package com.acme;
+
+                        import io.helidon.builder.api.Prototype;
+                        import io.helidon.builder.api.Option;
+
+                        /**
+                         * ACME config.
+                         */
+                        @Prototype.Blueprint
+                        @Prototype.Configured
+                        @Prototype.CustomMethods(AcmeConfigSupport.class)
+                        interface AcmeConfigBlueprint {
+
+                            /**
+                             * Option1.
+                             *
+                             * @return option1
+                             */
+                            @Option.Configured
+                            @Option.AllowedValue(value = "mode1", description = "Mode1")
+                            @Option.AllowedValue(value = "MODE2", description = "Mode2")
+                            AcmeMode option1();
+                        }
+                        """)
+                .build()
+                .compile();
+        assertThat(result.success(), is(true));
+        var schema = result.sourceOutput().resolve("com/acme/AcmeConfig.java");
+        assertThat(Files.exists(schema), is(true));
+
+        var actual = Files.readString(schema);
+        assertThat(actual, matches("""
+                //...
+                package com.acme;
+                //...
+                @Configured(
+                    description = "ACME config",
+                    options = {
+                        @ConfiguredOption(
+                            key = "option1",
+                            description = "Option1",
+                            type = AcmeMode.class,
+                            required = true,
+                            allowedValues = {
+                                @ConfiguredValue(value = "mode1", description = "Mode1"),
+                                @ConfiguredValue(value = "MODE2", description = "Mode2")
+                            })
+                    })
+                //...
+                public interface AcmeConfig extends AcmeConfigBlueprint, Prototype.Api {
+                //...
+                }
+                """));
+    }
+
+    @Test
     void testPrefixWithConstant() throws IOException {
         var compiler = TestCompiler.builder()
                 .currentRelease()

--- a/docs/config/io.helidon.tracing.ExtendedTracerConfig.md
+++ b/docs/config/io.helidon.tracing.ExtendedTracerConfig.md
@@ -92,7 +92,7 @@ Common settings for tracers including settings for span processors and secure cl
 <code>Sampler<wbr>Type</code>
 </td>
 <td>
-<code>CONSTANT</code>
+<code>constant</code>
 </td>
 <td>Type of sampler for collecting spans</td>
 </tr>

--- a/docs/config/io.helidon.tracing.SamplerType.md
+++ b/docs/config/io.helidon.tracing.SamplerType.md
@@ -24,7 +24,7 @@ This type is an enumeration.
 </tr>
 <tr>
 <td><code>ratio</code></td>
-<td>Sampling of a proportion of spans</td>
+<td>Sampling of a proportion [0.0, 1.0] of spans</td>
 </tr>
 </tbody>
 </table>

--- a/docs/config/io.helidon.tracing.SamplerType.md
+++ b/docs/config/io.helidon.tracing.SamplerType.md
@@ -15,12 +15,16 @@ This type is an enumeration.
 </thead>
 <tbody>
 <tr>
-<td><code>CONSTANT</code></td>
+<td><code>constant</code></td>
 <td>Sampling of every span</td>
 </tr>
 <tr>
-<td><code>RATIO</code></td>
-<td>Sampling of a proportion [0.0, 1.0] of spans</td>
+<td><code>const</code></td>
+<td>Deprecated. Use constant instead</td>
+</tr>
+<tr>
+<td><code>ratio</code></td>
+<td>Sampling of a proportion of spans</td>
 </tr>
 </tbody>
 </table>

--- a/docs/config/io.helidon.tracing.providers.opentelemetry.OpenTelemetryTracer.md
+++ b/docs/config/io.helidon.tracing.providers.opentelemetry.OpenTelemetryTracer.md
@@ -92,7 +92,7 @@ Settings for OpenTelemetry tracer configuration under the <code>Open<wbr>Telemet
 <code>Sampler<wbr>Type</code>
 </td>
 <td>
-<code>CONSTANT</code>
+<code>constant</code>
 </td>
 <td>Type of sampler for collecting spans</td>
 </tr>

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -165,7 +165,7 @@ tracing:
   tags:
     env: development
   enabled: true
-  sampler-type: "const"
+  sampler-type: "constant"
   sampler-param: 1
   log-spans: true
   propagation: b3
@@ -369,7 +369,7 @@ tracing:
   tags:
     env: development
   enabled: true
-  sampler-type: "const"
+  sampler-type: "constant"
   sampler-param: 1
   log-spans: true
   propagation: b3

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
@@ -19,25 +19,18 @@ package io.helidon.tracing.providers.opentelemetry;
 import java.util.List;
 import java.util.Map;
 
-import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-import io.helidon.tracing.Span;
-import io.helidon.tracing.SpanProcessorType;
+import io.helidon.tracing.SamplerType;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -181,6 +174,27 @@ class TestOtelTracingConfig {
         assertThat("OpenTelemetry",
                    tracer.prototype().openTelemetry().toString(),
                    containsString("spanExporter=OtlpHttpSpanExporter"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"constant", "const", "CONSTANT", "CONST"})
+    void testConstantSamplerTypeCompatibility(String samplerType) {
+        var configSettings = """
+                tracing:
+                  service: tracing-test
+                  global: false
+                  sampler-type: %s
+                """.formatted(samplerType);
+        Config config = Config.just(ConfigSources.create(configSettings, MediaTypes.APPLICATION_YAML));
+
+        OpenTelemetryTracer tracer = OpenTelemetryTracer.builder()
+                .config(config.get("tracing"))
+                .build();
+
+        assertThat("Sampler type", tracer.prototype().samplerType(), equalTo(SamplerType.CONSTANT));
+        assertThat("OpenTelemetry",
+                   tracer.prototype().openTelemetry().toString(),
+                   containsString("sampler=AlwaysOnSampler"));
     }
 
 

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestOtelTracingConfig.java
@@ -18,10 +18,15 @@ package io.helidon.tracing.providers.opentelemetry;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.common.testing.junit5.InMemoryLoggingHandler;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigMappingException;
 import io.helidon.config.ConfigSources;
+import io.helidon.tracing.ExtendedTracerConfig;
 import io.helidon.tracing.SamplerType;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -38,6 +43,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestOtelTracingConfig {
 
@@ -187,14 +193,67 @@ class TestOtelTracingConfig {
                 """.formatted(samplerType);
         Config config = Config.just(ConfigSources.create(configSettings, MediaTypes.APPLICATION_YAML));
 
-        OpenTelemetryTracer tracer = OpenTelemetryTracer.builder()
-                .config(config.get("tracing"))
+        Logger logger = Logger.getLogger("io.helidon.tracing.ExtendedTracerConfigBlueprintSupport");
+        try (var loggingHandler = InMemoryLoggingHandler.create(logger)) {
+            OpenTelemetryTracer tracer = OpenTelemetryTracer.builder()
+                    .config(config.get("tracing"))
+                    .build();
+
+            assertThat("Sampler type", tracer.prototype().samplerType(), equalTo(SamplerType.CONSTANT));
+            assertThat("OpenTelemetry",
+                       tracer.prototype().openTelemetry().toString(),
+                       containsString("sampler=AlwaysOnSampler"));
+
+            long deprecationWarnings = loggingHandler.logRecords()
+                    .stream()
+                    .filter(record -> record.getLevel() == Level.WARNING)
+                    .filter(record -> record.getMessage().contains("const"))
+                    .filter(record -> record.getMessage().contains("constant"))
+                    .count();
+            assertThat("Deprecation warning count",
+                       deprecationWarnings,
+                       equalTo(samplerType.equalsIgnoreCase("const") ? 1L : 0L));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ratio", "RATIO"})
+    void testRatioSamplerType(String samplerType) {
+        Config config = Config.builder(ConfigSources.create(Map.of(
+                        "service", "tracing-test",
+                        "sampler-type", samplerType,
+                        "sampler-param", "0.5")))
                 .build();
 
-        assertThat("Sampler type", tracer.prototype().samplerType(), equalTo(SamplerType.CONSTANT));
-        assertThat("OpenTelemetry",
-                   tracer.prototype().openTelemetry().toString(),
-                   containsString("sampler=AlwaysOnSampler"));
+        ExtendedTracerConfig tracingConfig = ExtendedTracerConfig.create(config);
+
+        assertThat("Sampler type", tracingConfig.samplerType(), equalTo(SamplerType.RATIO));
+        assertThat("Sampler parameter", tracingConfig.samplerParam(), equalTo(0.5));
+    }
+
+    @Test
+    void testCustomSamplerTypeMapperHasPriority() {
+        Config config = Config.builder(ConfigSources.create(Map.of(
+                        "service", "tracing-test",
+                        "sampler-type", "custom")))
+                .addMapper(SamplerType.class, _ -> SamplerType.RATIO)
+                .build();
+
+        ExtendedTracerConfig tracingConfig = ExtendedTracerConfig.create(config);
+
+        assertThat("Sampler type", tracingConfig.samplerType(), equalTo(SamplerType.RATIO));
+    }
+
+    @Test
+    void testSamplerTypeMustBeLeaf() {
+        Config config = Config.just(ConfigSources.create(Map.of(
+                "service", "tracing-test",
+                "sampler-type", "ratio",
+                "sampler-type.param", "0.0")));
+
+        var exception = assertThrows(ConfigMappingException.class, () -> ExtendedTracerConfig.create(config));
+
+        assertThat(exception.getMessage(), containsString("config node must be a leaf but is not"));
     }
 
 

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
@@ -29,6 +29,7 @@ import io.helidon.common.configurable.Resource;
  */
 @Prototype.Blueprint
 @Prototype.Configured
+@Prototype.CustomMethods(ExtendedTracerConfigBlueprintSupport.class)
 interface ExtendedTracerConfigBlueprint {
 
     /**

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
@@ -217,7 +217,7 @@ interface ExtendedTracerConfigBlueprint {
     @Option.Default("CONSTANT")
     @Option.AllowedValue(value = "constant", description = "Sampling of every span")
     @Option.AllowedValue(value = "const", description = "Deprecated. Use constant instead")
-    @Option.AllowedValue(value = "ratio", description = "Sampling of a proportion of spans")
+    @Option.AllowedValue(value = "ratio", description = "Sampling of a proportion [0.0, 1.0] of spans")
     SamplerType samplerType();
 
     /**

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprint.java
@@ -215,6 +215,9 @@ interface ExtendedTracerConfigBlueprint {
      */
     @Option.Configured
     @Option.Default("CONSTANT")
+    @Option.AllowedValue(value = "constant", description = "Sampling of every span")
+    @Option.AllowedValue(value = "const", description = "Deprecated. Use constant instead")
+    @Option.AllowedValue(value = "ratio", description = "Sampling of a proportion of spans")
     SamplerType samplerType();
 
     /**

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing;
+
+import java.util.Locale;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.config.Config;
+
+class ExtendedTracerConfigBlueprintSupport {
+
+    private ExtendedTracerConfigBlueprintSupport() {
+    }
+
+    @Prototype.ConfigFactoryMethod("samplerType")
+    static SamplerType createSamplerType(Config config) {
+        String samplerType = config.asString().get().toUpperCase(Locale.ROOT);
+        samplerType = "CONST".equals(samplerType) ? SamplerType.CONSTANT.name() : samplerType;
+        return SamplerType.valueOf(samplerType);
+    }
+}

--- a/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/ExtendedTracerConfigBlueprintSupport.java
@@ -16,20 +16,27 @@
 
 package io.helidon.tracing;
 
-import java.util.Locale;
-
 import io.helidon.builder.api.Prototype;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigMappingException;
 
 class ExtendedTracerConfigBlueprintSupport {
+    private static final System.Logger LOGGER = System.getLogger(ExtendedTracerConfigBlueprintSupport.class.getName());
 
     private ExtendedTracerConfigBlueprintSupport() {
     }
 
     @Prototype.ConfigFactoryMethod("samplerType")
     static SamplerType createSamplerType(Config config) {
-        String samplerType = config.asString().get().toUpperCase(Locale.ROOT);
-        samplerType = "CONST".equals(samplerType) ? SamplerType.CONSTANT.name() : samplerType;
-        return SamplerType.valueOf(samplerType);
+        try {
+            return config.as(SamplerType.class).get();
+        } catch (ConfigMappingException e) {
+            if (config.isLeaf() && "const".equalsIgnoreCase(config.asString().get())) {
+                LOGGER.log(System.Logger.Level.WARNING,
+                           "Sampler type \"const\" is deprecated; use \"constant\" instead");
+                return SamplerType.CONSTANT;
+            }
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
Resolves #12367

This is a source-faithful carry-forward of [4.x PR #11988](https://github.com/helidon-io/helidon/pull/11988) and commit [`49edbfa0`](https://github.com/helidon-io/helidon/commit/49edbfa0da4728c5d25ebeab8dda242cd2ffc5d4) to `main`.

Adds a configuration factory so the legacy `const` sampler type maps to `SamplerType.CONSTANT` without adding another public enum value. Covers lowercase and uppercase `const` and `constant` configurations.

This carry-forward intentionally preserves inherited source behavior, including existing invalid-value diagnostics and generated config-metadata representation; it is not an attempt to resolve those findings.
