### PR TITLE
27.x: upgrade protobuf to 4.36.0 and micrometer to 1.17.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -76,7 +76,7 @@
         <version.lib.jetbrains.annotations>17.0.0</version.lib.jetbrains.annotations>
         <version.lib.junit>5.12.2</version.lib.junit>
         <version.lib.log4j>2.25.5</version.lib.log4j>
-        <version.lib.micrometer>1.15.2</version.lib.micrometer>
+        <version.lib.micrometer>1.17.1</version.lib.micrometer>
         <version.lib.micrometer-prometheus>1.15.2</version.lib.micrometer-prometheus>
         <version.lib.mongodb>4.10.2</version.lib.mongodb>
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -45,7 +45,7 @@
         <version.lib.eclipselink>4.0.7</version.lib.eclipselink>
         <version.lib.google-error-prone-annotations>2.30.0</version.lib.google-error-prone-annotations>
         <version.lib.google-gson>2.13.2</version.lib.google-gson>
-        <version.lib.google-protobuf>4.31.1</version.lib.google-protobuf>
+        <version.lib.google-protobuf>4.36.0</version.lib.google-protobuf>
         <version.lib.google-j2objc-annotations>3.0.0</version.lib.google-j2objc-annotations>
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -77,7 +77,7 @@
         <version.lib.junit>5.12.2</version.lib.junit>
         <version.lib.log4j>2.25.5</version.lib.log4j>
         <version.lib.micrometer>1.17.1</version.lib.micrometer>
-        <version.lib.micrometer-prometheus>1.15.2</version.lib.micrometer-prometheus>
+        <version.lib.micrometer-prometheus>1.17.1</version.lib.micrometer-prometheus>
         <version.lib.mongodb>4.10.2</version.lib.mongodb>
         <version.lib.mysql-connector-j>8.2.0</version.lib.mysql-connector-j>
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -260,6 +260,70 @@
     <cve>CVE-2026-40894</cve>
 </suppress>
 
+
+<!-- False Positive
+  This CVE is againt OpenTelemetry JavaScript Client, not Java
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-api-1.65.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
+    <cve>CVE-2026-54285</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-proto@.*$</packageUrl>
+    <cve>CVE-2026-54285</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-54285</cve>
+</suppress>
+
+<!-- False Positive
+  This CVE is againt OpenTelemetry-Go, not Java
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-.*@.*$</packageUrl>
+    <cve>CVE-2026-41178</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-24051</cve>
+</suppress>
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-semconv-1.37.0.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+    <cve>CVE-2026-41178</cve>
+</suppress>
+
+<!-- False Positive
+  This CVE is againt OpenTelemetry-cpp, not Java
+-->
+<suppress>
+    <notes><![CDATA[
+    file name: opentelemetry-proto-1.5.0-alpha.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.proto/opentelemetry-.*@.*$</packageUrl>
+    <cve>CVE-2026-44967</cve>
+</suppress>
+
+
+
 <!-- False Positive.
      This CVE is against gRPC-Go servers not gRPC Java
 -->


### PR DESCRIPTION
### Description

* Upgrade Protobuf from 4.31.1 to 4.36.0 
* Upgrade micrometer from 1.15.2 to 1.17.1 (this requires at least protobuf 4.34.0)
* Suppress some opentelemetry false positives

Resolves #12330
