### PR TITLE
Add non-mutating LRU cache lookup (4.x)

### DIFF
--- a/common/common/src/main/java/io/helidon/common/LruCache.java
+++ b/common/common/src/main/java/io/helidon/common/LruCache.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.common;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -64,6 +65,22 @@ public interface LruCache<K, V> {
      * @return value if present or empty
      */
     Optional<V> get(K key);
+
+    /**
+     * Get a value from the cache without marking it as recently used.
+     * Custom implementations may not support this operation.
+     *
+     * @param key          key to retrieve
+     * @param defaultValue value to return if the key is not present
+     * @return cached value if present, otherwise {@code defaultValue}
+     * @throws NullPointerException if {@code key} or {@code defaultValue} is {@code null}
+     * @throws UnsupportedOperationException if this cache does not support peeking
+     */
+    default V peek(K key, V defaultValue) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(defaultValue);
+        throw new UnsupportedOperationException("Peeking is not supported by this cache");
+    }
 
     /**
      * Remove a value from the cache.

--- a/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
+++ b/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.common;
 
 import java.util.LinkedHashMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SequencedMap;
 import java.util.concurrent.locks.Lock;
@@ -70,6 +71,18 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
             return Optional.of(value);
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V peek(K key, V defaultValue) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(defaultValue);
+        readLock.lock();
+        try {
+            return backingMap.getOrDefault(key, defaultValue);
+        } finally {
+            readLock.unlock();
         }
     }
 

--- a/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
+++ b/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
@@ -80,7 +80,8 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
         Objects.requireNonNull(defaultValue);
         readLock.lock();
         try {
-            return backingMap.getOrDefault(key, defaultValue);
+            V value = backingMap.get(key);
+            return value == null ? defaultValue : value;
         } finally {
             readLock.unlock();
         }

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -79,6 +79,8 @@ class LruCacheTest {
         Object defaultValue = new Object();
         LruCache<String, Object> objectCache = LruCache.create();
         assertThat(objectCache.peek("missing", defaultValue), sameInstance(defaultValue));
+        objectCache.put("null", null);
+        assertThat(objectCache.peek("null", defaultValue), sameInstance(defaultValue));
         assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));
         assertThrows(NullPointerException.class, () -> cache.peek("first", null));
 

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link io.helidon.common.LruCache}.
@@ -63,6 +65,26 @@ class LruCacheTest {
         assertThat(res, is(Optional.of(value)));
         res = theCache.get(key);
         assertThat(res, is(Optional.empty()));
+    }
+
+    @Test
+    void testPeek() {
+        LruCache<String, String> cache = LruCache.create(3);
+        cache.put("first", "first-value");
+        cache.put("second", "second-value");
+        cache.put("third", "third-value");
+
+        assertThat(cache.peek("first", "default"), is("first-value"));
+
+        Object defaultValue = new Object();
+        LruCache<String, Object> objectCache = LruCache.create();
+        assertThat(objectCache.peek("missing", defaultValue), sameInstance(defaultValue));
+        assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));
+        assertThrows(NullPointerException.class, () -> cache.peek("first", null));
+
+        cache.put("fourth", "fourth-value");
+        assertThat(cache.get("first"), is(Optional.empty()));
+        assertThat(cache.get("second"), is(Optional.of("second-value")));
     }
 
     @Test

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -79,6 +79,7 @@ class LruCacheTest {
         Object defaultValue = new Object();
         LruCache<String, Object> objectCache = LruCache.create();
         assertThat(objectCache.peek("missing", defaultValue), sameInstance(defaultValue));
+        // Unsupported; validate only for backward compatibility until null values are rejected in the next major version.
         objectCache.put("null", null);
         assertThat(objectCache.peek("null", defaultValue), sameInstance(defaultValue));
         assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));

--- a/common/configurable/src/main/java/io/helidon/common/configurable/LruCache.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/LruCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,11 @@ public final class LruCache<K, V> implements io.helidon.common.LruCache<K, V>, R
     @Override
     public Optional<V> get(K key) {
         return delegate.get(key);
+    }
+
+    @Override
+    public V peek(K key, V defaultValue) {
+        return delegate.peek(key, defaultValue);
     }
 
     @Override

--- a/common/configurable/src/test/java/io/helidon/common/configurable/LruCacheTest.java
+++ b/common/configurable/src/test/java/io/helidon/common/configurable/LruCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,19 @@ class LruCacheTest {
         assertThat(res, is(Optional.of(value)));
         res = theCache.get(key);
         assertThat(res, is(Optional.empty()));
+    }
+
+    @Test
+    void testPeek() {
+        LruCache<Integer, Integer> theCache = LruCache.<Integer, Integer>builder().capacity(2).build();
+        theCache.put(1, 1);
+        theCache.put(2, 2);
+
+        assertThat(theCache.peek(1, -1), is(1));
+
+        theCache.put(3, 3);
+        assertThat(theCache.get(1), is(Optional.empty()));
+        assertThat(theCache.get(2), is(Optional.of(2)));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `LruCache.peek(K key, V defaultValue)` for lookup without changing LRU order.
- Guard Helidon's implementation with the existing read lock.
- Preserve compatibility for custom implementations with an unsupported default method.

Existing cache operations and their locking remain unchanged.
