### PR TITLE
Reject relative request targets at the protocol boundary (27.x)

### DIFF
--- a/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriValidator.java
@@ -163,10 +163,10 @@ public final class UriValidator {
         // pct-encoded = "%" HEXDIG HEXDIG
         // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 
-        char[] chars = rawQuery.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
-            validateAscii(Segment.QUERY, chars, i, c);
+        int length = rawQuery.length();
+        for (int i = 0; i < length; i++) {
+            char c = rawQuery.charAt(i);
+            validateAscii(Segment.QUERY, rawQuery, i, c);
             if (UNRESERVED[c]) {
                 continue;
             }
@@ -188,11 +188,11 @@ public final class UriValidator {
             // done with pchar validation except for percent encoded
             if (c == '%') {
                 // percent encoding
-                validatePercentEncoding(Segment.QUERY, rawQuery, chars, i);
+                validatePercentEncoding(Segment.QUERY, rawQuery, i);
                 i += 2;
                 continue;
             }
-            failInvalidChar(Segment.QUERY, chars, i, c);
+            failInvalidChar(Segment.QUERY, rawQuery, i, c);
         }
     }
 
@@ -525,11 +525,26 @@ public final class UriValidator {
                                          c);
     }
 
+    private static void failInvalidChar(Segment segment, String value, int i, char c) {
+        failInvalidChar(segment, value.toCharArray(), i, c);
+    }
+
     private static void validateAscii(Segment segment, char[] chars, int i, char c) {
         if (c > 254) {
             // in general only ASCII characters are allowed
             throw new UriValidationException(segment,
                                              chars,
+                                             segment.text() + " contains invalid char (non-ASCII)",
+                                             i,
+                                             c);
+        }
+    }
+
+    private static void validateAscii(Segment segment, String value, int i, char c) {
+        if (c > 254) {
+            // in general only ASCII characters are allowed
+            throw new UriValidationException(segment,
+                                             value.toCharArray(),
                                              segment.text() + " contains invalid char (non-ASCII)",
                                              i,
                                              c);
@@ -556,6 +571,32 @@ public final class UriValidator {
         // %p1p2
         validateHex(segment, value, chars, p1, segment.text(), i + 1, true);
         validateHex(segment, value, chars, p2, segment.text(), i + 2, true);
+    }
+
+    private static void validatePercentEncoding(Segment segment, String value, int i) {
+        if (i + 2 >= value.length()) {
+            throw new UriValidationException(segment,
+                                             value.toCharArray(),
+                                             segment.text()
+                                                     + " contains invalid % encoding, not enough chars left at index "
+                                                     + i);
+        }
+        char p1 = value.charAt(i + 1);
+        char p2 = value.charAt(i + 2);
+        // %p1p2
+        validateHex(segment, value, p1, segment.text(), i + 1, true);
+        validateHex(segment, value, p2, segment.text(), i + 2, true);
+    }
+
+    private static void validateHex(Segment segment,
+                                    String value,
+                                    char c,
+                                    String type,
+                                    int index,
+                                    boolean isPercentEncoding) {
+        if (c > 255 || !HEXDIGIT[c]) {
+            validateHex(segment, value, value.toCharArray(), c, type, index, isPercentEncoding);
+        }
     }
 
     private static void validateHex(Segment segment,
@@ -634,6 +675,9 @@ public final class UriValidator {
     }
 
     private static void validateIpOctet(String message, String host, String octet) {
+        if (octet.length() > 1 && octet.charAt(0) == '0') {
+            throw new UriValidationException(Segment.HOST, host.toCharArray(), message);
+        }
         int octetInt = Integer.parseInt(octet);
         // cannot be negative, as the regexp will not match
         if (octetInt > 255) {

--- a/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriValidatorTest.java
@@ -274,6 +274,9 @@ class UriValidatorTest {
                                    "[::14.266.44]");
         invokeLiteralExpectFailure("Host IPv6 dual address contains invalid IPv4 address: [::14.123.-44.147]",
                                    "[::14.123.-44.147]");
+        invokeLiteralExpectFailure("Host IPv6 dual address contains invalid IPv4 address: "
+                                           + "[1:2:3:4:5:6:010.000.000.001]",
+                                   "[1:2:3:4:5:6:010.000.000.001]");
     }
 
     @Test

--- a/docs/config/io.helidon.webserver.http1.Http1Config.md
+++ b/docs/config/io.helidon.webserver.http1.Http1Config.md
@@ -65,7 +65,7 @@ HTTP/1.1 server configuration
 <td>
 <code>true</code>
 </td>
-<td>If set to false, any query and fragment is accepted (even containing illegal characters)</td>
+<td>Disables query and fragment syntax validation when set to <code>false</code>; intended only for closed systems receiving trusted, valid request targets, as behavior for invalid input is unspecified</td>
 </tr>
 <tr>
 <td>
@@ -77,7 +77,7 @@ HTTP/1.1 server configuration
 <td>
 <code>true</code>
 </td>
-<td>If set to false, any path is accepted (even containing illegal characters)</td>
+<td>Whether to validate path characters and HTTP/1.1 request-target forms</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.webserver.http2.Http2Config.md
+++ b/docs/config/io.helidon.webserver.http2.Http2Config.md
@@ -101,7 +101,7 @@ HTTP/2 server configuration
 <td>
 <code>true</code>
 </td>
-<td>If set to false, any path is accepted (even containing illegal characters)</td>
+<td>Whether to validate path characters and the HTTP/2 <code>:path</code> pseudo-header</td>
 </tr>
 <tr>
 <td>

--- a/http/http/src/test/java/io/helidon/http/HttpPrologueTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpPrologueTest.java
@@ -152,4 +152,38 @@ class HttpPrologueTest {
 
         assertThat(withoutDelimiter.equals(withDelimiter), is(false));
     }
+
+    @Test
+    void testRelativePathCanBeCreatedWhenValidated() {
+        HttpPrologue prologue = HttpPrologue.create("HTTP/1.1",
+                                                    "HTTP",
+                                                    "1.1",
+                                                    Method.GET,
+                                                    "boards/",
+                                                    true);
+        assertThat(prologue.uriPath().rawPath(), is("boards/"));
+    }
+
+    @Test
+    void testAbsolutePathRemainsValid() {
+        HttpPrologue prologue = HttpPrologue.create("HTTP/1.1",
+                                                    "HTTP",
+                                                    "1.1",
+                                                    Method.GET,
+                                                    "/boards/",
+                                                    true);
+        assertThat(prologue.uriPath().rawPath(), is("/boards/"));
+    }
+
+    @Test
+    void testAbsoluteFormRemainsValid() {
+        HttpPrologue prologue = HttpPrologue.create("HTTP/1.1",
+                                                    "HTTP",
+                                                    "1.1",
+                                                    Method.GET,
+                                                    "http://example.com/boards/",
+                                                    true);
+        assertThat(prologue.uriPath().path(), is("/boards/"));
+    }
+
 }

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Exception.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,10 @@ public class Http2Exception extends RuntimeException {
      * Type of the HTTP/2 error.
      */
     private final Http2ErrorCode type;
+    /**
+     * Whether this is a request-target error.
+     */
+    private final boolean requestTarget;
 
     /**
      * Exception with type and message.
@@ -32,8 +36,7 @@ public class Http2Exception extends RuntimeException {
      * @param message   descriptive message
      */
     public Http2Exception(Http2ErrorCode errorCode, String message) {
-        super(message);
-        this.type = errorCode;
+        this(errorCode, message, false);
     }
 
     /**
@@ -46,6 +49,13 @@ public class Http2Exception extends RuntimeException {
     public Http2Exception(Http2ErrorCode errorCode, String message, Throwable cause) {
         super(message, cause);
         this.type = errorCode;
+        this.requestTarget = false;
+    }
+
+    Http2Exception(Http2ErrorCode errorCode, String message, boolean requestTarget) {
+        super(message);
+        this.type = errorCode;
+        this.requestTarget = requestTarget;
     }
 
     /**
@@ -55,5 +65,14 @@ public class Http2Exception extends RuntimeException {
      */
     public Http2ErrorCode code() {
         return type;
+    }
+
+    /**
+     * Whether this exception reports a malformed HTTP/2 request target.
+     *
+     * @return whether this is a request-target error
+     */
+    public boolean requestTarget() {
+        return requestTarget;
     }
 }

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -361,6 +361,11 @@ public class Http2Headers {
         if (pseudoHeaders.size() != 0) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Pseudo header in trailers");
         }
+        for (Header header : headers) {
+            if (header.headerName().isPseudoHeader()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Pseudo header in trailers");
+            }
+        }
     }
 
     /**

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -353,9 +353,9 @@ public class Http2Headers {
     }
 
     /**
-     * Validate request or response trailers.
+     * Validate that request or response trailers do not contain pseudo-headers.
      *
-     * @throws Http2Exception in case the trailers are invalid
+     * @throws Http2Exception if the trailers contain a pseudo-header
      */
     public void validateTrailers() throws Http2Exception {
         if (pseudoHeaders.size() != 0) {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -574,7 +574,7 @@ public class Http2Headers {
     }
 
     private static boolean authoritiesMatch(String scheme, String authority, String host) {
-        if (scheme == null && authority.equals(host)) {
+        if (scheme == null && authority.equalsIgnoreCase(host)) {
             return true;
         }
         try {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -396,10 +396,10 @@ public class Http2Headers {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :scheme pseudo header");
             }
             if (!pseudoHeaders.hasPath()) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :path pseudo header");
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :path pseudo header", true);
             }
             if (pseudoHeaders.path().isEmpty()) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":path pseudo header has empty value");
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":path pseudo header has empty value", true);
             }
         }
         List<String> hostValues = headers.all(HeaderNames.HOST, List::of);

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import io.helidon.common.buffers.Ascii;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.uri.UriAuthority;
 import io.helidon.http.Header;
@@ -574,7 +575,7 @@ public class Http2Headers {
     }
 
     private static boolean authoritiesMatch(String scheme, String authority, String host) {
-        if (scheme == null && authority.equalsIgnoreCase(host)) {
+        if (scheme == null && Ascii.toLowerCase(authority).equals(Ascii.toLowerCase(host))) {
             return true;
         }
         try {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -558,6 +558,9 @@ public class Http2Headers {
     }
 
     private static boolean authoritiesMatch(String scheme, String authority, String host) {
+        if (scheme == null && authority.equals(host)) {
+            return true;
+        }
         try {
             int defaultPort = scheme == null ? UriAuthority.UNDEFINED_PORT : defaultPort(scheme);
             UriAuthority authorityValue = UriAuthority.create(authority);

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -380,14 +380,24 @@ public class Http2Headers {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL, "te in headers with other value than trailers");
             }
         }
-        if (!pseudoHeaders.hasScheme()) {
-            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :scheme pseudo header");
-        }
-        if (!pseudoHeaders.hasPath()) {
-            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :path pseudo header");
-        }
         if (!pseudoHeaders.hasMethod()) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :method pseudo header");
+        }
+        boolean connect = Method.CONNECT.equals(pseudoHeaders.method());
+        if (connect) {
+            if (pseudoHeaders.hasScheme()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":scheme in CONNECT request headers");
+            }
+            if (pseudoHeaders.hasPath()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":path in CONNECT request headers");
+            }
+        } else {
+            if (!pseudoHeaders.hasScheme()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :scheme pseudo header");
+            }
+            if (!pseudoHeaders.hasPath()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :path pseudo header");
+            }
         }
         List<String> hostValues = headers.all(HeaderNames.HOST, List::of);
         if (hostValues.size() > 1) {
@@ -395,7 +405,10 @@ public class Http2Headers {
         }
         boolean hasHost = hostValues.size() == 1 && !hostValues.get(0).isEmpty();
         boolean hasAuthority = pseudoHeaders.hasAuthority() && !pseudoHeaders.authority().isEmpty();
-        if (!hasAuthority && !hasHost) {
+        if (connect && !hasAuthority) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :authority pseudo header in CONNECT request");
+        }
+        if (!connect && !hasAuthority && !hasHost) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :authority pseudo header or Host header");
         }
         if (pseudoHeaders.hasAuthority() && !hostValues.isEmpty()
@@ -543,7 +556,7 @@ public class Http2Headers {
 
     private static boolean authoritiesMatch(String scheme, String authority, String host) {
         try {
-            int defaultPort = defaultPort(scheme);
+            int defaultPort = scheme == null ? UriAuthority.UNDEFINED_PORT : defaultPort(scheme);
             UriAuthority authorityValue = UriAuthority.create(authority);
             UriAuthority hostValue = UriAuthority.create(host);
             return authorityValue.host().equals(hostValue.host())

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import io.helidon.common.buffers.Ascii;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.uri.UriAuthority;
+import io.helidon.common.uri.UriValidator;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -575,10 +576,15 @@ public class Http2Headers {
     }
 
     private static boolean authoritiesMatch(String scheme, String authority, String host) {
-        if (scheme == null && Ascii.toLowerCase(authority).equals(Ascii.toLowerCase(host))) {
-            return true;
-        }
         try {
+            if (scheme == null) {
+                String lowerAuthority = Ascii.toLowerCase(authority);
+                String lowerHost = Ascii.toLowerCase(host);
+                if (lowerAuthority.equals(lowerHost)
+                        || normalizeSchemeLessAuthority(lowerAuthority).equals(normalizeSchemeLessAuthority(lowerHost))) {
+                    return true;
+                }
+            }
             int defaultPort = scheme == null ? UriAuthority.UNDEFINED_PORT : defaultPort(scheme);
             UriAuthority authorityValue = UriAuthority.create(authority);
             UriAuthority hostValue = UriAuthority.create(host);
@@ -587,6 +593,92 @@ public class Http2Headers {
         } catch (IllegalArgumentException e) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid Host or :authority header", e);
         }
+    }
+
+    private static String normalizeSchemeLessAuthority(String authority) {
+        if (authority.isEmpty() || authority.charAt(0) == '[') {
+            return authority;
+        }
+
+        int colon = authority.indexOf(':');
+        if (colon != authority.lastIndexOf(':')) {
+            return authority;
+        }
+
+        int hostEnd = colon == -1 ? authority.length() : colon;
+        String host = authority.substring(0, hostEnd);
+        UriValidator.validateHost(host);
+        String normalizedHost = decodeUnreserved(host);
+        if (colon == -1) {
+            return normalizedHost;
+        }
+        return normalizedHost + ":" + parsePort(authority, colon + 1);
+    }
+
+    private static String decodeUnreserved(String host) {
+        int percent = host.indexOf('%');
+        if (percent == -1) {
+            return host;
+        }
+
+        StringBuilder result = new StringBuilder(host.length());
+        result.append(host, 0, percent);
+        for (int i = percent; i < host.length(); i++) {
+            char c = host.charAt(i);
+            if (c != '%') {
+                result.append(c);
+                continue;
+            }
+            char high = host.charAt(++i);
+            char low = host.charAt(++i);
+            char decoded = (char) ((hexDigit(high) << 4) | hexDigit(low));
+            if (isUnreserved(decoded)) {
+                result.append(Ascii.toLowerCase(decoded));
+            } else {
+                result.append('%')
+                        .append(Ascii.toUpperCase(high))
+                        .append(Ascii.toUpperCase(low));
+            }
+        }
+        return result.toString();
+    }
+
+    private static int parsePort(String authority, int offset) {
+        if (offset == authority.length()) {
+            throw new IllegalArgumentException("Authority port cannot be blank");
+        }
+        int result = 0;
+        for (int i = offset; i < authority.length(); i++) {
+            char c = authority.charAt(i);
+            if (c < '0' || c > '9') {
+                throw new IllegalArgumentException("Authority port must contain only digits");
+            }
+            result = result * 10 + c - '0';
+            if (result > 65535) {
+                throw new IllegalArgumentException("Authority port must be between 0 and 65535");
+            }
+        }
+        return result;
+    }
+
+    private static int hexDigit(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - 'a' + 10;
+        }
+        return c - 'A' + 10;
+    }
+
+    private static boolean isUnreserved(char c) {
+        return c >= 'a' && c <= 'z'
+                || c >= 'A' && c <= 'Z'
+                || c >= '0' && c <= '9'
+                || c == '-'
+                || c == '.'
+                || c == '_'
+                || c == '~';
     }
 
     private static int defaultPort(String scheme) {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -353,6 +353,17 @@ public class Http2Headers {
     }
 
     /**
+     * Validate request or response trailers.
+     *
+     * @throws Http2Exception in case the trailers are invalid
+     */
+    public void validateTrailers() throws Http2Exception {
+        if (pseudoHeaders.size() != 0) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Pseudo header in trailers");
+        }
+    }
+
+    /**
      * Validate client or server request.
      *
      * @throws Http2Exception in case the request is invalid

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -398,6 +398,9 @@ public class Http2Headers {
             if (!pseudoHeaders.hasPath()) {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Missing :path pseudo header");
             }
+            if (pseudoHeaders.path().isEmpty()) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":path pseudo header has empty value");
+            }
         }
         List<String> hostValues = headers.all(HeaderNames.HOST, List::of);
         if (hostValues.size() > 1) {
@@ -647,9 +650,6 @@ public class Http2Headers {
             if (isPseudoHeader) {
                 if (value == null) {
                     throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Value of a pseudo header must not be null");
-                }
-                if (headerName.equals(PATH_NAME) && value.length() == 0) {
-                    throw new Http2Exception(Http2ErrorCode.PROTOCOL, ":path pseudo header has empty value");
                 }
                 if (headerName.equals(PATH_NAME)) {
                     validateAndSetPseudoHeader(headerName, pseudoHeaders::hasPath, pseudoHeaders::path, value);

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -274,6 +274,19 @@ class Http2HeadersTest {
     }
 
     @Test
+    void testRequestRejectsUnicodeCaseFoldedHostOnOrdinaryConnect() {
+        String hexEncoded = literalWithIndexedName(2, "CONNECT")
+                + " " + literalWithIndexedName(1, "service%2Di.example:443")
+                + " " + literalWithNewNameUtf8("host", "service%2D\u0131.example:443");
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
     void testRequestRejectsConnectWithScheme() {
         Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create())
                 .method(Method.CONNECT)
@@ -596,6 +609,12 @@ class Http2HeadersTest {
 
     private static String literalWithNewName(String name, String value) {
         return "40 " + lengthAndValue(name) + " " + lengthAndValue(value);
+    }
+
+    private static String literalWithNewNameUtf8(String name, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        return "40 " + lengthAndValue(name) + " "
+                + String.format("%02x %s", bytes.length, HexFormat.of().formatHex(bytes));
     }
 
     private static String lengthAndValue(String value) {

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -24,6 +24,7 @@ import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.Method;
+import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Headers.DynamicTable;
 import io.helidon.http.http2.Http2Headers.HeaderRecord;
@@ -210,6 +211,25 @@ class Http2HeadersTest {
 
         assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
         assertThat(exception.requestTarget(), is(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"authority", "method", "path", "empty-path", "scheme", "status"})
+    void testTrailersRejectPseudoHeaders(String pseudoHeader) {
+        Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create());
+        switch (pseudoHeader) {
+        case "authority" -> http2Headers.authority("www.example.com");
+        case "method" -> http2Headers.method(Method.GET);
+        case "path" -> http2Headers.path("/forbidden");
+        case "empty-path" -> http2Headers.path("");
+        case "scheme" -> http2Headers.scheme("https");
+        case "status" -> http2Headers.status(Status.OK_200);
+        default -> throw new AssertionError("Unexpected pseudo header: " + pseudoHeader);
+        }
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateTrailers);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -197,6 +197,54 @@ class Http2HeadersTest {
     }
 
     @Test
+    void testRequestAcceptsOrdinaryConnect() {
+        String hexEncoded = connectRequestHeaders("proxy.example:443", "proxy.example:443");
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        http2Headers.validateRequest();
+
+        assertThat(http2Headers.method(), is(Method.CONNECT));
+        assertThat(http2Headers.authority(), is("proxy.example:443"));
+    }
+
+    @Test
+    void testRequestRejectsConnectWithScheme() {
+        Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create())
+                .method(Method.CONNECT)
+                .scheme("https")
+                .authority("proxy.example:443");
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
+    void testRequestRejectsConnectWithPath() {
+        Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create())
+                .method(Method.CONNECT)
+                .path("/")
+                .authority("proxy.example:443");
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
+    void testRequestRejectsConnectWithHostOnly() {
+        String hexEncoded = literalWithIndexedName(2, "CONNECT")
+                + " " + literalWithNewName("host", "proxy.example:443");
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
     void testRequestAcceptsMatchingHostAuthority() {
         String hexEncoded = requestHeaders("signed.example", "signed.example");
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
@@ -439,6 +487,17 @@ class Http2HeadersTest {
         Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
 
         assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    private static String connectRequestHeaders(String authority, String... hostValues) {
+        StringBuilder headers = new StringBuilder(literalWithIndexedName(2, "CONNECT"));
+        headers.append(' ')
+                .append(literalWithIndexedName(1, authority));
+        for (String hostValue : hostValues) {
+            headers.append(' ')
+                    .append(literalWithNewName("host", hostValue));
+        }
+        return headers.toString();
     }
 
     private Http2Headers headers(String hexEncoded, DynamicTable dynamicTable) {

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -196,6 +196,7 @@ class Http2HeadersTest {
         Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
 
         assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+        assertThat(exception.requestTarget(), is(false));
     }
 
     @Test
@@ -208,6 +209,7 @@ class Http2HeadersTest {
         Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
 
         assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+        assertThat(exception.requestTarget(), is(true));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -29,6 +29,8 @@ import io.helidon.http.http2.Http2Headers.DynamicTable;
 import io.helidon.http.http2.Http2Headers.HeaderRecord;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -218,6 +220,18 @@ class Http2HeadersTest {
 
         assertThat(http2Headers.method(), is(Method.CONNECT));
         assertThat(http2Headers.authority(), is("proxy.example:443"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[Vf.foo-bar]:443", "service+name:443", "service%2Dname:443"})
+    void testRequestAcceptsMatchingUriHostOnOrdinaryConnect(String authority) {
+        String hexEncoded = connectRequestHeaders(authority, authority);
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        http2Headers.validateRequest();
+
+        assertThat(http2Headers.authority(), is(authority));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -275,6 +275,21 @@ class Http2HeadersTest {
         assertThat(http2Headers.authority(), is(authority));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "service+name:443, service%2Bname:443",
+            "service%2Bname:443, service+name:443"
+    })
+    void testRequestRejectsReservedEncodingMismatchOnOrdinaryConnect(String authority, String host) {
+        String hexEncoded = connectRequestHeaders(authority, host);
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
     @Test
     void testRequestRejectsUnicodeCaseFoldedHostOnOrdinaryConnect() {
         String hexEncoded = literalWithIndexedName(2, "CONNECT")

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -233,6 +233,17 @@ class Http2HeadersTest {
     }
 
     @Test
+    void testTrailersRejectUnknownPseudoHeader() {
+        WritableHeaders<?> trailers = WritableHeaders.create()
+                .add(HeaderNames.create(":unknown"), "value");
+        Http2Headers http2Headers = Http2Headers.create(trailers);
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateTrailers);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
     void testRequestAcceptsOrdinaryConnect() {
         String hexEncoded = connectRequestHeaders("proxy.example:443", "proxy.example:443");
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -261,7 +261,9 @@ class Http2HeadersTest {
             "'[Vf.foo-bar]:443', '[Vf.foo-bar]:443'",
             "service+name:443, service+name:443",
             "service%2Dname:443, service%2Dname:443",
-            "service%2Dname:443, service%2dname:443"
+            "service%2Dname:443, service%2dname:443",
+            "service-name:443, service%2Dname:443",
+            "service%2Dname:443, service-name:443"
     })
     void testRequestAcceptsMatchingUriHostOnOrdinaryConnect(String authority, String host) {
         String hexEncoded = connectRequestHeaders(authority, host);

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -197,6 +197,18 @@ class Http2HeadersTest {
     }
 
     @Test
+    void testRequestRejectsEmptyPathAfterDecoding() {
+        String hexEncoded = "82 86 " + literalWithIndexedName(4, "")
+                + " " + literalWithIndexedName(1, "signed.example");
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
+
+        Http2Exception exception = assertThrows(Http2Exception.class, http2Headers::validateRequest);
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
+    }
+
+    @Test
     void testRequestAcceptsOrdinaryConnect() {
         String hexEncoded = connectRequestHeaders("proxy.example:443", "proxy.example:443");
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -31,6 +31,7 @@ import io.helidon.http.http2.Http2Headers.HeaderRecord;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
@@ -256,9 +257,14 @@ class Http2HeadersTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"[Vf.foo-bar]:443", "service+name:443", "service%2Dname:443"})
-    void testRequestAcceptsMatchingUriHostOnOrdinaryConnect(String authority) {
-        String hexEncoded = connectRequestHeaders(authority, authority);
+    @CsvSource({
+            "'[Vf.foo-bar]:443', '[Vf.foo-bar]:443'",
+            "service+name:443, service+name:443",
+            "service%2Dname:443, service%2Dname:443",
+            "service%2Dname:443, service%2dname:443"
+    })
+    void testRequestAcceptsMatchingUriHostOnOrdinaryConnect(String authority, String host) {
+        String hexEncoded = connectRequestHeaders(authority, host);
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
         Http2Headers http2Headers = headers(hexEncoded, dynamicTable);
 

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/http1/Http1ClientRequestTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/http1/Http1ClientRequestTargetBenchmark.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.context.Context;
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class Http1ClientRequestTargetBenchmark {
+    @Param
+    private Fragment fragment;
+
+    private BufferData buffer;
+    private Http1CallChainBase chain;
+    private ClientUri uri;
+    private WebClientServiceRequest request;
+
+    @Setup
+    public void setup() {
+        Http1ClientImpl client = (Http1ClientImpl) Http1Client.create(builder -> builder
+                .protocolConfig(protocol -> protocol.log(log -> log
+                        .sendLog(false)
+                        .receiveLog(false))));
+        if (client.sendListener().enabled()) {
+            throw new IllegalStateException("Benchmark requires HTTP/1 send logging to be disabled");
+        }
+        Http1ClientRequestImpl originalRequest = (Http1ClientRequestImpl) client.get("http://localhost/test");
+        chain = new BenchmarkChain(client, originalRequest);
+
+        String fragmentPart = fragment == Fragment.PRESENT ? "#fragment" : "";
+        uri = ClientUri.create(URI.create("http://localhost/test?query=value" + fragmentPart));
+        request = new BenchmarkRequest(uri);
+        buffer = BufferData.growing(256);
+    }
+
+    @Benchmark
+    public BufferData prologue() {
+        buffer.clear();
+        chain.prologue(null, buffer, request, uri);
+        return buffer;
+    }
+
+    public enum Fragment {
+        ABSENT,
+        PRESENT
+    }
+
+    private static final class BenchmarkChain extends Http1CallChainBase {
+        private BenchmarkChain(Http1ClientImpl client, Http1ClientRequestImpl request) {
+            super(client, request, new CompletableFuture<>());
+        }
+
+        @Override
+        WebClientServiceResponse doProceed(ClientConnection connection,
+                                           WebClientServiceRequest request,
+                                           ClientRequestHeaders headers,
+                                           DataWriter writer,
+                                           DataReader reader,
+                                           BufferData writeBuffer) {
+            return null;
+        }
+    }
+
+    private static final class BenchmarkRequest implements WebClientServiceRequest {
+        private final ClientUri uri;
+        private final ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
+        private final Context context = Context.create();
+        private final CompletionStage<WebClientServiceRequest> whenSent = CompletableFuture.completedFuture(this);
+        private final CompletionStage<WebClientServiceResponse> whenComplete = new CompletableFuture<>();
+        private final Map<String, String> properties = new HashMap<>();
+
+        private String requestId = "benchmark";
+
+        private BenchmarkRequest(ClientUri uri) {
+            this.uri = uri;
+        }
+
+        @Override
+        public ClientUri uri() {
+            return uri;
+        }
+
+        @Override
+        public Method method() {
+            return Method.GET;
+        }
+
+        @Override
+        public String protocolId() {
+            return Http1Client.PROTOCOL_ID;
+        }
+
+        @Override
+        public ClientRequestHeaders headers() {
+            return headers;
+        }
+
+        @Override
+        public Context context() {
+            return context;
+        }
+
+        @Override
+        public String requestId() {
+            return requestId;
+        }
+
+        @Override
+        public void requestId(String requestId) {
+            this.requestId = requestId;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceRequest> whenSent() {
+            return whenSent;
+        }
+
+        @Override
+        public CompletionStage<WebClientServiceResponse> whenComplete() {
+            return whenComplete;
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return properties;
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/http2/Http2ClientRequestTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/http2/Http2ClientRequestTargetBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.URI;
+
+import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.Method;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.webclient.api.ClientUri;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class Http2ClientRequestTargetBenchmark {
+    @Param
+    private Fragment fragment;
+
+    private ClientRequestHeaders headers;
+    private ClientUri uri;
+
+    @Setup
+    public void setup() {
+        String fragmentPart = fragment == Fragment.PRESENT ? "#fragment" : "";
+        uri = ClientUri.create(URI.create("http://localhost/test?query=value" + fragmentPart));
+        headers = ClientRequestHeaders.create(WritableHeaders.create());
+    }
+
+    @Benchmark
+    public Http2Headers prepareHeaders() {
+        return Http2CallChainBase.prepareHeaders(Method.GET, headers, uri);
+    }
+
+    public enum Fragment {
+        ABSENT,
+        PRESENT
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http1ServerRequestTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http1ServerRequestTargetBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.buffers.DataReader;
+import io.helidon.http.HttpPrologue;
+import io.helidon.webserver.http1.Http1Prologue;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class Http1ServerRequestTargetBenchmark {
+    private static final int MAX_PROLOGUE_LENGTH = 4096;
+
+    @Param
+    private Form form;
+
+    @Param({"32", "4000"})
+    private int targetLength;
+
+    private byte[] requestLine;
+
+    @Setup
+    public void setup() {
+        String prefix = switch (form) {
+        case ORIGIN -> "/";
+        case ABSOLUTE -> "http://example.test/";
+        };
+        String requestTarget = prefix + "a".repeat(targetLength - prefix.length());
+        requestLine = ("GET " + requestTarget + " HTTP/1.1\r\n").getBytes(StandardCharsets.US_ASCII);
+    }
+
+    @Benchmark
+    public HttpPrologue parse() {
+        return new Http1Prologue(DataReader.create(() -> requestLine), MAX_PROLOGUE_LENGTH, true).readPrologue();
+    }
+
+    public enum Form {
+        ORIGIN,
+        ABSOLUTE
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ServerRequestTargetBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webserver/benchmark/jmh/Http2ServerRequestTargetBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http1.Http1Config;
+import io.helidon.webserver.http1.Http1ConnectionSelector;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+import io.helidon.webserver.http2.Http2Upgrader;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@State(Scope.Benchmark)
+public class Http2ServerRequestTargetBenchmark {
+    private static final Duration EXCHANGE_TIMEOUT = Duration.ofSeconds(10);
+
+    @Param({"32", "4000"})
+    private int targetLength;
+
+    @Param({"false"})
+    private boolean withQuery;
+
+    private WebServer server;
+    private HttpClient client;
+    private HttpRequest request;
+
+    @Setup
+    public void setup() throws IOException, InterruptedException {
+        Http2Config http2Config = Http2Config.builder()
+                .validatePath(true)
+                .build();
+        server = WebServer.builder()
+                .host("127.0.0.1")
+                .port(-1)
+                .protocolsDiscoverServices(false)
+                .addConnectionSelector(Http2ConnectionSelector.builder()
+                                               .http2Config(http2Config)
+                                               .build())
+                .addConnectionSelector(Http1ConnectionSelector.builder()
+                                               .config(Http1Config.create())
+                                               .addUpgrader(Http2Upgrader.create(http2Config))
+                                               .build())
+                .routing(routing -> routing.any((req, res) -> res.send("OK")))
+                .build()
+                .start();
+
+        client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(EXCHANGE_TIMEOUT)
+                .build();
+        String path = withQuery
+                ? "/a?q=" + "b".repeat(targetLength - 5)
+                : "/" + "a".repeat(targetLength - 1);
+        request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + server.port() + path))
+                .timeout(EXCHANGE_TIMEOUT)
+                .build();
+
+        boolean setupComplete = false;
+        try {
+            HttpResponse<Void> response = exchange();
+            if (response.version() != HttpClient.Version.HTTP_2) {
+                throw new IllegalStateException("Benchmark connection did not negotiate HTTP/2");
+            }
+            setupComplete = true;
+        } finally {
+            if (!setupComplete) {
+                server.stop();
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        server.stop();
+    }
+
+    @Benchmark
+    public HttpResponse<Void> exchange() throws IOException, InterruptedException {
+        return client.send(request, HttpResponse.BodyHandlers.discarding());
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/RequestTargetJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webserver/benchmark/jmh/RequestTargetJmhRunnerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import io.helidon.webclient.http1.Http1ClientRequestTargetBenchmark;
+import io.helidon.webclient.http2.Http2ClientRequestTargetBenchmark;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class RequestTargetJmhRunnerTest {
+    @Test
+    void throughputAndAllocation() throws RunnerException {
+        Options options = options()
+                .mode(Mode.Throughput)
+                .timeUnit(TimeUnit.SECONDS)
+                .addProfiler(GCProfiler.class)
+                .result("target/request-target-throughput.json")
+                .build();
+        new Runner(options).run();
+    }
+
+    @Test
+    void sampleLatency() throws RunnerException {
+        Options options = options()
+                .mode(Mode.SampleTime)
+                .timeUnit(TimeUnit.NANOSECONDS)
+                .result("target/request-target-sample.json")
+                .build();
+        new Runner(options).run();
+    }
+
+    @Test
+    void http2QueryThroughputAndAllocation() throws RunnerException {
+        Options options = commonOptions(new OptionsBuilder()
+                                                .include(exact(Http2ServerRequestTargetBenchmark.class, "exchange"))
+                                                .param("withQuery", "true"))
+                .mode(Mode.Throughput)
+                .timeUnit(TimeUnit.SECONDS)
+                .addProfiler(GCProfiler.class)
+                .result("target/request-target-http2-query-throughput.json")
+                .build();
+        new Runner(options).run();
+    }
+
+    private static ChainedOptionsBuilder options() {
+        return commonOptions(new OptionsBuilder()
+                .include(exact(Http1ServerRequestTargetBenchmark.class, "parse"))
+                .include(exact(Http2ServerRequestTargetBenchmark.class, "exchange"))
+                .include(exact(Http1ClientRequestTargetBenchmark.class, "prologue"))
+                .include(exact(Http2ClientRequestTargetBenchmark.class, "prepareHeaders")));
+    }
+
+    private static ChainedOptionsBuilder commonOptions(ChainedOptionsBuilder options) {
+        return options
+                .forks(3)
+                .threads(1)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(8)
+                .measurementTime(TimeValue.seconds(1))
+                .timeout(TimeValue.seconds(30))
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON);
+    }
+
+    private static String exact(Class<?> benchmarkClass, String method) {
+        return "^" + Pattern.quote(benchmarkClass.getName() + "." + method) + "$";
+    }
+}

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -35,6 +35,7 @@ import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.HelidonSocket;
+import io.helidon.common.uri.UriFragment;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.Header;
@@ -276,6 +277,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                              + request.headers().get(HeaderNames.HOST).get()
                                              + " HTTP/1.1\r\n");
         } else {
+            String requestTarget = requestTarget(uri);
             // When proxy is set, ensure that the request uses absolute URI because of Section 5.1.2 Request-URI in
             // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html which states: "The absoluteURI form is REQUIRED when the
             // request is being made to a proxy."
@@ -292,7 +294,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             nonEntityData.writeAscii(request.method().text()
                                              + " "
                                              + requestUri
-                                             + uri.pathWithQueryAndFragment()
+                                             + requestTarget
                                              + " HTTP/1.1\r\n");
         }
 
@@ -303,7 +305,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                                                                            request.method(),
                                                                                            uri.path(),
                                                                                            uri.query(),
-                                                                                           uri.fragment()));
+                                                                                           UriFragment.empty()));
         }
     }
 
@@ -530,6 +532,17 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Chunk size is not a number");
         }
+    }
+
+    private static String requestTarget(ClientUri uri) {
+        String requestTarget = uri.pathWithQueryAndFragment();
+        var fragment = uri.fragment();
+        if (!fragment.hasValue()) {
+            return requestTarget;
+        }
+        String rawFragment = fragment.rawValue();
+        int fragmentLength = requestTarget.endsWith(rawFragment) ? rawFragment.length() : fragment.value().length();
+        return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
     }
 
     private ClientConnection obtainConnection(ClientConnectionTarget connectionTarget,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -29,6 +29,7 @@ import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
+import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriInfo;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
@@ -425,7 +426,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                                                                request.method(),
                                                                uri.path(),
                                                                uri.query(),
-                                                               uri.fragment()));
+                                                               UriFragment.empty()));
             }
 
             writeHeaders(connection,

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -89,6 +89,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.noHeader;
@@ -799,6 +800,64 @@ class Http1ClientTest {
             String message = messages.getFirst();
             assertThat(message, containsString("Authorization: Bearer secret-token"));
             assertThat(message, containsString("Cookie: session=secret-cookie"));
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
+            handler.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRequestFragmentOmittedFromWireAndSendLog(boolean outputStream) {
+        String fragment = "send-listener-fragment";
+        Logger logger = Logger.getLogger(CLIENT_SEND_LOGGER_NAME);
+        Level previousLevel = logger.getLevel();
+        boolean previousUseParentHandlers = logger.getUseParentHandlers();
+        List<String> messages = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                messages.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.FINER);
+
+        try {
+            Http1Client client = Http1Client.builder()
+                    .protocolConfig(it -> it.log(log -> log.sendLog(true)
+                            .receiveLog(false)
+                            .unsafeRawData(true)))
+                    .build();
+            FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection();
+            Http1ClientRequest request = client.put("http://localhost:" + dummyPort + "/test")
+                    .fragment(fragment);
+            request.connection(connection);
+
+            Http1ClientResponse response = outputStream
+                    ? getHttp1ClientResponseFromOutputStream(request, new String[] {"Sending Something"})
+                    : request.submit("Sending Something");
+            assertThat(response.entity().as(String.class), is("Sending Something"));
+
+            assertThat(connection.getPrologue(), not(containsString(fragment)));
+            List<String> prologueMessages = messages.stream()
+                    .filter(message -> message.contains(" prologue: "))
+                    .toList();
+            assertThat(prologueMessages.isEmpty(), is(false));
+            assertThat(prologueMessages.toString(), not(containsString(fragment)));
         } finally {
             logger.removeHandler(handler);
             logger.setLevel(previousLevel);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -390,8 +390,10 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
     protected static Http2Headers prepareHeaders(Method method, ClientRequestHeaders headers, ClientUri uri) {
         Http2Headers h2Headers = Http2Headers.create(headers);
         h2Headers.method(method);
-        h2Headers.path(uri.pathWithQueryAndFragment());
-        h2Headers.scheme(uri.scheme());
+        if (!Method.CONNECT.equals(method)) {
+            h2Headers.path(requestTarget(uri));
+            h2Headers.scheme(uri.scheme());
+        }
 
         return h2Headers;
     }
@@ -425,6 +427,17 @@ abstract class Http2CallChainBase implements WebClientService.WireProtocolChain 
         requestHeaders.first(Http2Headers.AUTHORITY_NAME)
                 .ifPresentOrElse(authority -> requestHeaders.set(HeaderValues.create(HeaderNames.HOST, authority)),
                                  () -> requestHeaders.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority())));
+    }
+
+    private static String requestTarget(ClientUri uri) {
+        String requestTarget = uri.pathWithQueryAndFragment();
+        var fragment = uri.fragment();
+        if (!fragment.hasValue()) {
+            return requestTarget;
+        }
+        String rawFragment = fragment.rawValue();
+        int fragmentLength = requestTarget.endsWith(rawFragment) ? rawFragment.length() : fragment.value().length();
+        return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
     }
 
     private static final class LogHeaderConsumer implements Consumer<Header> {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -224,6 +224,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
             readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
             incrementInboundWindowSizeLocked(header.length());
+            buffer.dataProcessed(header.length());
         } finally {
             inboundStateLock.unlock();
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -753,7 +753,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                         failInboundLocked(e);
                         incrementInboundWindowSizeLocked(discardedDataLength);
                     } finally {
-                        trailers.completeExceptionally(e);
+                        Thread.startVirtualThread(() -> completeTrailersFailure(e));
                     }
                 } else {
                     failInboundLocked(e);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -743,10 +743,14 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 }
             } catch (Http2Exception e) {
                 if (trailerBlock) {
+                    int discardedDataLength = buffer.discard();
+                    failInboundLocked(e);
+                    incrementInboundWindowSizeLocked(discardedDataLength);
                     buffer.fail(e);
                     trailers.completeExceptionally(e);
+                } else {
+                    failInboundLocked(e);
                 }
-                failInboundLocked(e);
                 inboundStateChanged.signalAll();
                 return;
             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -744,10 +744,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 }
             } catch (Http2Exception e) {
                 if (trailerBlock) {
-                    int discardedDataLength = buffer.discard();
+                    int discardedDataLength = buffer.failAndDiscard(e);
                     failInboundLocked(e);
                     incrementInboundWindowSizeLocked(discardedDataLength);
-                    buffer.fail(e);
                     trailers.completeExceptionally(e);
                 } else {
                     failInboundLocked(e);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -731,17 +731,24 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             if (closed) {
                 return;
             }
-            if (readState == ReadState.CONTINUE_100_HEADERS || readState == ReadState.HEADERS) {
-                try {
+            boolean trailerBlock = readState == ReadState.DATA || readState == ReadState.TRAILERS;
+            try {
+                if (readState == ReadState.CONTINUE_100_HEADERS || readState == ReadState.HEADERS) {
                     headers.validateResponse();
                     if (protocolConfig().validateResponseHeaders()) {
                         validateRegularHeaders(headers.httpHeaders());
                     }
-                } catch (Http2Exception e) {
-                    failInboundLocked(e);
-                    inboundStateChanged.signalAll();
-                    return;
+                } else if (trailerBlock) {
+                    headers.validateTrailers();
                 }
+            } catch (Http2Exception e) {
+                if (trailerBlock) {
+                    buffer.fail(e);
+                    trailers.completeExceptionally(e);
+                }
+                failInboundLocked(e);
+                inboundStateChanged.signalAll();
+                return;
             }
             switch (readState) {
             case CONTINUE_100_HEADERS -> continue100Locked(headers, endOfStream);

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -745,9 +745,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
             } catch (Http2Exception e) {
                 if (trailerBlock) {
                     int discardedDataLength = buffer.failAndDiscard(e);
-                    failInboundLocked(e);
-                    incrementInboundWindowSizeLocked(discardedDataLength);
-                    trailers.completeExceptionally(e);
+                    try {
+                        failInboundLocked(e);
+                        incrementInboundWindowSizeLocked(discardedDataLength);
+                    } finally {
+                        trailers.completeExceptionally(e);
+                    }
                 } else {
                     failInboundLocked(e);
                 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -733,6 +733,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                 return;
             }
             boolean trailerBlock = readState == ReadState.DATA || readState == ReadState.TRAILERS;
+            if (trailerBlock && !endOfStream) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL,
+                                         "Received trailers without END_STREAM");
+            }
             try {
                 if (readState == ReadState.CONTINUE_100_HEADERS || readState == ReadState.HEADERS) {
                     headers.validateResponse();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -103,14 +103,18 @@ class StreamBuffer {
         }
     }
 
-    int discard() {
+    int failAndDiscard(RuntimeException failure) {
         int discardedDataLength;
         try {
             streamLock.lock();
+            if (this.failure == null) {
+                this.failure = failure;
+            }
             discardedDataLength = unprocessedDataLength.getAndSet(0);
             buffer.clear();
         } finally {
             streamLock.unlock();
+            dequeSemaphore.release();
         }
         return discardedDataLength;
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -34,6 +35,7 @@ class StreamBuffer {
     private final Queue<InboundItem> buffer = new ArrayDeque<>();
     private final Http2ClientStream stream;
     private final int streamId;
+    private final AtomicInteger unprocessedDataLength = new AtomicInteger();
     private volatile RuntimeException failure;
 
     StreamBuffer(Http2ClientStream stream, int streamId) {
@@ -79,6 +81,9 @@ class StreamBuffer {
         try {
             streamLock.lock();
             buffer.add(item);
+            if (item instanceof InboundData inboundData) {
+                unprocessedDataLength.addAndGet(inboundData.frameData().header().length());
+            }
         } finally {
             streamLock.unlock();
             // Release deque threads
@@ -99,19 +104,19 @@ class StreamBuffer {
     }
 
     int discard() {
-        int discardedDataLength = 0;
+        int discardedDataLength;
         try {
             streamLock.lock();
-            for (InboundItem item : buffer) {
-                if (item instanceof InboundData inboundData) {
-                    discardedDataLength += inboundData.frameData().header().length();
-                }
-            }
+            discardedDataLength = unprocessedDataLength.getAndSet(0);
             buffer.clear();
         } finally {
             streamLock.unlock();
         }
         return discardedDataLength;
+    }
+
+    void dataProcessed(int dataLength) {
+        unprocessedDataLength.addAndGet(-dataLength);
     }
 
     sealed interface InboundItem permits InboundData, InboundTrailers {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -98,6 +98,22 @@ class StreamBuffer {
         }
     }
 
+    int discard() {
+        int discardedDataLength = 0;
+        try {
+            streamLock.lock();
+            for (InboundItem item : buffer) {
+                if (item instanceof InboundData inboundData) {
+                    discardedDataLength += inboundData.frameData().header().length();
+                }
+            }
+            buffer.clear();
+        } finally {
+            streamLock.unlock();
+        }
+        return discardedDataLength;
+    }
+
     sealed interface InboundItem permits InboundData, InboundTrailers {
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallChainBaseTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallChainBaseTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.webclient.api.ClientUri;
@@ -28,6 +29,7 @@ import io.helidon.webclient.api.ClientUri;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class Http2CallChainBaseTest {
@@ -59,6 +61,34 @@ class Http2CallChainBaseTest {
         Http2CallChainBase.alignHostHeader(uri(), headers);
 
         assertThat(headers.first(HeaderNames.HOST).orElseThrow(), is("service.example:8443"));
+    }
+
+    @Test
+    void ordinaryConnectOmitsSchemeAndPath() {
+        ClientRequestHeaders headers = emptyHeaders();
+        ClientUri uri = uri();
+        Http2CallChainBase.alignHostHeader(uri, headers);
+
+        Http2Headers http2Headers = Http2CallChainBase.prepareHeaders(Method.CONNECT, headers, uri);
+
+        http2Headers.validateRequest();
+        assertThat(http2Headers.method(), is(Method.CONNECT));
+        assertThat(http2Headers.authority(), is("service.example:8443"));
+        assertThat(http2Headers.scheme(), is(nullValue()));
+        assertThat(http2Headers.path(), is(nullValue()));
+    }
+
+    @Test
+    void ordinaryRequestKeepsSchemeAndPath() {
+        ClientRequestHeaders headers = emptyHeaders();
+        ClientUri uri = uri();
+        Http2CallChainBase.alignHostHeader(uri, headers);
+
+        Http2Headers http2Headers = Http2CallChainBase.prepareHeaders(Method.GET, headers, uri);
+
+        http2Headers.validateRequest();
+        assertThat(http2Headers.scheme(), is("https"));
+        assertThat(http2Headers.path(), is("/path"));
     }
 
     private static ClientRequestHeaders emptyHeaders() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallOutputStreamChainTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2CallOutputStreamChainTest.java
@@ -17,17 +17,21 @@
 package io.helidon.webclient.http2;
 
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.Http2Headers;
 import io.helidon.webclient.api.ClientRequest;
+import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.WebClientServiceRequest;
 
@@ -41,6 +45,18 @@ import static org.mockito.Mockito.when;
 
 class Http2CallOutputStreamChainTest {
     private static final String BLOCKED_REDIRECT_MESSAGE = "Cross-origin redirect with request entity is disabled.";
+
+    @Test
+    void fragmentIsNotWrittenToPathPseudoHeader() {
+        ClientUri uri = ClientUri.create(URI.create("https://example.com/resource?query=value#fragment"));
+
+        Http2Headers headers = Http2CallChainBase.prepareHeaders(Method.GET,
+                                                                 ClientRequestHeaders.create(WritableHeaders.create()),
+                                                                 uri);
+
+        assertThat(headers.path(), is("/resource?query=value"));
+        assertThat(uri.fragment().value(), is("fragment"));
+    }
 
     @Test
     void doesNotProbeOneShotHandlerAfterHttp1FallbackAlreadySentEntity() throws Exception {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.socket.SocketContext;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
@@ -1746,6 +1747,77 @@ class Http2ClientConnectionTest {
 
             stream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void pseudoHeaderInTrailersRestoresConnectionWindowForDequeuedData() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            CountDownLatch dataDequeued = new CountDownLatch(1);
+            CountDownLatch resumeEntityReader = new CountDownLatch(1);
+            AtomicReference<Thread> entityReaderThread = new AtomicReference<>();
+            Http2FrameListener recvListener = new Http2FrameListener() {
+                @Override
+                public void frame(SocketContext ctx, int streamId, BufferData data) {
+                    if (Thread.currentThread() == entityReaderThread.get()) {
+                        dataDequeued.countDown();
+                        try {
+                            assertThat(resumeEntityReader.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS),
+                                       is(true));
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException("Interrupted while holding dequeued DATA", e);
+                        }
+                    }
+                }
+            };
+            when(test.client.recvListener()).thenReturn(recvListener);
+
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            long initialConnectionWindow = connection.flowControl().incrementInboundConnectionWindowSize(0);
+            byte[] entityBytes = "hello".getBytes(StandardCharsets.UTF_8);
+            CompletableFuture<BufferData> entity = CompletableFuture.supplyAsync(() -> {
+                entityReaderThread.set(Thread.currentThread());
+                return stream.read();
+            });
+            try {
+                test.offerInbound(dataFrame(stream.streamId(), entityBytes, false));
+                assertThat(dataDequeued.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+
+                Http2Headers trailers = encodedTrailers().path("/forbidden");
+                test.offerInbound(encodedHeaderFrame(stream.streamId(), trailers, inboundTable, huffman, true));
+
+                ExecutionException trailersFailure = assertThrows(
+                        ExecutionException.class,
+                        () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThat(trailersFailure.getCause(), instanceOf(Http2Exception.class));
+                assertThat(((Http2Exception) trailersFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+                assertThat(connection.flowControl().incrementInboundConnectionWindowSize(0), is(initialConnectionWindow));
+
+                resumeEntityReader.countDown();
+                ExecutionException entityFailure = assertThrows(
+                        ExecutionException.class,
+                        () -> entity.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+                assertThat(entityFailure.getCause(), instanceOf(Http2Exception.class));
+                assertThat(((Http2Exception) entityFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+            } finally {
+                resumeEntityReader.countDown();
+                stream.close();
+                connection.close();
+            }
         }
     }
 

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1715,6 +1715,41 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void pseudoHeaderInTrailersRestoresConnectionWindowForDiscardedData() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            long initialConnectionWindow = connection.flowControl().incrementInboundConnectionWindowSize(0);
+            byte[] entity = "hello".getBytes(StandardCharsets.UTF_8);
+            Http2Headers trailers = encodedTrailers().path("/forbidden");
+            test.offerInbound(dataFrame(stream.streamId(), entity, false),
+                              encodedHeaderFrame(stream.streamId(), trailers, inboundTable, huffman, true));
+
+            ExecutionException trailersFailure = assertThrows(
+                    ExecutionException.class,
+                    () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+            assertThat(trailersFailure.getCause(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) trailersFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+            assertThat(connection.flowControl().incrementInboundConnectionWindowSize(0), is(initialConnectionWindow));
+
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1670,6 +1670,51 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void pseudoHeaderInTrailersFailsStream() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            CountDownLatch entityReadStarted = new CountDownLatch(1);
+            CompletableFuture<BufferData> entity = CompletableFuture.supplyAsync(() -> {
+                entityReadStarted.countDown();
+                return stream.read();
+            });
+            assertThat(entityReadStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+            assertThrows(TimeoutException.class, () -> entity.get(200, TimeUnit.MILLISECONDS));
+
+            Http2Headers trailers = encodedTrailers().path("/forbidden");
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), trailers, inboundTable, huffman, true));
+
+            ExecutionException entityFailure = assertThrows(
+                    ExecutionException.class,
+                    () -> entity.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+            assertThat(entityFailure.getCause(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) entityFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+
+            ExecutionException trailersFailure = assertThrows(
+                    ExecutionException.class,
+                    () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+            assertThat(trailersFailure.getCause(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) trailersFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1833,6 +1833,48 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void invalidTrailersCompleteFutureWhenWindowUpdateFails() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            doAnswer(invocation -> {
+                BufferData frame = invocation.getArgument(0);
+                if (frame.get(3) == Http2FrameType.WINDOW_UPDATE.type()) {
+                    throw new UncheckedIOException(new IOException("expected WINDOW_UPDATE failure"));
+                }
+                return null;
+            }).when(test.dataWriter).writeNow(any(BufferData.class));
+
+            byte[] entity = "hello".getBytes(StandardCharsets.UTF_8);
+            Http2Headers trailers = encodedTrailers().path("/forbidden");
+            test.offerInbound(dataFrame(stream.streamId(), entity, false),
+                              encodedHeaderFrame(stream.streamId(), trailers, inboundTable, huffman, true));
+
+            ExecutionException trailersFailure = assertThrows(
+                    ExecutionException.class,
+                    () -> stream.trailers().get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS));
+            assertThat(trailersFailure.getCause(), instanceOf(Http2Exception.class));
+            assertThat(((Http2Exception) trailersFailure.getCause()).code(), is(Http2ErrorCode.PROTOCOL));
+            test.assertConnectionClosed();
+
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1716,6 +1716,61 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void invalidTrailersCallbackDoesNotBlockSiblingStream() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream firstStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream secondStream = connection.createStream(STREAM_CONFIG);
+            firstStream.writeHeaders(requestHeaders(), true);
+            secondStream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(firstStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(firstStream.readHeaders().status(), is(Status.OK_200));
+
+            CountDownLatch callbackStarted = new CountDownLatch(1);
+            CountDownLatch releaseCallback = new CountDownLatch(1);
+            CompletableFuture<Headers> publishedTrailers = firstStream.trailers().thenApply(it -> it);
+            publishedTrailers.whenComplete((_, _) -> {
+                callbackStarted.countDown();
+                try {
+                    releaseCallback.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            try {
+                Http2Headers invalidTrailers = encodedTrailers().path("/forbidden");
+                test.offerInbound(encodedHeaderFrame(firstStream.streamId(),
+                                                     invalidTrailers,
+                                                     inboundTable,
+                                                     huffman,
+                                                     true),
+                                  encodedHeaderFrame(secondStream.streamId(),
+                                                     encodedResponseHeaders(false),
+                                                     inboundTable,
+                                                     huffman,
+                                                     true));
+
+                assertThat(callbackStarted.await(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS), is(true));
+                assertThat(secondStream.readHeaders().status(), is(Status.OK_200));
+            } finally {
+                releaseCallback.countDown();
+                firstStream.close();
+                secondStream.close();
+                connection.close();
+            }
+        }
+    }
+
+    @Test
     void pseudoHeaderInTrailersRestoresConnectionWindowForDiscardedData() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             test.offerInbound(settingsFrame(10));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1875,6 +1875,33 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void pseudoHeaderTrailersWithoutEndStreamCloseConnection() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(stream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(stream.readHeaders().status(), is(Status.OK_200));
+
+            Http2Headers trailers = encodedTrailers().path("/forbidden");
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), trailers, inboundTable, huffman, false));
+
+            test.assertConnectionClosed();
+
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1822,6 +1822,17 @@ class Http2ClientConnectionTest {
     }
 
     @Test
+    void discardedStreamBufferPublishesFailure() {
+        StreamBuffer buffer = new StreamBuffer(mock(Http2ClientStream.class), 1);
+        byte[] entity = "hello".getBytes(StandardCharsets.UTF_8);
+        buffer.push(dataFrame(1, entity, false));
+        Http2Exception failure = new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid trailers");
+
+        assertThat(buffer.failAndDiscard(failure), is(entity.length));
+        assertThat(assertThrows(Http2Exception.class, () -> buffer.poll(Duration.ZERO)), is(failure));
+    }
+
+    @Test
     void createWaitsForInitialSettingsAndHonorsPeerMaxConcurrentStreams() throws Exception {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
             CompletableFuture<Http2ClientConnection> connectionFuture = new CompletableFuture<>();

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/GreetService.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/GreetService.java
@@ -131,7 +131,9 @@ public class GreetService implements HttpService {
 
     private void valuesPropagated(ServerRequest serverRequest, ServerResponse serverResponse) {
         String queryParam = serverRequest.query().first("param").orElse("Query param not present");
-        String fragment = serverRequest.prologue().fragment().value();
+        String fragment = serverRequest.prologue().fragment().hasValue()
+                ? serverRequest.prologue().fragment().value()
+                : "";
         serverResponse.status(Status.OK_200);
         serverResponse.send(queryParam + " " + fragment);
     }

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/UriPartTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/UriPartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ class UriPartTest extends TestParent {
     }
 
     @Test
-    void testFragment() {
+    void testFragmentIsNotSent() {
         String fragment = "super fragment#&?/";
         String response = noSecurityClient.get()
                 .path("obtainedQuery")
@@ -93,18 +93,18 @@ class UriPartTest extends TestParent {
                 .queryParam("empty", "")
                 .fragment(fragment)
                 .requestEntity(String.class);
-        assertThat(response.trim(), is(fragment));
+        assertThat(response.trim(), is(""));
     }
 
     @Test
-    void testBadFragment() {
-        String fragment = "super fragment#&?/"; // contains illegal characters, that should break validation
+    void testUnencodedFragmentIsNotSent() {
+        String fragment = "super fragment#&?/";
         try (HttpClientResponse response = noSecurityClient.get()
                 .skipUriEncoding(true)
                 .fragment(fragment)
                 .request()) {
 
-            assertThat(response.status(), is(Status.BAD_REQUEST_400));
+            assertThat(response.status(), is(Status.OK_200));
         }
     }
 

--- a/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/WebclientServiceValuePropagationTest.java
+++ b/webclient/tests/webclient/src/test/java/io/helidon/webclient/tests/WebclientServiceValuePropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,13 +45,17 @@ class WebclientServiceValuePropagationTest extends TestParent {
         Http1Client webClient = Http1Client.builder()
                 .baseUri(URI.create("http://invalid"))
                 .addService(new UriChangingService())
+                .addService((chain, request) -> {
+                    assertThat(request.uri().fragment().value(), is("Test"));
+                    return chain.proceed(request);
+                })
                 .build();
 
         String response = webClient.get("/greet/valuesPropagated")
                 .path("replace/me")
                 .requestEntity(String.class);
 
-        assertThat(response, is("Hi Test"));
+        assertThat(response, is("Hi "));
     }
 
     @Test

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ConfigBlueprint.java
@@ -150,7 +150,7 @@ interface Http2ConfigBlueprint extends ProtocolConfig, HttpConfig {
     int maxEmptyFrames();
 
     /**
-     * If set to false, any path is accepted (even containing illegal characters).
+     * Whether to validate path characters and the HTTP/2 {@code :path} pseudo-header.
      *
      * @return whether to validate path
      */

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -1000,11 +1000,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             headers.validateRequest();
             return true;
         } catch (Http2Exception e) {
-            Method method = headers.method();
-            boolean connect = Method.CONNECT.equals(method);
-            String path = headers.path();
-            boolean invalidPath = method != null && !connect && (path == null || path.isEmpty());
-            if (e.code() != Http2ErrorCode.PROTOCOL || (!connect && !invalidPath)) {
+            boolean connect = Method.CONNECT.equals(headers.method());
+            if (e.code() != Http2ErrorCode.PROTOCOL || (!connect && !e.requestTarget())) {
                 throw e;
             }
             if (newStream) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -998,7 +998,12 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         if (!endOfStream) {
             throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers without endOfStream flag " + streamId);
         }
-        if ("".equals(headers.path())) {
+        try {
+            headers.validateTrailers();
+        } catch (Http2Exception e) {
+            if (e.code() != Http2ErrorCode.PROTOCOL) {
+                throw e;
+            }
             stream.resetProtocolError(0, true);
             state = State.READ_FRAME;
             return false;

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -942,8 +942,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
 
 
         if (trailers) {
-            if (!endOfStream) {
-                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers without endOfStream flag " + streamId);
+            if (!validateRequestTrailers(headers, stream, streamId, endOfStream)) {
+                return;
             }
             stream.closeFromRemote();
             state = State.READ_FRAME;
@@ -989,6 +989,21 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         // we now have all information needed to execute
         ctx.executor()
                 .submit(new StreamRunnable(streams, stream, Thread.currentThread()));
+    }
+
+    private boolean validateRequestTrailers(Http2Headers headers,
+                                            Http2ServerStream stream,
+                                            int streamId,
+                                            boolean endOfStream) {
+        if (!endOfStream) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers without endOfStream flag " + streamId);
+        }
+        if ("".equals(headers.path())) {
+            stream.resetProtocolError(0, true);
+            state = State.READ_FRAME;
+            return false;
+        }
+        return true;
     }
 
     private boolean validateRequestHeaders(Http2Headers headers,

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -33,9 +33,15 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.parameters.Parameters;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.task.InterruptableTask;
 import io.helidon.common.tls.TlsUtils;
+import io.helidon.common.uri.UriFragment;
+import io.helidon.common.uri.UriPath;
+import io.helidon.common.uri.UriPathSegment;
+import io.helidon.common.uri.UriQuery;
+import io.helidon.common.uri.UriValidator;
 import io.helidon.http.DateTime;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
@@ -408,6 +414,45 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             if (connectionThread != null && connectionThread != Thread.currentThread()) {
                 connectionThread.interrupt();
             }
+        }
+    }
+
+    private static void validateConnectAuthority(String authority) {
+        int portSeparator;
+        if (authority.charAt(0) == '[') {
+            int closingBracket = authority.indexOf(']');
+            if (closingBracket == -1) {
+                throw new IllegalArgumentException("CONNECT authority is missing a closing bracket");
+            }
+            UriValidator.validateIpLiteral(authority.substring(0, closingBracket + 1));
+            portSeparator = closingBracket + 1;
+            if (portSeparator == authority.length() || authority.charAt(portSeparator) != ':') {
+                throw new IllegalArgumentException("CONNECT authority must include a port");
+            }
+        } else {
+            portSeparator = authority.lastIndexOf(':');
+            if (portSeparator <= 0 || authority.indexOf(':') != portSeparator) {
+                throw new IllegalArgumentException("CONNECT authority must contain a host and port");
+            }
+            UriValidator.validateNonIpLiteral(authority.substring(0, portSeparator));
+        }
+
+        if (portSeparator == authority.length() - 1) {
+            throw new IllegalArgumentException("CONNECT authority port cannot be blank");
+        }
+        int port = 0;
+        for (int i = portSeparator + 1; i < authority.length(); i++) {
+            char c = authority.charAt(i);
+            if (c < '0' || c > '9') {
+                throw new IllegalArgumentException("CONNECT authority port must contain only digits");
+            }
+            port = port * 10 + c - '0';
+            if (port > 65535) {
+                throw new IllegalArgumentException("CONNECT authority port must be between 1 and 65535");
+            }
+        }
+        if (port == 0) {
+            throw new IllegalArgumentException("CONNECT authority port must be between 1 and 65535");
         }
     }
 
@@ -906,7 +951,9 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             return;
         }
 
-        headers.validateRequest();
+        if (!validateRequestHeaders(headers, stream, streamId, newStream, endOfStream)) {
+            return;
+        }
         if (http2Config.validateRequestHeaders()) {
             for (var header : headers.httpHeaders()) {
                 if (!SERVER_CONTROLLED_REQUEST_HEADERS.contains(header.headerName())) {
@@ -918,17 +965,17 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
                 }
             }
         }
-        String path = headers.path();
-        Method method = headers.method();
         if (newStream) {
             activateStream(streamId);
         }
-        HttpPrologue httpPrologue = HttpPrologue.create(FULL_PROTOCOL,
-                                                        PROTOCOL,
-                                                        PROTOCOL_VERSION,
-                                                        method,
-                                                        path,
-                                                        http2Config.validatePath());
+        HttpPrologue httpPrologue;
+        try {
+            httpPrologue = createPrologue(headers);
+        } catch (IllegalArgumentException _) {
+            stream.resetProtocolError(0, endOfStream);
+            state = State.READ_FRAME;
+            return;
+        }
         stream.prologue(httpPrologue);
         stream.requestLimit(limit);
         stream.headers(headers, endOfStream);
@@ -942,6 +989,27 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         // we now have all information needed to execute
         ctx.executor()
                 .submit(new StreamRunnable(streams, stream, Thread.currentThread()));
+    }
+
+    private boolean validateRequestHeaders(Http2Headers headers,
+                                           Http2ServerStream stream,
+                                           int streamId,
+                                           boolean newStream,
+                                           boolean endOfStream) {
+        try {
+            headers.validateRequest();
+            return true;
+        } catch (Http2Exception e) {
+            if (!Method.CONNECT.equals(headers.method())) {
+                throw e;
+            }
+            if (newStream) {
+                activateStream(streamId);
+            }
+            stream.resetProtocolError(0, endOfStream);
+            state = State.READ_FRAME;
+            return false;
+        }
     }
 
     private void decodeDroppedInboundHeaders(Http2FrameData... headerFrames) {
@@ -991,6 +1059,62 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         } else {
             emptyFrames = 0;
         }
+    }
+
+    private HttpPrologue createPrologue(Http2Headers headers) {
+        Method method = headers.method();
+        if (Method.CONNECT.equals(method)) {
+            String authority = headers.authority();
+            if (http2Config.validatePath()) {
+                validateConnectAuthority(authority);
+            }
+            return HttpPrologue.create(FULL_PROTOCOL,
+                                       PROTOCOL,
+                                       PROTOCOL_VERSION,
+                                       method,
+                                       new AuthorityFormPath(authority),
+                                       UriQuery.empty(),
+                                       UriFragment.empty());
+        }
+
+        String path = headers.path();
+        HttpPrologue prologue;
+        if (validateRequestTarget(method, path)) {
+            prologue = HttpPrologue.create(FULL_PROTOCOL,
+                                           PROTOCOL,
+                                           PROTOCOL_VERSION,
+                                           method,
+                                           UriPath.createRelative(UriPath.root(), path),
+                                           UriQuery.empty(),
+                                           UriFragment.empty());
+        } else {
+            prologue = HttpPrologue.create(FULL_PROTOCOL,
+                                           PROTOCOL,
+                                           PROTOCOL_VERSION,
+                                           method,
+                                           path,
+                                           http2Config.validatePath());
+        }
+        if (http2Config.validatePath() && prologue.hasQuery()) {
+            UriValidator.validateQuery(prologue.query().rawValue());
+        }
+        return prologue;
+    }
+
+    private boolean validateRequestTarget(Method method, String requestTarget) {
+        boolean specialRequestTarget = Method.OPTIONS.equals(method) && "*".equals(requestTarget);
+        if (!http2Config.validatePath()) {
+            return specialRequestTarget;
+        }
+        if (specialRequestTarget) {
+            return true;
+        }
+        if (!requestTarget.isEmpty()
+                && requestTarget.charAt(0) == '/'
+                && requestTarget.indexOf('#') == -1) {
+            return false;
+        }
+        throw new IllegalArgumentException("Invalid HTTP/2 request-target form");
     }
 
     private void activateStream(int streamId) {
@@ -1194,6 +1318,44 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         CONTINUATION,
         // unknown frames must be discarded
         UNKNOWN
+    }
+
+    private record AuthorityFormPath(String rawPath) implements UriPath {
+        private static final Parameters EMPTY_PARAMETERS = Parameters.empty("uri/authority");
+
+        @Override
+        public String rawPathNoParams() {
+            return rawPath;
+        }
+
+        @Override
+        public String path() {
+            return "";
+        }
+
+        @Override
+        public Parameters matrixParameters() {
+            return EMPTY_PARAMETERS;
+        }
+
+        @Override
+        public UriPath absolute() {
+            return this;
+        }
+
+        @Override
+        public List<UriPathSegment> segments() {
+            return List.of();
+        }
+
+        @Override
+        public void validate() {
+        }
+
+        @Override
+        public String toString() {
+            return rawPath;
+        }
     }
 
     // Package-private for deterministic tests of writer-thread failure handling.

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -1000,7 +1000,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             headers.validateRequest();
             return true;
         } catch (Http2Exception e) {
-            if (!Method.CONNECT.equals(headers.method())) {
+            if (e.code() != Http2ErrorCode.PROTOCOL) {
                 throw e;
             }
             if (newStream) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -1000,7 +1000,11 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             headers.validateRequest();
             return true;
         } catch (Http2Exception e) {
-            if (e.code() != Http2ErrorCode.PROTOCOL) {
+            Method method = headers.method();
+            boolean connect = Method.CONNECT.equals(method);
+            String path = headers.path();
+            boolean invalidPath = method != null && !connect && (path == null || path.isEmpty());
+            if (e.code() != Http2ErrorCode.PROTOCOL || (!connect && !invalidPath)) {
                 throw e;
             }
             if (newStream) {

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -74,6 +74,7 @@ import io.helidon.webserver.Router;
 import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.SniContext;
 import io.helidon.webserver.SniRequestSupport;
+import io.helidon.webserver.http.DirectTransportRequest;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 import io.helidon.webserver.http2.spi.SubProtocolResult;
@@ -424,13 +425,13 @@ class Http2ServerStream implements Runnable, Http2Stream {
             return;
         }
         if (expectedLength != -1 && expectedLength < dataLength) {
-            resetInvalidContentLength(header.length(), endOfStream);
+            resetProtocolError(header.length(), endOfStream);
             return;
         }
         if (expectedLength != -1) {
             expectedLength -= dataLength;
             if (endOfStream && expectedLength != 0) {
-                resetInvalidContentLength(header.length(), true);
+                resetProtocolError(header.length(), true);
                 return;
             }
         }
@@ -796,7 +797,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     void closeFromRemote() {
         if (expectedLength != -1 && expectedLength != 0) {
-            resetInvalidContentLength(0, true);
+            resetProtocolError(0, true);
             return;
         }
         resetCompletionLock.lock();
@@ -956,7 +957,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
         this.requestLimit = limit;
     }
 
-    private void resetInvalidContentLength(int currentFrameLength, boolean endOfStream) {
+    void resetProtocolError(int currentFrameLength, boolean endOfStream) {
         Http2RstStream rst = new Http2RstStream(Http2ErrorCode.PROTOCOL);
         boolean sendReset = false;
         resetCompletionLock.lock();
@@ -1247,6 +1248,15 @@ class Http2ServerStream implements Runnable, Http2Stream {
 
     private void handle() {
         Headers httpHeaders = headers.httpHeaders();
+        if (Method.CONNECT.equals(prologue.method())) {
+            throw RequestException.builder()
+                    .type(DirectHandler.EventType.OTHER)
+                    .status(Status.NOT_IMPLEMENTED_501)
+                    .request(DirectTransportRequest.create(prologue, httpHeaders))
+                    .message("CONNECT is not supported over HTTP/2")
+                    .safeMessage(true)
+                    .build();
+        }
         if (httpHeaders.containsToken(HeaderValues.EXPECT_100)) {
             writeState.updateAndGet(s -> s.checkAndMove(WriteState.EXPECTED_100));
         }

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/ConnectionStreamTest.java
@@ -29,6 +29,8 @@ import io.helidon.common.socket.SocketContext;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.ConnectionFlowControl;
 import io.helidon.http.http2.FlowControl;
@@ -372,20 +374,28 @@ class ConnectionStreamTest {
         when(ctx.router()).thenReturn(Router.empty());
         when(ctx.listenerContext()).thenReturn(listenerContext);
 
-        return new Http2ServerStream(ctx,
-                                     streams,
-                                     NO_OP_RESET_TRACKER,
-                                     HttpRouting.empty(),
-                                     config,
-                                     subProtocols,
-                                     STREAM_ID,
-                                     Http2Settings.builder().build(),
-                                     Http2Settings.builder().build(),
-                                     writer,
-                                     flowControl,
-                                     new Http2ServerStream.InboundDataBudget(1024,
-                                                                             2L * config.initialWindowSize()),
-                                     new Http2ConnectionChecks(config, mock(Http2Connection.class)));
+        Http2ServerStream stream = new Http2ServerStream(ctx,
+                                                        streams,
+                                                        NO_OP_RESET_TRACKER,
+                                                        HttpRouting.empty(),
+                                                        config,
+                                                        subProtocols,
+                                                        STREAM_ID,
+                                                        Http2Settings.builder().build(),
+                                                        Http2Settings.builder().build(),
+                                                        writer,
+                                                        flowControl,
+                                                        new Http2ServerStream.InboundDataBudget(
+                                                                1024,
+                                                                2L * config.initialWindowSize()),
+                                                        new Http2ConnectionChecks(config, mock(Http2Connection.class)));
+        stream.prologue(HttpPrologue.create(Http2Connection.FULL_PROTOCOL,
+                                            Http2Connection.PROTOCOL,
+                                            Http2Connection.PROTOCOL_VERSION,
+                                            Method.GET,
+                                            "/",
+                                            false));
+        return stream;
     }
 
     private static final class AsyncSubProtocolHandler implements Http2SubProtocolSelector.SubProtocolHandler {

--- a/webserver/security/src/test/java/io/helidon/webserver/security/SpecialRequestTargetTest.java
+++ b/webserver/security/src/test/java/io/helidon/webserver/security/SpecialRequestTargetTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.security;
+
+import java.util.List;
+
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityContext;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class SpecialRequestTargetTest {
+    private final SocketHttpClient client;
+
+    SpecialRequestTargetTest(SocketHttpClient client) {
+        this.client = client;
+    }
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder server) {
+        Handler handler = (req, res) -> {
+            var path = req.prologue().uriPath();
+            var securityContext = req.context().get(SecurityContext.class).orElseThrow();
+            var status = Method.CONNECT.equals(req.prologue().method())
+                    ? Status.NOT_IMPLEMENTED_501
+                    : Status.OK_200;
+            res.status(status)
+                    .send(path.rawPath()
+                                  + '|' + path.path()
+                                  + '|' + path.absolute().path()
+                                  + '|' + req.requestedUri().toUri()
+                                  + '|' + securityContext.env().targetUri()
+                                  + '|' + req.requestedUri().authority()
+                                  + '|' + req.requestedUri().port());
+        };
+        server.featuresDiscoverServices(false)
+                .addFeature(ContextFeature.create())
+                .addFeature(SecurityFeature.builder()
+                                    .security(Security.builder().build())
+                                    .build())
+                .routing(routing -> routing.any(handler));
+    }
+
+    @Test
+    void optionsAsteriskReachesRouting() {
+        String response = client.sendAndReceive(Method.OPTIONS, "*", null, List.of());
+
+        assertThat(response, containsString("200 OK"));
+        assertThat(response, containsString("*|/"));
+    }
+
+    @Test
+    void connectAuthorityMatchesSecurityTarget() {
+        assertConnectTarget("example.com:443", "", "http://example.com:443", "example.com:443", 443);
+    }
+
+    @Test
+    void encodedConnectAuthorityMatchesSecurityTarget() {
+        assertConnectTarget("example%2Ecom:443", "", "http://example%2Ecom:443", "example%2Ecom:443", 443);
+    }
+
+    @Test
+    void connectAuthorityPreservesPlus() {
+        assertConnectTarget("example+service:443",
+                            "",
+                            "http://example+service:443",
+                            "example+service:443",
+                            443);
+    }
+
+    @Test
+    void connectAuthorityPreservesEncodedDelimiter() {
+        assertConnectTarget("example%40service:443",
+                            "",
+                            "http://example%40service:443",
+                            "example%40service:443",
+                            443);
+    }
+
+    @Test
+    void connectAuthorityNormalizesPort() {
+        assertConnectTarget("example.com:0443", "", "http://example.com:443", "example.com:443", 443);
+    }
+
+    @Test
+    void connectIpFutureIsNotImplemented() {
+        String response = client.sendAndReceive(Method.CONNECT, "[Vf.foo-bar]:443", null, List.of());
+
+        assertThat(SocketHttpClient.statusFromResponse(response), is(Status.NOT_IMPLEMENTED_501));
+        assertThat(response, not(containsString("[Vf.foo-bar]:443|")));
+    }
+
+    @Test
+    void connectIpFutureWithFragmentIsBadRequest() {
+        String response = client.sendAndReceive(Method.CONNECT, "[Vf.foo-bar]:443#fragment", null, List.of());
+
+        assertThat(SocketHttpClient.statusFromResponse(response), is(Status.BAD_REQUEST_400));
+        assertThat(response, not(containsString("[Vf.foo-bar]:443|")));
+    }
+
+    private String assertConnectTarget(String requestTarget,
+                                       String expectedPath,
+                                       String expectedUri,
+                                       String expectedAuthority,
+                                       int expectedPort) {
+        String response = client.sendAndReceive(Method.CONNECT, requestTarget, null, List.of());
+
+        assertThat(response, containsString("501 Not Implemented"));
+        assertThat(response,
+                   containsString(requestTarget
+                                          + '|' + expectedPath
+                                          + "||" + expectedUri
+                                          + '|' + expectedUri
+                                          + '|' + expectedAuthority
+                                          + '|' + expectedPort));
+        return response;
+    }
+}

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -370,6 +370,26 @@ class ContentLengthTest {
         assertNextRequestSucceeds(h2conn, 3);
     }
 
+    @Test
+    void emptyRequestTargetInTrailersResetsStream(Http2TestClient client) {
+        Http2TestConnection h2conn = client.createConnection();
+
+        writeRequestHeaders(h2conn, 1, ZERO_DATA_PATH, requestHeadersWithContentLength(0), false);
+        Http2Headers trailers = Http2Headers.create(WritableHeaders.create());
+        trailers.path("");
+        h2conn.writer().writeHeaders(trailers,
+                                     1,
+                                     Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                     FlowControl.Outbound.NOOP);
+
+        h2conn.assertSettings(TIMEOUT);
+        h2conn.assertWindowsUpdate(0, TIMEOUT);
+        h2conn.assertSettings(TIMEOUT);
+
+        assertProtocolRstStream(h2conn, 1);
+        assertNextRequestSucceeds(h2conn, 3);
+    }
+
     private static Handler handler() {
         return (req, res) -> {
             try {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -374,7 +374,7 @@ class ContentLengthTest {
     void emptyRequestTargetInTrailersResetsStream(Http2TestClient client) {
         Http2TestConnection h2conn = client.createConnection();
 
-        writeRequestHeaders(h2conn, 1, ZERO_DATA_PATH, requestHeadersWithContentLength(0), false);
+        writeRequestHeaders(h2conn, 1, LONGER_DATA_PATH, WritableHeaders.create(), false);
         Http2Headers trailers = Http2Headers.create(WritableHeaders.create());
         trailers.path("");
         h2conn.writer().writeHeaders(trailers,

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ContentLengthTest.java
@@ -371,12 +371,12 @@ class ContentLengthTest {
     }
 
     @Test
-    void emptyRequestTargetInTrailersResetsStream(Http2TestClient client) {
+    void pseudoHeaderInTrailersResetsStream(Http2TestClient client) {
         Http2TestConnection h2conn = client.createConnection();
 
         writeRequestHeaders(h2conn, 1, LONGER_DATA_PATH, WritableHeaders.create(), false);
         Http2Headers trailers = Http2Headers.create(WritableHeaders.create());
-        trailers.path("");
+        trailers.path("/forbidden");
         h2conn.writer().writeHeaders(trailers,
                                      1,
                                      Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -399,6 +399,16 @@ public class HeadersServerTest {
     }
 
     @Test
+    void malformedContentLengthWithMissingRequestTargetClosesConnection(Http2TestClient testClient) {
+        assertMalformedContentLengthClosesConnection(testClient, false);
+    }
+
+    @Test
+    void malformedContentLengthWithEmptyRequestTargetClosesConnection(Http2TestClient testClient) {
+        assertMalformedContentLengthClosesConnection(testClient, true);
+    }
+
+    @Test
     void relativeRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
         assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "boards/");
     }
@@ -562,6 +572,32 @@ public class HeadersServerTest {
             Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
             assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
             assertConnectionReusable(connection);
+        }
+    }
+
+    private static void assertMalformedContentLengthClosesConnection(Http2TestClient testClient,
+                                                                      boolean emptyRequestTarget) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            WritableHeaders<?> headers = WritableHeaders.create();
+            headers.add(HeaderNames.CONTENT_LENGTH, "+5");
+            Http2Headers invalidHeaders = Http2Headers.create(headers);
+            invalidHeaders.method(GET);
+            if (emptyRequestTarget) {
+                invalidHeaders.path("");
+            }
+            invalidHeaders.scheme(connection.clientUri().scheme());
+            invalidHeaders.authority(connection.clientUri().authority());
+
+            connection.completeHandshake(TIMEOUT);
+            connection.writer()
+                    .writeHeaders(invalidHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertGoAway(Http2ErrorCode.PROTOCOL,
+                                    "Content-Length header must be a number.",
+                                    TIMEOUT);
         }
     }
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -59,6 +59,7 @@ import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
@@ -466,13 +467,19 @@ public class HeadersServerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"[Vf.foo-bar]:443", "service+name:443", "service%2Dname:443"})
+    @CsvSource({
+            "'[Vf.foo-bar]:443', '[Vf.foo-bar]:443'",
+            "service+name:443, service+name:443",
+            "service%2Dname:443, service%2Dname:443",
+            "service%2Dname:443, service%2dname:443"
+    })
     void ordinaryConnectWithMatchingHostReturnsNotImplementedAndKeepsConnectionOpen(String authority,
+                                                                                     String host,
                                                                                      Http2TestClient testClient) {
         try (Http2TestConnection connection = testClient.createConnection()) {
             WritableHeaders<?> headers = WritableHeaders.create();
             Http2Headers connectHeaders = Http2Headers.create(headers);
-            headers.add(HeaderNames.HOST, authority);
+            headers.add(HeaderNames.HOST, host);
             connectHeaders.method(Method.CONNECT);
             connectHeaders.authority(authority);
             connection.writer()

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -22,12 +22,14 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.helidon.common.buffers.BufferData;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -37,6 +39,9 @@ import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameData;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.webclient.api.ClientResponseTyped;
@@ -498,6 +503,31 @@ public class HeadersServerTest {
     }
 
     @Test
+    void ordinaryConnectRejectsUnicodeCaseFoldedHostAndKeepsConnectionOpen(Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            BufferData headerBlock = BufferData.growing(128);
+            writeLiteralWithIndexedName(headerBlock, 2, "CONNECT");
+            writeLiteralWithIndexedName(headerBlock, 1, "service%2Di.example:443");
+            writeLiteralWithNewName(headerBlock, "host", "service%2D\u0131.example:443");
+            connection.writer()
+                    .write(new Http2FrameData(Http2FrameHeader.create(headerBlock.available(),
+                                                                     Http2FrameTypes.HEADERS,
+                                                                     Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS
+                                                                                                          | Http2Flag.END_OF_STREAM),
+                                                                     1),
+                                                  headerBlock));
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertConnectionReusable(connection);
+        }
+    }
+
+    @Test
     void connectWithPathResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
         assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, Method.CONNECT, "/");
     }
@@ -621,6 +651,23 @@ public class HeadersServerTest {
                               FlowControl.Outbound.NOOP);
 
         assertThat(connection.assertHeaders(3, TIMEOUT).status(), is(Status.OK_200));
+    }
+
+    private static void writeLiteralWithIndexedName(BufferData target, int index, String value) {
+        target.write(0x40 | index);
+        writeRawString(target, value);
+    }
+
+    private static void writeLiteralWithNewName(BufferData target, String name, String value) {
+        target.write(0x40);
+        writeRawString(target, name);
+        writeRawString(target, value);
+    }
+
+    private static void writeRawString(BufferData target, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        target.write(bytes.length);
+        target.write(bytes);
     }
 
     private HttpClient http2Client(URI base) throws IOException, InterruptedException {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -504,6 +504,36 @@ public class HeadersServerTest {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "service+name:443, service%2Bname:443",
+            "service%2Bname:443, service+name:443"
+    })
+    void ordinaryConnectRejectsReservedEncodingMismatchAndKeepsConnectionOpen(String authority,
+                                                                               String host,
+                                                                               Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            WritableHeaders<?> headers = WritableHeaders.create();
+            Http2Headers connectHeaders = Http2Headers.create(headers);
+            headers.add(HeaderNames.HOST, host);
+            connectHeaders.method(Method.CONNECT);
+            connectHeaders.authority(authority);
+            connection.writer()
+                    .writeHeaders(connectHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertConnectionReusable(connection);
+        }
+    }
+
     @Test
     void ordinaryConnectRejectsUnicodeCaseFoldedHostAndKeepsConnectionOpen(Http2TestClient testClient) {
         try (Http2TestConnection connection = testClient.createConnection()) {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -455,6 +455,31 @@ public class HeadersServerTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"[Vf.foo-bar]:443", "service+name:443", "service%2Dname:443"})
+    void ordinaryConnectWithMatchingHostReturnsNotImplementedAndKeepsConnectionOpen(String authority,
+                                                                                     Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            WritableHeaders<?> headers = WritableHeaders.create();
+            Http2Headers connectHeaders = Http2Headers.create(headers);
+            headers.add(HeaderNames.HOST, authority);
+            connectHeaders.method(Method.CONNECT);
+            connectHeaders.authority(authority);
+            connection.writer()
+                    .writeHeaders(connectHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            assertThat(connection.assertHeaders(1, TIMEOUT).status(), is(Status.NOT_IMPLEMENTED_501));
+            assertConnectionReusable(connection);
+        }
+    }
+
     @Test
     void connectWithPathResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
         assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, Method.CONNECT, "/");

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -371,6 +371,34 @@ public class HeadersServerTest {
     }
 
     @Test
+    void missingRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            Http2Headers invalidHeaders = Http2Headers.create(WritableHeaders.create());
+            invalidHeaders.method(GET);
+            invalidHeaders.scheme(connection.clientUri().scheme());
+            invalidHeaders.authority(connection.clientUri().authority());
+            connection.writer()
+                    .writeHeaders(invalidHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertConnectionReusable(connection);
+        }
+    }
+
+    @Test
+    void emptyRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "");
+    }
+
+    @Test
     void relativeRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
         assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "boards/");
     }

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.FlowControl;
@@ -57,6 +58,8 @@ import io.helidon.webserver.testing.junit5.http2.Http2TestClient;
 import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.http.Method.GET;
@@ -368,6 +371,112 @@ public class HeadersServerTest {
     }
 
     @Test
+    void relativeRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "boards/");
+    }
+
+    @Test
+    void queryOnlyRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "?q=1");
+    }
+
+    @Test
+    void malformedQueryRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "/ok?q=%GG");
+    }
+
+    @Test
+    void absoluteRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "http://example/a");
+    }
+
+    @Test
+    void asteriskRequestTargetRequiresOptions(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "*");
+    }
+
+    @Test
+    void asteriskRequestTargetDoesNotAllowQuery(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, Method.OPTIONS, "*?q=1");
+    }
+
+    @Test
+    void fragmentRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, GET, "/boards/#fragment");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"proxy.example:443", "[::1]:443", "[Vf.foo-bar]:443"})
+    void ordinaryConnectReturnsNotImplementedAndKeepsConnectionOpen(String authority, Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            Http2Headers connectHeaders = Http2Headers.create(WritableHeaders.create());
+            connectHeaders.method(Method.CONNECT);
+            connectHeaders.authority(authority);
+            connection.writer()
+                    .writeHeaders(connectHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            assertThat(connection.assertHeaders(1, TIMEOUT).status(), is(Status.NOT_IMPLEMENTED_501));
+            assertConnectionReusable(connection);
+        }
+    }
+
+    @Test
+    void connectWithPathResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(testClient, Method.CONNECT, "/");
+    }
+
+    @Test
+    void connectWithoutPortResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            Http2Headers connectHeaders = Http2Headers.create(WritableHeaders.create());
+            connectHeaders.method(Method.CONNECT);
+            connectHeaders.authority("proxy.example");
+            connection.writer()
+                    .writeHeaders(connectHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertConnectionReusable(connection);
+        }
+    }
+
+    @Test
+    void asteriskRequestTargetReachesRequestHandlingForOptions(Http2TestClient testClient) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create());
+            headers.method(Method.OPTIONS);
+            headers.path("*");
+            headers.scheme(connection.clientUri().scheme());
+            headers.authority(connection.clientUri().authority());
+            connection.writer()
+                    .writeHeaders(headers,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            connection.assertHeaders(1, TIMEOUT);
+        }
+    }
+
+    @Test
     void invalidResponseHeaderCanBeWrittenWhenValidationIsDisabled() {
         ClientResponseTyped<String> res = responseValidationDisabledClient
                 .get("/invalid-response-header")
@@ -376,6 +485,46 @@ public class HeadersServerTest {
         assertThat(res.status(), is(Status.OK_200));
         assertThat(res.headers().get(INVALID_RESPONSE_HEADER.headerName()).get(),
                    is(INVALID_RESPONSE_HEADER.get()));
+    }
+
+    private static void assertInvalidRequestTargetResetsStreamAndKeepsConnectionOpen(Http2TestClient testClient,
+                                                                                      Method method,
+                                                                                      String requestTarget) {
+        try (Http2TestConnection connection = testClient.createConnection()) {
+            Http2Headers invalidHeaders = Http2Headers.create(WritableHeaders.create());
+            invalidHeaders.method(method);
+            invalidHeaders.path(requestTarget);
+            invalidHeaders.scheme(connection.clientUri().scheme());
+            invalidHeaders.authority(connection.clientUri().authority());
+            connection.writer()
+                    .writeHeaders(invalidHeaders,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            Http2RstStream rstStream = connection.assertRstStream(1, TIMEOUT);
+            assertThat(rstStream.errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertConnectionReusable(connection);
+        }
+    }
+
+    private static void assertConnectionReusable(Http2TestConnection connection) {
+        Http2Headers validHeaders = Http2Headers.create(WritableHeaders.create());
+        validHeaders.method(GET);
+        validHeaders.path("/ping");
+        validHeaders.scheme(connection.clientUri().scheme());
+        validHeaders.authority(connection.clientUri().authority());
+        connection.writer()
+                .writeHeaders(validHeaders,
+                              3,
+                              Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                              FlowControl.Outbound.NOOP);
+
+        assertThat(connection.assertHeaders(3, TIMEOUT).status(), is(Status.OK_200));
     }
 
     private HttpClient http2Client(URI base) throws IOException, InterruptedException {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -476,7 +476,9 @@ public class HeadersServerTest {
             "'[Vf.foo-bar]:443', '[Vf.foo-bar]:443'",
             "service+name:443, service+name:443",
             "service%2Dname:443, service%2Dname:443",
-            "service%2Dname:443, service%2dname:443"
+            "service%2Dname:443, service%2dname:443",
+            "service-name:443, service%2Dname:443",
+            "service%2Dname:443, service-name:443"
     })
     void ordinaryConnectWithMatchingHostReturnsNotImplementedAndKeepsConnectionOpen(String authority,
                                                                                      String host,

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/HeadersServerTest.java
@@ -509,11 +509,12 @@ public class HeadersServerTest {
             writeLiteralWithIndexedName(headerBlock, 2, "CONNECT");
             writeLiteralWithIndexedName(headerBlock, 1, "service%2Di.example:443");
             writeLiteralWithNewName(headerBlock, "host", "service%2D\u0131.example:443");
+            Http2Flag.HeaderFlags flags =
+                    Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM);
             connection.writer()
                     .write(new Http2FrameData(Http2FrameHeader.create(headerBlock.available(),
                                                                      Http2FrameTypes.HEADERS,
-                                                                     Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS
-                                                                                                          | Http2Flag.END_OF_STREAM),
+                                                                     flags,
                                                                      1),
                                                   headerBlock));
 

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SpecialRequestTargetTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/SpecialRequestTargetTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+import io.helidon.http.http2.FlowControl;
+import io.helidon.http.http2.Http2Flag;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2Headers;
+import io.helidon.security.Security;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.context.ContextFeature;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.security.SecurityFeature;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.http2.Http2TestClient;
+import io.helidon.webserver.testing.junit5.http2.Http2TestConnection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class SpecialRequestTargetTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @SetUpServer
+    static void setup(WebServerConfig.Builder server) {
+        server.featuresDiscoverServices(false)
+                .addFeature(ContextFeature.create())
+                .addFeature(SecurityFeature.builder()
+                                    .security(Security.builder().build())
+                                    .build())
+                .addProtocol(Http2Config.builder().build())
+                .routing(routing -> routing.any((req, res) -> {
+                    var path = req.prologue().uriPath();
+                    res.send(path.rawPath() + '|' + path.path() + '|' + path.absolute().path());
+                }));
+    }
+
+    @Test
+    void optionsAsteriskReachesRouting(Http2TestClient client) {
+        try (Http2TestConnection connection = client.createConnection()) {
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create());
+            headers.method(Method.OPTIONS);
+            headers.path("*");
+            headers.scheme(connection.clientUri().scheme());
+            headers.authority(connection.clientUri().authority());
+            connection.writer()
+                    .writeHeaders(headers,
+                                  1,
+                                  Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS | Http2Flag.END_OF_STREAM),
+                                  FlowControl.Outbound.NOOP);
+
+            connection.assertSettings(TIMEOUT);
+            connection.assertWindowsUpdate(0, TIMEOUT);
+            connection.assertSettings(TIMEOUT);
+
+            assertThat(connection.assertHeaders(1, TIMEOUT).status(), is(Status.OK_200));
+            byte[] responseBytes = connection.assertNextFrame(Http2FrameType.DATA, TIMEOUT).data().readBytes();
+            assertThat(new String(responseBytes, StandardCharsets.UTF_8), is("*|*|/"));
+        }
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueNoEntityTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueNoEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,15 +116,11 @@ class BadPrologueNoEntityTest {
     @Test
     void testBadFragment() {
         String response = socketClient.sendAndReceive(Method.GET,
-                                                      "/?a=b#invalid-fragment>",
+                                                      "/#fragment",
                                                       null,
                                                       List.of());
 
         assertThat(response, containsString("400 Bad Request"));
-        // beginning of message to the first double quote
         assertThat(response, not(containsString("Fragment contains invalid char: ")));
-        // end of message from double quote, index of bad char, and bad char
-        assertThat(response, not(containsString(", index: 16, char: 0x3e")));
-        assertThat(response, not(containsString(">")));
     }
 }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/BadPrologueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,15 +126,48 @@ class BadPrologueTest {
     @Test
     void testBadFragment() {
         String response = socketClient.sendAndReceive(Method.GET,
-                                                      "/?a=b#invalid-fragment>",
+                                                      "/#fragment",
                                                       null,
                                                       List.of());
 
         assertThat(response, containsString("400 Bad Request"));
-        // beginning of message to the first double quote
-        assertThat(response, containsString("Fragment contains invalid char: "));
-        // end of message from double quote, index of bad char, and bad char
-        assertThat(response, containsString(", index: 16, char: 0x3e"));
-        assertThat(response, not(containsString(">")));
+        assertThat(response, not(containsString("500 Internal Server Error")));
+        assertThat(response, containsString("Bad request, see server log for more information"));
+    }
+
+    @Test
+    void testBadAbsoluteFormFragment() {
+        String response = socketClient.sendAndReceive(Method.GET,
+                                                      "http://example.com/#fragment",
+                                                      null,
+                                                      List.of());
+
+        assertThat(response, containsString("400 Bad Request"));
+        assertThat(response, not(containsString("500 Internal Server Error")));
+        assertThat(response, containsString("Bad request, see server log for more information"));
+    }
+
+    @Test
+    void testRelativeOriginForm() {
+        String response = socketClient.sendAndReceive(Method.GET,
+                                                      "boards/",
+                                                      null,
+                                                      List.of());
+
+        assertThat(response, containsString("400 Bad Request"));
+        assertThat(response, not(containsString("500 Internal Server Error")));
+        assertThat(response, containsString("Bad request, see server log for more information"));
+    }
+
+    @Test
+    void testQueryOnlyOriginForm() {
+        String response = socketClient.sendAndReceive(Method.GET,
+                                                      "?q=1",
+                                                      null,
+                                                      List.of());
+
+        assertThat(response, containsString("400 Bad Request"));
+        assertThat(response, not(containsString("500 Internal Server Error")));
+        assertThat(response, containsString("Bad request, see server log for more information"));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ConfigBlueprint.java
@@ -63,7 +63,8 @@ interface Http1ConfigBlueprint extends HttpConfig, ProtocolConfig {
     int maxHeadersSize();
 
     /**
-     * If set to false, any query and fragment is accepted (even containing illegal characters).
+     * Disables query and fragment syntax validation when set to {@code false}; intended only for closed systems receiving
+     * trusted, valid request targets, as behavior for invalid input is unspecified.
      * Validation of path is controlled by {@link #validatePath()}.
      *
      * @return whether to validate prologue query and fragment
@@ -74,7 +75,7 @@ interface Http1ConfigBlueprint extends HttpConfig, ProtocolConfig {
 
 
     /**
-     * If set to false, any path is accepted (even containing illegal characters).
+     * Whether to validate path characters and HTTP/1.1 request-target forms.
      *
      * @return whether to validate path
      */

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Prologue.java
@@ -165,6 +165,111 @@ public final class Http1Prologue {
         return maybePost == POST_INT;
     }
 
+    private static boolean validateRequestTarget(Method method,
+                                                 String requestTarget,
+                                                 boolean hasQuery,
+                                                 boolean hasFragment) {
+        if (hasFragment) {
+            throw new IllegalArgumentException("Invalid HTTP/1.1 request-target form");
+        }
+        if ("*".equals(requestTarget)) {
+            if (!hasQuery && Method.OPTIONS.equals(method)) {
+                return true;
+            }
+        } else {
+            if (!requestTarget.isEmpty()
+                    && (requestTarget.charAt(0) == '/' || isAbsoluteForm(requestTarget))) {
+                return false;
+            }
+            throw new IllegalArgumentException("Relative path in HTTP request-target");
+        }
+        throw new IllegalArgumentException("Invalid HTTP/1.1 request-target form");
+    }
+
+    private static boolean isAbsoluteForm(String requestTarget) {
+        int colon = requestTarget.indexOf(':');
+        if (colon <= 0) {
+            return false;
+        }
+        char first = requestTarget.charAt(0);
+        if ((first < 'a' || first > 'z') && (first < 'A' || first > 'Z')) {
+            return false;
+        }
+        for (int i = 1; i < colon; i++) {
+            char c = requestTarget.charAt(i);
+            if ((c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '+' || c == '-' || c == '.') {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private static HttpPrologue connectPrologue(String protocol,
+                                                Method method,
+                                                String path,
+                                                boolean validatePath) {
+        if (validatePath) {
+            int portSeparator;
+            if (path.charAt(0) == '[') {
+                int closingBracket = path.indexOf(']');
+                if (closingBracket == -1) {
+                    throw new IllegalArgumentException("CONNECT authority is missing a closing bracket");
+                }
+                UriValidator.validateIpLiteral(path.substring(0, closingBracket + 1));
+                portSeparator = closingBracket + 1;
+                if (portSeparator == path.length() || path.charAt(portSeparator) != ':') {
+                    throw new IllegalArgumentException("CONNECT authority must include a port");
+                }
+            } else {
+                portSeparator = path.lastIndexOf(':');
+                if (portSeparator <= 0 || path.indexOf(':') != portSeparator) {
+                    throw new IllegalArgumentException("CONNECT authority must contain a host and port");
+                }
+
+                String host = path.substring(0, portSeparator);
+                UriValidator.validateNonIpLiteral(host);
+            }
+
+            if (portSeparator == path.length() - 1) {
+                throw new IllegalArgumentException("CONNECT authority port cannot be blank");
+            }
+            int port = 0;
+            for (int i = portSeparator + 1; i < path.length(); i++) {
+                char c = path.charAt(i);
+                if (c < '0' || c > '9') {
+                    throw new IllegalArgumentException("CONNECT authority port must contain only digits");
+                }
+                port = port * 10 + c - '0';
+                if (port > 65535) {
+                    throw new IllegalArgumentException("CONNECT authority port must be between 1 and 65535");
+                }
+            }
+            if (port == 0) {
+                throw new IllegalArgumentException("CONNECT authority port must be between 1 and 65535");
+            }
+        }
+        if (path.startsWith("[v") || path.startsWith("[V")) {
+            throw RequestException.builder()
+                    .type(DirectHandler.EventType.OTHER)
+                    .status(Status.NOT_IMPLEMENTED_501)
+                    .request(DirectTransportRequest.create(protocol, method.text(), path))
+                    .message("CONNECT IP address mechanism is not supported")
+                    .safeMessage(true)
+                    .build();
+        }
+        return HttpPrologue.create(protocol,
+                                   "HTTP",
+                                   "1.1",
+                                   method,
+                                   new AuthorityFormPath(path),
+                                   UriQuery.empty(),
+                                   UriFragment.empty());
+    }
+
     private HttpPrologue doRead() {
         int eol;
 
@@ -239,55 +344,31 @@ public final class Http1Prologue {
 
         try {
             if (Method.CONNECT.equals(method)) {
-                int portSeparator;
-                if (path.charAt(0) == '[') {
-                    int closingBracket = path.indexOf(']');
-                    if (closingBracket == -1) {
-                        throw new IllegalArgumentException("CONNECT authority is missing a closing bracket");
-                    }
-                    UriValidator.validateIpLiteral(path.substring(0, closingBracket + 1));
-                    portSeparator = closingBracket + 1;
-                    if (portSeparator == path.length() || path.charAt(portSeparator) != ':') {
-                        throw new IllegalArgumentException("CONNECT authority must include a port");
-                    }
-                } else {
-                    portSeparator = path.lastIndexOf(':');
-                    if (portSeparator <= 0 || path.indexOf(':') != portSeparator) {
-                        throw new IllegalArgumentException("CONNECT authority must contain a host and port");
-                    }
-
-                    String host = path.substring(0, portSeparator);
-                    UriValidator.validateNonIpLiteral(host);
-                }
-
-                if (portSeparator == path.length() - 1) {
-                    throw new IllegalArgumentException("CONNECT authority port cannot be blank");
-                }
-                int port = 0;
-                for (int i = portSeparator + 1; i < path.length(); i++) {
-                    char c = path.charAt(i);
-                    if (c < '0' || c > '9') {
-                        throw new IllegalArgumentException("CONNECT authority port must contain only digits");
-                    }
-                    port = port * 10 + c - '0';
-                    if (port > 65535) {
-                        throw new IllegalArgumentException("CONNECT authority port must be between 0 and 65535");
-                    }
-                }
+                return connectPrologue(protocol, method, path, validatePath);
+            }
+            HttpPrologue prologue = HttpPrologue.create(protocol,
+                                                        "HTTP",
+                                                        "1.1",
+                                                        method,
+                                                        path,
+                                                        validatePath);
+            if (!validatePath) {
+                return prologue;
+            }
+            String requestTarget = prologue.uriPath().rawPath();
+            if (validateRequestTarget(method,
+                                      requestTarget,
+                                      prologue.hasQuery(),
+                                      prologue.fragment().hasValue())) {
                 return HttpPrologue.create(protocol,
                                            "HTTP",
                                            "1.1",
                                            method,
-                                           new AuthorityFormPath(path),
-                                           UriQuery.empty(),
-                                           UriFragment.empty());
+                                           UriPath.createRelative(UriPath.root(), requestTarget),
+                                           prologue.query(),
+                                           prologue.fragment());
             }
-            return HttpPrologue.create(protocol,
-                                       "HTTP",
-                                       "1.1",
-                                       method,
-                                       path,
-                                       validatePath);
+            return prologue;
         } catch (IllegalArgumentException e) {
             throw badRequest("Invalid path: " + e.getMessage(), method.text(), path, "HTTP", "1.1");
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1ServerRequest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.http1;
 
+import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -27,12 +28,15 @@ import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriInfo;
+import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
 import io.helidon.http.RequestedUriDiscoveryContext;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
@@ -273,7 +277,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
     }
 
     private UriInfo createUriInfo() {
-        return ctx.listenerContext().config().requestedUriDiscoveryContext()
+        UriInfo requestedUri = ctx.listenerContext().config().requestedUriDiscoveryContext()
                 .orElse(DEFAULT_REQUESTED_URI_DISCOVERY_CONTEXT)
                 .uriInfo(remotePeer().address(),
                          localPeer().address(),
@@ -281,5 +285,80 @@ abstract class Http1ServerRequest implements RoutingRequest {
                          headers,
                          query(),
                          isSecure());
+        if (!Method.CONNECT.equals(prologue.method())) {
+            return requestedUri;
+        }
+        String authority = prologue.uriPath().rawPath();
+        UriInfo connectUri = UriInfo.builder()
+                .from(requestedUri)
+                .authority(authority)
+                .path("")
+                .build();
+        return new ConnectUriInfo(connectUri, connectUri.authority());
+    }
+
+    private static final class ConnectUriInfo implements UriInfo {
+        private final UriInfo delegate;
+        private final String authority;
+
+        private ConnectUriInfo(UriInfo delegate, String authority) {
+            this.delegate = delegate;
+            this.authority = authority;
+        }
+
+        @Override
+        public String scheme() {
+            return delegate.scheme();
+        }
+
+        @Override
+        public String host() {
+            return delegate.host();
+        }
+
+        @Override
+        public int port() {
+            return delegate.port();
+        }
+
+        @Override
+        public String authority() {
+            return authority;
+        }
+
+        @Override
+        public UriPath path() {
+            return delegate.path();
+        }
+
+        @Override
+        public UriQuery query() {
+            return delegate.query();
+        }
+
+        @Override
+        public UriFragment fragment() {
+            return delegate.fragment();
+        }
+
+        @Override
+        public URI toUri() {
+            return URI.create(scheme() + "://" + authority);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return delegate.equals(object);
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1PrologueTest.java
@@ -81,9 +81,7 @@ class Http1PrologueTest {
             "service+name:443",
             "service%2Dname:443",
             "192.0.2.10:8443",
-            "[2001:db8::1]:9443",
-            "[v1.fe80]:443",
-            "[Vf.foo-bar]:443"
+            "[2001:db8::1]:9443"
     })
     void testConnectAuthorityForm(String authority) {
         DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
@@ -100,6 +98,7 @@ class Http1PrologueTest {
     @ValueSource(strings = {
             "example.com",
             ":443",
+            "boards/",
             "user@example.com:443",
             "http://example.com:443",
             "example.com:443?query=value",
@@ -109,12 +108,15 @@ class Http1PrologueTest {
             "[2001:db8::1]",
             "[1:2:3]:443",
             "[1.2.3.4]:443",
+            "[1:2:3:4:5:6:010.000.000.001]:443",
             "[v1.]:443",
             "[vG.fe80]:443",
             "[v1.fe80]x:443",
             "2001:db8::1:443",
             "example.com:not-a-port",
-            "example.com:65536"
+            "example.com:0",
+            "example.com:65536",
+            "example.com:2147483648"
     })
     void testInvalidConnectAuthorityForm(String authority) {
         DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
@@ -126,4 +128,90 @@ class Http1PrologueTest {
         assertThat(exception.status(), is(Status.BAD_REQUEST_400));
         assertThat(exception.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"[v1.fe80]:443", "[Vf.foo-bar]:443"})
+    void testConnectIpFutureIsNotImplemented(String authority) {
+        DataReader reader = DataReader.create(() -> ("CONNECT " + authority + " HTTP/1.1\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue prologue = new Http1Prologue(reader, 100, true);
+
+        RequestException exception = assertThrows(RequestException.class, prologue::readPrologue);
+
+        assertThat(exception.status(), is(Status.NOT_IMPLEMENTED_501));
+        assertThat(exception.eventType(), is(DirectHandler.EventType.OTHER));
+    }
+
+    @Test
+    void testRelativeOriginFormIsBadRequest() {
+        DataReader reader = DataReader.create(() -> "GET boards/ HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue p = new Http1Prologue(reader, 100, true);
+
+        RequestException e = assertThrows(RequestException.class, p::readPrologue);
+
+        assertThat(e.status(), is(Status.BAD_REQUEST_400));
+        assertThat(e.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
+        assertThat(e.getMessage(), containsString("Relative path in HTTP request-target"));
+    }
+
+    @Test
+    void testQueryOnlyOriginFormIsBadRequest() {
+        DataReader reader = DataReader.create(() -> "GET ?q=1 HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue p = new Http1Prologue(reader, 100, true);
+
+        RequestException e = assertThrows(RequestException.class, p::readPrologue);
+
+        assertThat(e.status(), is(Status.BAD_REQUEST_400));
+        assertThat(e.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
+        assertThat(e.getMessage(), containsString("Relative path in HTTP request-target"));
+    }
+
+    @Test
+    void testAsteriskFormRemainsValid() {
+        DataReader reader = DataReader.create(() -> "OPTIONS * HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII));
+        HttpPrologue prologue = new Http1Prologue(reader, 100, true).readPrologue();
+
+        assertThat(prologue.method(), is(Method.OPTIONS));
+        assertThat(prologue.uriPath().rawPath(), is("*"));
+        assertThat(prologue.uriPath().path(), is("*"));
+        assertThat(prologue.uriPath().absolute().path(), is("/"));
+        assertThat(prologue.uriPath().segments().size(), is(1));
+        assertThat(prologue.uriPath().segments().get(0).value(), is("*"));
+    }
+
+    @Test
+    void testAsteriskFormRequiresOptions() {
+        assertInvalidRequestTarget("GET * HTTP/1.1\r\n");
+    }
+
+    @Test
+    void testAsteriskFormRejectsFragment() {
+        assertInvalidRequestTarget("OPTIONS *#fragment HTTP/1.1\r\n");
+    }
+
+    @Test
+    void testAsteriskFormDoesNotAllowQuery() {
+        assertInvalidRequestTarget("OPTIONS *?q=1 HTTP/1.1\r\n");
+    }
+
+    @Test
+    void testAbsoluteFormRemainsValid() {
+        DataReader reader = DataReader.create(() -> "GET http://example.com/boards/ HTTP/1.1\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+        HttpPrologue prologue = new Http1Prologue(reader, 100, true).readPrologue();
+
+        assertThat(prologue.method(), is(Method.GET));
+        assertThat(prologue.uriPath().path(), is("/boards/"));
+    }
+
+    private static void assertInvalidRequestTarget(String requestLine) {
+        DataReader reader = DataReader.create(() -> requestLine.getBytes(StandardCharsets.US_ASCII));
+        Http1Prologue prologue = new Http1Prologue(reader, 100, true);
+
+        RequestException e = assertThrows(RequestException.class, prologue::readPrologue);
+
+        assertThat(e.status(), is(Status.BAD_REQUEST_400));
+        assertThat(e.eventType(), is(DirectHandler.EventType.BAD_REQUEST));
+    }
+
 }


### PR DESCRIPTION
Resolves #12334

Carries forward the request-target validation from #12329 to main, preserving protocol-owned HTTP/1.1 and HTTP/2 behavior. It also aligns ordinary HTTP/2 CONNECT framing with RFC 9113 while returning 501 because HTTP/2 tunnel lifecycle is not supported.
