### PR TITLE
Guard null context class loader lookups (27.x)

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ final class ResourceUtil {
      */
     static InputStream toIs(String resPath) {
         Objects.requireNonNull(resPath, "Resource path must not be null");
-        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resPath);
+        InputStream is = contextClassLoader().getResourceAsStream(resPath);
         Objects.requireNonNull(is, "Resource path does not exist: " + resPath);
         return is;
     }
@@ -104,5 +104,10 @@ final class ResourceUtil {
         } catch (IOException e) {
             throw new ResourceException("Failed to open stream to uri: " + uri, e);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ResourceUtil.class.getClassLoader() : classLoader;
     }
 }

--- a/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
+++ b/common/features/features/src/main/java/io/helidon/common/features/HelidonFeatures.java
@@ -182,7 +182,7 @@ public final class HelidonFeatures {
             return;
         }
 
-        scan(Thread.currentThread().getContextClassLoader());
+        scan(contextClassLoader());
 
         Set<FeatureMetadata> features = FEATURES.get(currentFlavor);
         if (null == features) {
@@ -402,6 +402,11 @@ public final class HelidonFeatures {
             }
             printDetails(actualName, childNode, level + 1);
         });
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? HelidonFeatures.class.getClassLoader() : classLoader;
     }
 
     static final class Node {

--- a/config/config/src/main/java/io/helidon/config/ClasspathConfigSource.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,12 +223,15 @@ public class ClasspathConfigSource extends AbstractConfigSource implements Confi
     private static Enumeration<URL> findAllResources(String resource) {
         String cleaned = resource.startsWith("/") ? resource.substring(1) : resource;
         try {
-            return Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResources(cleaned);
+            return contextClassLoader().getResources(cleaned);
         } catch (IOException e) {
             throw new ConfigException("Could not access config resource " + resource, e);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathConfigSource.class.getClassLoader() : classLoader;
     }
 
     /**
@@ -308,9 +311,7 @@ public class ClasspathConfigSource extends AbstractConfigSource implements Confi
             this.resource = resource;
 
             // the URL may not exist, and that is fine - maybe we are an optional config source
-            this.url = Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResource(cleaned);
+            this.url = contextClassLoader().getResource(cleaned);
 
             return this;
         }

--- a/config/config/src/main/java/io/helidon/config/ClasspathOverrideSource.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathOverrideSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,11 @@ public class ClasspathOverrideSource extends AbstractSource implements OverrideS
         return new Builder();
     }
 
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathOverrideSource.class.getClassLoader() : classLoader;
+    }
+
     /**
      * Classpath OverrideSource Builder.
      * <p>
@@ -141,9 +146,7 @@ public class ClasspathOverrideSource extends AbstractSource implements OverrideS
             this.resource = resource;
 
             // the URL may not exist, and that is fine - maybe we are an optional config source
-            this.url = Thread.currentThread()
-                    .getContextClassLoader()
-                    .getResource(cleaned);
+            this.url = contextClassLoader().getResource(cleaned);
 
             return this;
         }

--- a/config/config/src/main/java/io/helidon/config/ClasspathSourceHelper.java
+++ b/config/config/src/main/java/io/helidon/config/ClasspathSourceHelper.java
@@ -54,7 +54,7 @@ final class ClasspathSourceHelper {
     }
 
     static Path resourcePath(String resourceName) throws URISyntaxException {
-        URL resourceUrl = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        URL resourceUrl = contextClassLoader().getResource(resourceName);
         if (resourceUrl != null) {
             // this can only work if we are using a file based classloader (which may not be always the case)
             // we may load classes from http, or from specific loaders, such as in Graal native image
@@ -67,6 +67,11 @@ final class ClasspathSourceHelper {
         } else {
             return null;
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ClasspathSourceHelper.class.getClassLoader() : classLoader;
     }
 
 }

--- a/config/config/src/main/java/io/helidon/config/ConfigSources.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigSources.java
@@ -238,7 +238,7 @@ public final class ConfigSources {
 
         List<UrlConfigSource.Builder> result = new LinkedList<>();
         try {
-            Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(resource);
+            Enumeration<URL> resources = contextClassLoader().getResources(resource);
             while (resources.hasMoreElements()) {
                 URL url = resources.nextElement();
                 result.add(url(url));
@@ -293,6 +293,11 @@ public final class ConfigSources {
      */
     public static UrlConfigSource.Builder url(URL url) {
         return UrlConfigSource.builder().url(url);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? ConfigSources.class.getClassLoader() : classLoader;
     }
 
     /**

--- a/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
+++ b/config/config/src/main/java/io/helidon/config/MetaConfigFinder.java
@@ -95,7 +95,7 @@ final class MetaConfigFinder {
 
     static Optional<ConfigSource> findConfigSource(Function<MediaType, Boolean> supportedMediaType,
                                                    List<String> supportedSuffixes) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         return findSource(supportedMediaType, cl, CONFIG_PREFIX, "config source", supportedSuffixes);
     }
 
@@ -139,7 +139,7 @@ final class MetaConfigFinder {
 
     private static Optional<ConfigSource> findMetaConfigSource(Function<MediaType, Boolean> supportedMediaType,
                                                                List<String> supportedSuffixes) {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = contextClassLoader();
         Optional<ConfigSource> source;
 
         // check if meta configuration is configured using system property
@@ -374,5 +374,10 @@ final class MetaConfigFinder {
             return Optional.of(ConfigSources.classpath(name).build());
         }
         return Optional.empty();
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? MetaConfigFinder.class.getClassLoader() : classLoader;
     }
 }

--- a/config/config/src/test/java/io/helidon/config/ClasspathConfigSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/ClasspathConfigSourceTest.java
@@ -109,4 +109,22 @@ public class ClasspathConfigSourceTest {
 
         assertThat(configSource, notNullValue());
     }
+
+    @Test
+    public void testLoadWithNullContextClassLoader() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            ClasspathConfigSource configSource = ConfigSources.classpath("logging.properties")
+                    .optional()
+                    .build();
+
+            assertThat(configSource.load().get().mediaType(),
+                       optionalValue(is(MediaTypes.TEXT_PROPERTIES)));
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
 }

--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class JulProvider implements LoggingProvider {
             logConfigStream = new BufferedInputStream(Files.newInputStream(path));
             source = "file: " + path.toAbsolutePath();
         } else {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ClassLoader cl = contextClassLoader();
 
             // check if there is a logging-test.properties first (we are running within a unit test)
             InputStream resourceStream = classPath(TEST_LOGGING_FILE);
@@ -165,5 +165,10 @@ public class JulProvider implements LoggingProvider {
 
     private static InputStream classPath(String loggingFile) {
         return JulProvider.class.getResourceAsStream("/" + loggingFile);
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return cl == null ? JulProvider.class.getClassLoader() : cl;
     }
 }

--- a/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
+++ b/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
@@ -103,14 +103,6 @@ public final class AnnotationFactory {
                                                       new AnnotationInvocationHandler(annotationType, annotation)));
     }
 
-    private static ClassLoader classLoader() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        if (loader == null) {
-            return loader;
-        }
-        return AnnotationFactory.class.getClassLoader();
-    }
-
     // basically the same semantics as in `AptAnnotationFactory` (and scan based annotation factory)
     private static Optional<Annotation> createAnnotation(java.lang.annotation.Annotation annotation,
                                                          Set<TypeName> processedTypes) {
@@ -227,6 +219,14 @@ public final class AnnotationFactory {
             return result;
         }
         throw new IllegalArgumentException("Unknown primitive type: " + componentType.getName());
+    }
+
+    private static ClassLoader classLoader() {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            return AnnotationFactory.class.getClassLoader();
+        }
+        return loader;
     }
 
     private static class AnnotationInvocationHandler implements InvocationHandler {

--- a/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
+++ b/metadata/reflection/src/main/java/io/helidon/metadata/reflection/AnnotationFactory.java
@@ -98,7 +98,7 @@ public final class AnnotationFactory {
         }
 
         // type is available, we can synthesize the annotation
-        return Optional.of((T) Proxy.newProxyInstance(classLoader(),
+        return Optional.of((T) Proxy.newProxyInstance(annotationType.getClassLoader(),
                                                       new Class[] {annotationType},
                                                       new AnnotationInvocationHandler(annotationType, annotation)));
     }
@@ -219,14 +219,6 @@ public final class AnnotationFactory {
             return result;
         }
         throw new IllegalArgumentException("Unknown primitive type: " + componentType.getName());
-    }
-
-    private static ClassLoader classLoader() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        if (loader == null) {
-            return AnnotationFactory.class.getClassLoader();
-        }
-        return loader;
     }
 
     private static class AnnotationInvocationHandler implements InvocationHandler {

--- a/metadata/reflection/src/test/java/io/helidon/metadata/reflection/AnnotationTest.java
+++ b/metadata/reflection/src/test/java/io/helidon/metadata/reflection/AnnotationTest.java
@@ -110,6 +110,23 @@ public class AnnotationTest {
 
     @Order(1)
     @Test
+    public void testSyntheticAnnotationWithNullContextClassLoader() {
+        Thread thread = Thread.currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(null);
+
+            Optional<MyAnnotation> synthesizedAnnotation = AnnotationFactory.synthesize(helidonAnnotation);
+
+            assertThat(synthesizedAnnotation, optionalPresent());
+            assertThat(synthesizedAnnotation.get().annotationType(), sameInstance(MyAnnotation.class));
+        } finally {
+            thread.setContextClassLoader(original);
+        }
+    }
+
+    @Order(1)
+    @Test
     public void testSyntheticAnnotationWithUnrelatedContextClassLoader() {
         Thread thread = Thread.currentThread();
         ClassLoader original = thread.getContextClassLoader();

--- a/metadata/reflection/src/test/java/io/helidon/metadata/reflection/AnnotationTest.java
+++ b/metadata/reflection/src/test/java/io/helidon/metadata/reflection/AnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,23 @@ public class AnnotationTest {
         assertThat(annotation.annotationValues("lannotation"), optionalPresent());
         assertThat(annotation.stringValues("emptyList"), optionalValue(is(List.of())));
         assertThat(annotation.stringValues("singletonList"), optionalValue(is(List.of("value"))));
+    }
+
+    @Order(1)
+    @Test
+    public void testSyntheticAnnotationWithUnrelatedContextClassLoader() {
+        Thread thread = Thread.currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(ClassLoader.getPlatformClassLoader());
+
+            Optional<MyAnnotation> synthesizedAnnotation = AnnotationFactory.synthesize(helidonAnnotation);
+
+            assertThat(synthesizedAnnotation, optionalPresent());
+            assertThat(synthesizedAnnotation.get().annotationType(), sameInstance(MyAnnotation.class));
+        } finally {
+            thread.setContextClassLoader(original);
+        }
     }
 
     @Order(2)

--- a/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
+++ b/openapi/openapi/src/main/java/io/helidon/openapi/OpenApiFeature.java
@@ -186,12 +186,17 @@ public final class OpenApiFeature implements Weighted, ServerFeature, RuntimeTyp
             if (Files.exists(file)) {
                 return Files.readString(file);
             } else {
-                try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+                try (InputStream is = contextClassLoader().getResourceAsStream(path)) {
                     return is != null ? new String(is.readAllBytes(), StandardCharsets.UTF_8) : null;
                 }
             }
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? OpenApiFeature.class.getClassLoader() : classLoader;
     }
 }

--- a/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeature.java
+++ b/webserver/static-content/src/main/java/io/helidon/webserver/staticcontent/StaticContentFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ public class StaticContentFeature implements Weighted, ServerFeature, RuntimeTyp
             defaultSockets = new HashSet<>(this.sockets);
         }
 
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader contextClassLoader = contextClassLoader();
 
         for (ClasspathHandlerConfig handlerConfig : config.classpath()) {
             if (!handlerConfig.enabled()) {
@@ -245,5 +245,10 @@ public class StaticContentFeature implements Weighted, ServerFeature, RuntimeTyp
                         .register(handlerConfig.context(), service);
             }
         }
+    }
+
+    private static ClassLoader contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return classLoader == null ? StaticContentFeature.class.getClassLoader() : classLoader;
     }
 }

--- a/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentFeatureTest.java
+++ b/webserver/static-content/src/test/java/io/helidon/webserver/staticcontent/StaticContentFeatureTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.staticcontent;
+
+import java.util.Set;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.spi.ServerFeature.ServerFeatureContext;
+import io.helidon.webserver.spi.ServerFeature.SocketBuilders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StaticContentFeatureTest {
+    @Test
+    void testSetupWithNullContextClassLoader() {
+        StaticContentFeature feature = StaticContentFeature.create(builder -> builder
+                .addClasspath(it -> it.location("web")));
+        ServerFeatureContext context = mock(ServerFeatureContext.class);
+        SocketBuilders socketBuilders = mock(SocketBuilders.class);
+        HttpRouting.Builder routing = mock(HttpRouting.Builder.class);
+
+        when(context.sockets()).thenReturn(Set.of());
+        when(context.socketExists(WebServer.DEFAULT_SOCKET_NAME)).thenReturn(true);
+        when(context.socket(WebServer.DEFAULT_SOCKET_NAME)).thenReturn(socketBuilders);
+        when(socketBuilders.httpRouting()).thenReturn(routing);
+
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            feature.setup(context);
+
+            verify(routing).register(eq("/"), any(HttpService.class));
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12370

This is a source-faithful carry-forward of the current core-owned portion of [4.x PR #12078](https://github.com/helidon-io/helidon/pull/12078) and commit [`55db2d30`](https://github.com/helidon-io/helidon/commit/55db2d3015c62521a254718d1c3d9f29fe502be9) to `main`.

Falls back to each owning class loader when a lookup requires a non-null class loader and the TCCL is null. Annotation proxy synthesis always uses the annotation type’s class loader so an unrelated non-null TCCL cannot make the annotation interface invisible. Other source semantics remain unchanged, including intentionally nullable propagation and restoration paths.

The target adaptation omits moved and removed monorepo paths and updates the static-content regression for the current feature-based implementation. The MicroProfile portion is already complete in [helidon-microprofile PR #73](https://github.com/helidon-io/helidon-microprofile/pull/73); Extensions has no remaining matching work.

This carry-forward otherwise preserves inherited source behavior and documentation and is not an attempt to resolve inherited findings.
