### PR TITLE
Forward port - implement HTTP method name canonicalization required in OTel semantic conventions

### DIFF
--- a/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
+++ b/docs/src/main/asciidoc/includes/metrics/metrics-config.adoc
@@ -113,6 +113,36 @@ Helidon decides whether to measure incoming requests as follows:
 
 The `auto-http-metrics.sockets` setting controls which sockets are included in the measurements; if not set, Helidon measures requests on all sockets.
 
+ifdef::se-flavor[]
+[[auto-http-known-methods]]
+===== Controlling HTTP Method Attribute Values
+
+For the OpenTelemetry `http.server.request.duration` metric, the `auto-http-metrics.known-methods` setting controls the
+values Helidon records for the `http.request.method` attribute. This setting does not control which requests Helidon
+measures; use the `methods` setting in a `paths` entry for that purpose.
+
+By default, Helidon records `CONNECT`, `DELETE`, `GET`, `HEAD`, `LIST`, `OPTIONS`, `PATCH`, `POST`, `PUT`, and `TRACE`
+as their canonical method names. Helidon records any other method as `_OTHER`. Method names in the configuration are
+canonicalized using Helidon's HTTP method model; for example, `propfind` becomes `PROPFIND`.
+
+Assigning `known-methods` replaces the entire default list. Include every default method you want to retain.
+
+[source,yaml]
+.Configuring HTTP Method Attribute Values
+----
+server:
+  features:
+    observe:
+      observers:
+        metrics:
+          auto-http-metrics:
+            known-methods: ["GET", "HEAD", "POST", "PROPFIND"]
+----
+
+With this configuration, Helidon records the four listed methods using their canonical names and records every other
+HTTP method, including default methods omitted from the list, as `_OTHER`.
+endif::se-flavor[]
+
 [NOTE]
 ====
 The `auto-http-metrics.use-updated-http-metrics` setting is deprecated and retained only for configuration compatibility

