### PR TITLE
Add non-mutating LRU cache lookup (27.x)

### DIFF
--- a/common/common/src/main/java/io/helidon/common/LruCache.java
+++ b/common/common/src/main/java/io/helidon/common/LruCache.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.common;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -64,6 +65,22 @@ public interface LruCache<K, V> {
      * @return value if present or empty
      */
     Optional<V> get(K key);
+
+    /**
+     * Get a value from the cache without marking it as recently used.
+     * Custom implementations may not support this operation.
+     *
+     * @param key          key to retrieve
+     * @param defaultValue value to return if the key is not present
+     * @return cached value if present, otherwise {@code defaultValue}
+     * @throws NullPointerException if {@code key} or {@code defaultValue} is {@code null}
+     * @throws UnsupportedOperationException if this cache does not support peeking
+     */
+    default V peek(K key, V defaultValue) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(defaultValue);
+        throw new UnsupportedOperationException("Peeking is not supported by this cache");
+    }
 
     /**
      * Remove a value from the cache.

--- a/common/common/src/main/java/io/helidon/common/LruCache.java
+++ b/common/common/src/main/java/io/helidon/common/LruCache.java
@@ -63,6 +63,7 @@ public interface LruCache<K, V> {
      *
      * @param key key to retrieve
      * @return value if present or empty
+     * @throws NullPointerException if {@code key} is {@code null}
      */
     Optional<V> get(K key);
 
