### PR TITLE
Upgrade PostgreSQL JDBC driver to 42.7.13 (27.x)

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -86,7 +86,7 @@
         <version.lib.opentelemetry.semconv>1.37.0</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry>1.65.0</version.lib.opentelemetry>
         <version.lib.parsson>1.1.9</version.lib.parsson>
-        <version.lib.postgresql>42.7.11</version.lib.postgresql>
+        <version.lib.postgresql>42.7.13</version.lib.postgresql>
         <version.lib.prometheus>0.16.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.17</version.lib.slf4j>


### PR DESCRIPTION
Resolves #12372

This is a source-faithful carry-forward of [4.x PR #12201](https://github.com/helidon-io/helidon/pull/12201) and commit [`11d04000`](https://github.com/helidon-io/helidon/commit/11d0400036212e7682bdbe52101259efeba311fc) to `main`.

It updates the managed `org.postgresql:postgresql` dependency from 42.7.11 to 42.7.13. Version 42.7.13 remains the latest pgJDBC release and includes the fix for [CVE-2026-54291](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-j92g-9f8w-j867) plus its follow-up fail-closed correction.

Core is the only current repository owner; MicroProfile and Extensions do not manage this dependency.

This carry-forward intentionally preserves inherited source behavior and is not an attempt to resolve findings against upstream 42.7.13. Known inherited concerns are left unchanged, including an XA batch progress-reporting regression whose correction is still unreleased, [pgjdbc#4309](https://github.com/pgjdbc/pgjdbc/issues/4309), and [pgjdbc#4349](https://github.com/pgjdbc/pgjdbc/issues/4349).