--- a/docs/src/main/asciidoc/se/telemetry/open-telemetry.adoc
+++ b/docs/src/main/asciidoc/se/telemetry/open-telemetry.adoc
@@ -216,6 +216,11 @@ OpenTelemetry prescribes its own link:{metrics-semconv-link}[semantic convention
 </dependency>
 ----
 
+Helidon limits the values recorded for the OpenTelemetry `http.request.method` attribute, mapping methods not in the
+configured known-method list to `_OTHER`. See the
+xref:{rootdir}/se/metrics/metrics.adoc#auto-http-known-methods[automatic HTTP metrics configuration] for the default
+method list and customization details.
+
 === Enabling OpenTelemetry for Outgoing Helidon Webclient Traffic
 Helidon supports the OpenTelemetry semantic conventions for outgoing traffic which uses the Helidon WebClient. See the xref:{rootdir}/se/webclient.adoc#_configuring_telemetry[Helidon WebClient documentation].
 

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
@@ -82,6 +82,8 @@ interface AutoHttpMetricsConfigBlueprint {
      * to retain.
      * <p>
      * Method names are canonicalized using Helidon's HTTP method model.
+     * See the <a href="https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-method">
+     * OpenTelemetry semantic convention for HTTP request methods</a>.
      *
      * @return known HTTP methods
      */

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
@@ -73,6 +73,24 @@ interface AutoHttpMetricsConfigBlueprint {
     List<String> optIn();
 
     /**
+     * HTTP methods to be used in the HTTP method tag for automatic metrics, defaulted to the standard HTTP methods plus
+     * {@code LIST}; assigning this value fully replaces the set of method names.
+     * <p>
+     * Default known HTTP methods: {@code CONNECT}, {@code DELETE}, {@code GET}, {@code HEAD}, {@code LIST},
+     * {@code OPTIONS}, {@code PATCH}, {@code POST}, {@code PUT}, and {@code TRACE}. Unlisted methods are reported as
+     * {@code _OTHER}, so configurations that add additional method names must also include default methods they intend
+     * to retain.
+     * <p>
+     * Method names are canonicalized using Helidon's HTTP method model.
+     *
+     * @return known HTTP methods
+     */
+    @Option.Configured
+    @Option.DefaultCode("new java.util.ArrayList<>(AutoHttpMetricsConfigSupport.DEFAULT_KNOWN_METHODS)")
+    @Option.Singular
+    List<String> knownMethods();
+
+    /**
      * Retained for configuration compatibility with Helidon 4.x; Helidon 27 ignores the value and always uses the updated
      * automatic HTTP metrics behavior.
      *

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigSupport.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigSupport.java
@@ -24,6 +24,9 @@ import io.helidon.http.Method;
 
 class AutoHttpMetricsConfigSupport {
 
+    static final List<String> DEFAULT_KNOWN_METHODS = List.of(
+            "CONNECT", "DELETE", "GET", "HEAD", "LIST", "OPTIONS", "PATCH", "POST", "PUT", "TRACE");
+
     private static final List<AutoHttpMetricsPathConfig> MEASUREMENT_DISABLED_HELIDON_ENDPOINTS = List.of(
             disabled("/metrics/*"),
             disabled("/observe/*"),

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoMetricsConfig.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoMetricsConfig.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver.observe.metrics;
 
+import java.util.List;
+
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.uri.UriPath;
 import io.helidon.config.Config;
@@ -37,6 +39,7 @@ class TestAutoMetricsConfig {
                       observers:
                         metrics:
                           auto-http-metrics:
+                            known-methods: ["LIST"]
                             paths:
                               - path: "/greet/{name}"
                                 methods: ["GET","OPTIONS"]
@@ -57,6 +60,7 @@ class TestAutoMetricsConfig {
         var config = AutoHttpMetricsConfig.create(configFromText);
 
         assertThat("Updated HTTP metrics default", config.useUpdatedHttpMetrics(), is(true));
+        assertThat(config.knownMethods(), is(List.of("LIST")));
 
         assertThat("GET /greet", config.isMeasured(Method.GET, UriPath.create("/greet")), is(true));
         assertThat("PUT /greet", config.isMeasured(Method.PUT, UriPath.create("/greet")), is(true));
@@ -123,6 +127,7 @@ class TestAutoMetricsConfig {
 
         assertThat("GET /metrics", config.isMeasured(Method.GET, UriPath.create("/metrics")), is(false));
         assertThat("Updated HTTP metrics default", config.useUpdatedHttpMetrics(), is(true));
+        assertThat(config.knownMethods(), is(AutoHttpMetricsConfigSupport.DEFAULT_KNOWN_METHODS));
 
     }
 

--- a/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
+++ b/webserver/observe/telemetry/metrics/src/main/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventions.java
@@ -18,10 +18,13 @@ package io.helidon.webserver.observe.telemetry.metrics;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import io.helidon.config.Config;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.service.registry.Service;
 import io.helidon.telemetry.otelconfig.HelidonOpenTelemetry;
@@ -67,6 +70,7 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
     // Helidon
     static final String SOCKET_NAME = "socket.name";
     static final String TIMER_NAME = "http.server.request.duration";
+    private static final String OTHER_METHOD = "_OTHER";
     /*
     Bucket boundaries as recommended by the OpenTelemetry spec.
     https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
@@ -116,10 +120,15 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
 
         private final DoubleHistogram httpRequestDuration;
         private final AutoHttpMetricsConfig config;
+        private final Set<String> knownMethods;
 
         private MetricsRecordingFilter(DoubleHistogram httpRequestDuration, AutoHttpMetricsConfig config) {
             this.httpRequestDuration = httpRequestDuration;
             this.config = config;
+            this.knownMethods = config.knownMethods().stream()
+                    .map(Method::create)
+                    .map(Method::text)
+                    .collect(Collectors.toUnmodifiableSet());
         }
 
         @Override
@@ -187,7 +196,7 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
             }
             AttributesBuilder attrBuilder = Attributes.builder();
 
-            attrBuilder.put(AttributeKey.stringKey(HTTP_METHOD), req.prologue().method().text())
+            attrBuilder.put(AttributeKey.stringKey(HTTP_METHOD), httpMethod(req.prologue().method()))
                     .put(AttributeKey.stringKey(URL_SCHEME), req.prologue().protocol())
                     .put(AttributeKey.stringKey(ERROR_TYPE), errorType(resp, exception))
                     .put(AttributeKey.longKey(STATUS_CODE), resp.status().code())
@@ -218,6 +227,11 @@ class OpenTelemetryMetricsHttpSemanticConventions implements AutoHttpMetricsProv
                     : resp.status().equals(Status.OK_200)
                             ? ""
                             : resp.status().codeText();
+        }
+
+        private String httpMethod(Method method) {
+            String methodName = method.text();
+            return knownMethods.contains(methodName) ? methodName : OTHER_METHOD;
         }
 
     }

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
@@ -71,6 +71,70 @@ import static org.mockito.Mockito.when;
 class OpenTelemetryMetricsHttpSemanticConventionsTest {
 
     @Test
+    void knownStandardHttpMethodUsesMethodMetricAttribute() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filter(recordedAttributes::set)
+                .filter(mock(FilterChain.class), request(Method.GET), response(whenSent));
+        whenSent.get().run();
+
+        assertThat(methodAttribute(recordedAttributes.get()), is("GET"));
+    }
+
+    @Test
+    void knownExtensionHttpMethodUsesMethodMetricAttribute() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filter(recordedAttributes::set)
+                .filter(mock(FilterChain.class), request(Method.create("LIST")), response(whenSent));
+        whenSent.get().run();
+
+        assertThat(methodAttribute(recordedAttributes.get()), is("LIST"));
+    }
+
+    @Test
+    void unknownHttpMethodUsesOtherMetricAttribute() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filter(recordedAttributes::set)
+                .filter(mock(FilterChain.class), request(Method.create("UNIQUE_METHOD")), response(whenSent));
+        whenSent.get().run();
+
+        assertThat(methodAttribute(recordedAttributes.get()), is("_OTHER"));
+    }
+
+    @Test
+    void deprecatedFalseSettingDoesNotDisableMethodNormalization() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filterWithDeprecatedSetting(recordedAttributes::set, false)
+                .filter(mock(FilterChain.class), request(Method.create("UNIQUE_METHOD")), response(whenSent));
+        whenSent.get().run();
+
+        assertThat(methodAttribute(recordedAttributes.get()), is("_OTHER"));
+    }
+
+    @Test
+    void knownMethodsConfigFullyOverridesDefaults() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        Filter filter = filter(recordedAttributes::set, List.of("list"));
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filter.filter(mock(FilterChain.class), request(Method.GET), response(whenSent));
+        whenSent.get().run();
+        assertThat(methodAttribute(recordedAttributes.get()), is("_OTHER"));
+
+        whenSent.set(null);
+        filter.filter(mock(FilterChain.class), request(Method.create("LIST")), response(whenSent));
+        whenSent.get().run();
+        assertThat(methodAttribute(recordedAttributes.get()), is("LIST"));
+    }
+
+    @Test
     void measuredRequestUsesMatchingPatternAtResponseCompletion() throws Exception {
         AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
         Filter filter = filter(recordedAttributes::set);
@@ -137,6 +201,7 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
         when(metricsConfig.autoHttpMetrics()).thenReturn(Optional.of(autoConfig));
         when(autoConfig.enabled()).thenReturn(true);
         when(autoConfig.isMeasured(any(), any())).thenReturn(false);
+        when(autoConfig.knownMethods()).thenReturn(List.of("GET"));
         when(autoConfig.optIn()).thenReturn(List.of());
         when(request.matchingPattern()).thenAnswer(invocation -> {
             routeInvocations.incrementAndGet();
@@ -298,6 +363,12 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
                 .build());
     }
 
+    private static Filter filter(Consumer<Attributes> recorder, List<String> knownMethods) {
+        return filter(recorder, AutoHttpMetricsConfig.builder()
+                .knownMethods(knownMethods)
+                .build());
+    }
+
     private static Filter filter(Consumer<Attributes> recorder, AutoHttpMetricsConfig autoHttpMetricsConfig) {
         DoubleHistogram histogram = mock(DoubleHistogram.class);
         doAnswer(invocation -> {
@@ -334,6 +405,10 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
     }
 
     private static RoutingRequest request() {
+        return request(Method.GET);
+    }
+
+    private static RoutingRequest request(Method method) {
         RoutingRequest request = mock(RoutingRequest.class);
         ListenerConfig listenerConfig = mock(ListenerConfig.class);
         ListenerContext listenerContext = mock(ListenerContext.class);
@@ -341,7 +416,7 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
         when(request.prologue()).thenReturn(HttpPrologue.create("HTTP/1.1",
                                                                 "HTTP",
                                                                 "1.1",
-                                                                Method.GET,
+                                                                method,
                                                                 "/test",
                                                                 false));
         when(request.matchingPattern()).thenReturn(Optional.empty());
@@ -360,6 +435,10 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
             return response;
         });
         return response;
+    }
+
+    private static String methodAttribute(Attributes attributes) {
+        return attributes.get(AttributeKey.stringKey(OpenTelemetryMetricsHttpSemanticConventions.HTTP_METHOD));
     }
 
     private static final class TestLogHandler extends Handler implements AutoCloseable {


### PR DESCRIPTION
### Description
Resolves #12386 

Forward port of #12245 

## Release note
____
Helidon OpenTelemetry HTTP metrics now limit `http.request.method` attribute values to configured known methods, recording other methods as `_OTHER` in accordance with the [[OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-method)](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-method). The new `auto-http-metrics.known-methods` setting allows applications to replace the default list.
____
## Summary

This change updates automatic OpenTelemetry HTTP server metrics to constrain the `http.request.method` attribute and avoid unbounded metric cardinality.

- Adds the `auto-http-metrics.known-methods` configuration option.
- Defaults the known methods to `CONNECT`, `DELETE`, `GET`, `HEAD`, `LIST`, `OPTIONS`, `PATCH`, `POST`, `PUT`, and `TRACE`. (The non-standard `LIST` method is often used in OCI services.)
- Records methods not in the configured list as `_OTHER`.
- Canonicalizes configured method names using Helidon’s HTTP method model.
- Treats a configured `known-methods` list as a complete replacement for the defaults.
- Preserves `main` behavior for the deprecated `use-updated-http-metrics` setting: the setting remains accepted for compatibility but its value is ignored for this (and other) purposes.
- Documents the new setting, replacement behavior, defaults, and OpenTelemetry requirements.
- Adds tests covering standard, extension, unknown, and configured method names, including behavior when `use-updated-http-metrics` is `false`.

## Validation

- Module tests pass.
- Maven Checkstyle and copyright validation pass with no violations.

### Documentation
Update included.