@@ -87,6 +88,7 @@ public interface LruCache<K, V> {
      *
      * @param key key of the record to remove
      * @return the value that was mapped to the key, or empty if none was
+     * @throws NullPointerException if {@code key} is {@code null}
      */
     Optional<V> remove(K key);
 
@@ -96,6 +98,7 @@ public interface LruCache<K, V> {
      * @param key   key to add
      * @param value value to add
      * @return value that was already mapped or empty if the value was not mapped
+     * @throws NullPointerException if {@code key} or {@code value} is {@code null}
      */
     Optional<V> put(K key, V value);
 
@@ -109,6 +112,7 @@ public interface LruCache<K, V> {
      * @param key           key to check/insert value for
      * @param valueSupplier supplier called if the value is not yet cached, or is invalid
      * @return current value from the cache, or computed value from the supplier
+     * @throws NullPointerException if {@code key} or {@code valueSupplier} is {@code null}
      */
     Optional<V> computeValue(K key, Supplier<Optional<V>> valueSupplier);
 

--- a/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
+++ b/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
@@ -46,6 +46,7 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
 
     @Override
     public Optional<V> get(K key) {
+        Objects.requireNonNull(key);
         readLock.lock();
         V value;
         try {
@@ -80,8 +81,7 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
         Objects.requireNonNull(defaultValue);
         readLock.lock();
         try {
-            V value = backingMap.get(key);
-            return value == null ? defaultValue : value;
+            return backingMap.getOrDefault(key, defaultValue);
         } finally {
             readLock.unlock();
         }
@@ -89,7 +89,7 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
 
     @Override
     public Optional<V> remove(K key) {
-
+        Objects.requireNonNull(key);
         writeLock.lock();
         try {
             return Optional.ofNullable(backingMap.remove(key));
@@ -100,6 +100,8 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
 
     @Override
     public Optional<V> put(K key, V value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
         writeLock.lock();
         try {
             V oldValue = backingMap.putLast(key, value);
@@ -119,6 +121,8 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
 
     @Override
     public Optional<V> computeValue(K key, Supplier<Optional<V>> valueSupplier) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(valueSupplier);
         // get is properly synchronized
         Optional<V> currentValue = get(key);
         if (currentValue.isPresent()) {

--- a/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
+++ b/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.common;
 
 import java.util.LinkedHashMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SequencedMap;
 import java.util.concurrent.locks.Lock;
@@ -70,6 +71,19 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
             return Optional.of(value);
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V peek(K key, V defaultValue) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(defaultValue);
+        readLock.lock();
+        try {
+            V value = backingMap.get(key);
+            return value == null ? defaultValue : value;
+        } finally {
+            readLock.unlock();
         }
     }
 

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -79,15 +79,25 @@ class LruCacheTest {
         Object defaultValue = new Object();
         LruCache<String, Object> objectCache = LruCache.create();
         assertThat(objectCache.peek("missing", defaultValue), sameInstance(defaultValue));
-        // Unsupported; validate only for backward compatibility until null values are rejected in the next major version.
-        objectCache.put("null", null);
-        assertThat(objectCache.peek("null", defaultValue), sameInstance(defaultValue));
-        assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));
-        assertThrows(NullPointerException.class, () -> cache.peek("first", null));
 
         cache.put("fourth", "fourth-value");
         assertThat(cache.get("first"), is(Optional.empty()));
         assertThat(cache.get("second"), is(Optional.of("second-value")));
+    }
+
+    @Test
+    void testNullParameters() {
+        LruCache<String, String> cache = LruCache.create();
+
+        assertThrows(NullPointerException.class, () -> cache.get(null));
+        assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));
+        assertThrows(NullPointerException.class, () -> cache.peek("key", null));
+        assertThrows(NullPointerException.class, () -> cache.remove(null));
+        assertThrows(NullPointerException.class, () -> cache.put(null, "value"));
+        assertThrows(NullPointerException.class, () -> cache.put("key", null));
+        assertThrows(NullPointerException.class, () -> cache.computeValue(null, Optional::empty));
+        cache.put("key", "value");
+        assertThrows(NullPointerException.class, () -> cache.computeValue("key", null));
     }
 
     @Test

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link io.helidon.common.LruCache}.
@@ -63,6 +65,29 @@ class LruCacheTest {
         assertThat(res, is(Optional.of(value)));
         res = theCache.get(key);
         assertThat(res, is(Optional.empty()));
+    }
+
+    @Test
+    void testPeek() {
+        LruCache<String, String> cache = LruCache.create(3);
+        cache.put("first", "first-value");
+        cache.put("second", "second-value");
+        cache.put("third", "third-value");
+
+        assertThat(cache.peek("first", "default"), is("first-value"));
+
+        Object defaultValue = new Object();
+        LruCache<String, Object> objectCache = LruCache.create();
+        assertThat(objectCache.peek("missing", defaultValue), sameInstance(defaultValue));
+        // Unsupported; validate only for backward compatibility until null values are rejected in the next major version.
+        objectCache.put("null", null);
+        assertThat(objectCache.peek("null", defaultValue), sameInstance(defaultValue));
+        assertThrows(NullPointerException.class, () -> cache.peek(null, "default"));
+        assertThrows(NullPointerException.class, () -> cache.peek("first", null));
+
+        cache.put("fourth", "fourth-value");
+        assertThat(cache.get("first"), is(Optional.empty()));
+        assertThat(cache.get("second"), is(Optional.of("second-value")));
     }
 
     @Test

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -30,6 +30,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-uri</artifactId>
         </dependency>
         <dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/common/benchmark/jmh/LruCacheJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/common/benchmark/jmh/LruCacheJmhBenchmark.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.benchmark.jmh;
+
+import java.util.Optional;
+
+import io.helidon.common.LruCache;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class LruCacheJmhBenchmark {
+    private static final int CACHE_SIZE = 128;
+
+    private LruCache<String, String> cache;
+    private String hitKey;
+    private String missKey;
+    private String defaultValue;
+
+    @Setup
+    public void setup() {
+        cache = LruCache.create(CACHE_SIZE);
+        for (int i = 0; i < CACHE_SIZE; i++) {
+            cache.put("key-" + i, "value-" + i);
+        }
+        hitKey = "key-64";
+        missKey = "missing";
+        defaultValue = "default";
+    }
+
+    @Benchmark
+    public String peekHit() {
+        return cache.peek(hitKey, defaultValue);
+    }
+
+    @Benchmark
+    public String peekMiss() {
+        return cache.peek(missKey, defaultValue);
+    }
+
+    @Benchmark
+    public Optional<String> getHit() {
+        return cache.get(hitKey);
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/common/benchmark/jmh/LruCacheJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/common/benchmark/jmh/LruCacheJmhRunnerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class LruCacheJmhRunnerTest {
+    @Test
+    void runExactBenchmark() throws RunnerException {
+        String result = System.getProperty("lru.cache.jmh.result",
+                                           "./target/lru-cache-jmh-result.json");
+        Options options = new OptionsBuilder()
+                .include("^" + Pattern.quote(LruCacheJmhBenchmark.class.getName())
+                                 + "\\.(peekHit|peekMiss|getHit)$")
+                .forks(Integer.getInteger("lru.cache.jmh.forks", 3))
+                .threads(1)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .warmupIterations(Integer.getInteger("lru.cache.jmh.warmupIterations", 5))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("lru.cache.jmh.warmupMillis", 500)))
+                .measurementIterations(Integer.getInteger("lru.cache.jmh.measurementIterations", 8))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("lru.cache.jmh.measurementMillis", 1_000)))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
Resolves #12383

Carries the non-mutating LRU cache lookup from #12381 to main, enforces non-null cache parameters, and adds targeted benchmark coverage.
