### PR TITLE
Annotate HTTP encoding APIs with API stability

### DIFF
--- a/http/encoding/deflate/pom.xml
+++ b/http/encoding/deflate/pom.xml
@@ -70,6 +70,30 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -79,6 +103,11 @@
                     <dependency>
                         <groupId>io.helidon.common.features</groupId>
                         <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncoding.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncoding.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
+import io.helidon.common.Api;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -32,6 +33,7 @@ import io.helidon.http.encoding.ContentEncoding;
 /**
  * Support for {@code deflate} content encoding.
  */
+@Api.Stable
 public class DeflateEncoding implements ContentEncoding {
     private static final Header CONTENT_ENCODING_DEFLATE =
             HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,

--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
@@ -24,6 +24,7 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
 /**
  * Support for {@code deflate} content encoding.
  */
+@Api.Stable
 public class DeflateEncodingProvider implements ContentEncodingProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/http/encoding/deflate/src/main/java/io/helidon/http/encoding/deflate/DeflateEncodingProvider.java
@@ -24,12 +24,11 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
 /**
  * Support for {@code deflate} content encoding.
  */
-@Api.Stable
+@Api.Internal
 public class DeflateEncodingProvider implements ContentEncodingProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Api.Internal
     public DeflateEncodingProvider() {
     }
 

--- a/http/encoding/gzip/pom.xml
+++ b/http/encoding/gzip/pom.xml
@@ -70,6 +70,30 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -79,6 +103,11 @@
                     <dependency>
                         <groupId>io.helidon.common.features</groupId>
                         <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncoding.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncoding.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import io.helidon.common.Api;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -36,6 +37,7 @@ import static io.helidon.http.HeaderNames.CONTENT_LENGTH;
 /**
  * Support for gzip content encoding.
  */
+@Api.Stable
 public class GzipEncoding implements ContentEncoding {
     private static final Header CONTENT_ENCODING_GZIP = HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,
                                                                                   false,

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
@@ -25,6 +25,7 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
 /**
  * Support for gzip content encoding.
  */
+@Api.Stable
 public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
+++ b/http/encoding/gzip/src/main/java/io/helidon/http/encoding/gzip/GzipEncodingProvider.java
@@ -25,12 +25,11 @@ import io.helidon.http.encoding.spi.ContentEncodingProvider;
 /**
  * Support for gzip content encoding.
  */
-@Api.Stable
+@Api.Internal
 public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Api.Internal
     public GzipEncodingProvider() {
     }
 


### PR DESCRIPTION
Part of #11500

Annotates the gzip and deflate encoding APIs as stable, classifies their ServiceLoader provider types as internal, and enables API-stability enforcement without replacing feature metadata generation.
