### PR TITLE
Fix nullable cascading validation [4.x]

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
@@ -83,10 +83,14 @@ final class ValidationHelper {
     }
 
     static void addValidationOfValid(ContentBuilder<?> contentBuilder, String validatorField, String varName) {
-        contentBuilder.addContent(validatorField)
+        contentBuilder.addContent("if (")
+                .addContent(varName)
+                .addContentLine(" != null) {")
+                .addContent(validatorField)
                 .addContent(".check(validation__ctx, ")
                 .addContent(varName)
-                .addContentLine(");");
+                .addContentLine(");")
+                .addContentLine("}");
     }
 
     static ValidationContext validationContext(TypeName generatedType,

--- a/docs/se/injection/declarative.md
+++ b/docs/se/injection/declarative.md
@@ -497,6 +497,10 @@ interceptor. Type-use validation is supported on nested `Optional`,
 `Collection`, `List`, `Set`, `Map` key/value types, array component types, and
 wildcard bounds.
 
+Cascaded validation is skipped when a value annotated with `@Validation.Valid`
+is `null`. The annotation does not make the value required; add
+`@Validation.NotNull` when `null` must be rejected.
+
 #### Usage
 
 Example of a validated type

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/InterfaceMethodValidationTest.java
@@ -17,6 +17,7 @@
 package io.helidon.validation.tests.validation;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -876,6 +877,9 @@ class InterfaceMethodValidationTest {
 
         assertThat(service.validate(new ValidatedType("good_test_value", 42, new BigDecimal("1.10"))), is("ok"));
         assertThat(service.validateAll(List.of(new ValidatedType("good_test_value", 42, new BigDecimal("1.10")))), is("ok"));
+        assertThat(service.validate(null), is("ok"));
+        assertThat(service.validateAll(Collections.singletonList(null)), is("ok"));
+        assertThat(service.nullableReturn(), is((ValidatedType) null));
 
         var result = assertThrows(ValidationException.class, () -> service.validate(invalidValue));
         assertViolation(result,

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/NullableCascadingArrayType.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/NullableCascadingArrayType.java
@@ -16,15 +16,8 @@
 
 package io.helidon.validation.tests.validation;
 
-import java.util.List;
-
 import io.helidon.validation.Validation;
 
-interface ValidInterfaceConstrainedService {
-    String validate(@Validation.Valid ValidatedType value);
-
-    String validateAll(List<? super @Validation.Valid ValidatedType> values);
-
-    @Validation.Valid
-    ValidatedType nullableReturn();
+@Validation.Validated
+record NullableCascadingArrayType(@Validation.Valid ValidatedType[] array) {
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/NullableCascadingType.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/NullableCascadingType.java
@@ -17,14 +17,22 @@
 package io.helidon.validation.tests.validation;
 
 import java.util.List;
+import java.util.Map;
 
 import io.helidon.validation.Validation;
 
-interface ValidInterfaceConstrainedService {
-    String validate(@Validation.Valid ValidatedType value);
-
-    String validateAll(List<? super @Validation.Valid ValidatedType> values);
-
+@Validation.Validated
+class NullableCascadingType {
     @Validation.Valid
-    ValidatedType nullableReturn();
+    final ValidatedType direct;
+    final List<@Validation.Valid ValidatedType> list;
+    final Map<String, @Validation.Valid ValidatedType> map;
+
+    NullableCascadingType(ValidatedType direct,
+                          List<ValidatedType> list,
+                          Map<String, ValidatedType> map) {
+        this.direct = direct;
+        this.list = list;
+        this.map = map;
+    }
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
@@ -57,7 +57,7 @@ public class TypeValidationTest {
         var value = new NullableCascadingType(null,
                                               Collections.singletonList(null),
                                               map);
-        var arrayValue = new NullableCascadingArrayType(new ValidatedType[]{null});
+        var arrayValue = new NullableCascadingArrayType(new ValidatedType[] {null});
 
         assertThat(validator.validate(NullableCascadingType.class, value).valid(), is(true));
         assertThat(validator.validate(NullableCascadingArrayType.class, arrayValue).valid(), is(true));

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/TypeValidationTest.java
@@ -17,6 +17,8 @@
 package io.helidon.validation.tests.validation;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
 
 import io.helidon.testing.junit5.Testing;
 import io.helidon.validation.TypeValidation;
@@ -46,6 +48,19 @@ public class TypeValidationTest {
         response = validator.validate(ValidatedType.class, validatedType);
         assertThat(response.valid(), is(false));
         assertThat(response.message(), is("41 is less than 42"));
+    }
+
+    @Test
+    public void validateNullableCascadingBoundaries() {
+        var map = new HashMap<String, ValidatedType>();
+        map.put("null", null);
+        var value = new NullableCascadingType(null,
+                                              Collections.singletonList(null),
+                                              map);
+        var arrayValue = new NullableCascadingArrayType(new ValidatedType[]{null});
+
+        assertThat(validator.validate(NullableCascadingType.class, value).valid(), is(true));
+        assertThat(validator.validate(NullableCascadingArrayType.class, arrayValue).valid(), is(true));
     }
 
     @Test

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidInterfaceConstrainedServiceImpl.java
@@ -31,4 +31,9 @@ class ValidInterfaceConstrainedServiceImpl implements ValidInterfaceConstrainedS
     public String validateAll(List<? super ValidatedType> values) {
         return "ok";
     }
+
+    @Override
+    public ValidatedType nullableReturn() {
+        return null;
+    }
 }

--- a/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
+++ b/validation/tests/validation/src/test/java/io/helidon/validation/tests/validation/ValidationTest.java
@@ -68,6 +68,15 @@ public class ValidationTest {
     }
 
     @Test
+    public void testValidAndNotNullRejectsNull() {
+        var result = assertThrows(ValidationException.class, () -> service.process((ValidatedType) null));
+
+        assertThat(result.violations(), hasSize(1));
+        assertThat(result.violations().getFirst().annotation().typeName(),
+                   is(TypeName.create(Validation.NotNull.class)));
+    }
+
+    @Test
     public void testInterfaceMethodConstraint() {
         var response = interfaceConstrainedService.validate("value");
 

--- a/validation/validation/src/main/java/io/helidon/validation/Validation.java
+++ b/validation/validation/src/main/java/io/helidon/validation/Validation.java
@@ -77,6 +77,9 @@ public final class Validation {
      * Mark an element as validated even when no explicit constraints are added on it to validate
      * the nested object structure.
      * <p>
+     * Cascaded validation is skipped when the annotated value is {@code null}. To reject a {@code null} value,
+     * annotate the element with {@link io.helidon.validation.Validation.NotNull} as well.
+     * <p>
      * Each object must be annotated with {@link io.helidon.validation.Validation.Validated}, as otherwise
      * we cannot know what to do (Helidon only supports build-time generated validations, we do not use
      * reflection to analyze types).


### PR DESCRIPTION
Fixes #12375.

`@Validation.Valid` now skips cascading validation when the value is null. This allows nullable and optional values to remain optional while still recursively validating values that are present.

An independent `@Validation.NotNull` constraint continues to reject null values.

Regression tests cover method parameters, return values, fields, collection and array elements, and map values.

### Validation

- 36 focused tests passed
- 0 failures or errors
- `git diff --check` passed