### PR TITLE
Stabilize gRPC request backpressure test (27.x)

### DIFF
--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
@@ -515,9 +515,9 @@ class GrpcTeTrailersTest {
         assertThat("server consumed all requests after demand resumed",
                    pausedConsumed.get(),
                    is(BIDI_MESSAGE_COUNT));
-        assertThat("client consumed all responses after server demand resumed",
+        assertThat("client received completion response after server demand resumed",
                    responsesReceived.get(),
-                   is(BIDI_MESSAGE_COUNT));
+                   is(1));
     }
 
     private static boolean awaitCompletion(CountDownLatch callFinished,
@@ -611,9 +611,9 @@ class GrpcTeTrailersTest {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while waiting to release paused gRPC request stream", e);
             }
-            // Keep response flow control out of this request-side backpressure test.
-            return requests.peek(_ -> pausedConsumed.incrementAndGet())
-                    .map(_ -> Strings.StringMessage.getDefaultInstance());
+            // Keep response demand and flow control out of this request-side backpressure test.
+            requests.forEach(_ -> pausedConsumed.incrementAndGet());
+            return Stream.of(Strings.StringMessage.getDefaultInstance());
         }, observer);
     }
 

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
@@ -515,9 +515,9 @@ class GrpcTeTrailersTest {
         assertThat("server consumed all requests after demand resumed",
                    pausedConsumed.get(),
                    is(BIDI_MESSAGE_COUNT));
-        assertThat("client received completion response after server demand resumed",
+        assertThat("client consumed all responses after server demand resumed",
                    responsesReceived.get(),
-                   is(1));
+                   is(BIDI_MESSAGE_COUNT));
     }
 
     private static boolean awaitCompletion(CountDownLatch callFinished,
@@ -611,9 +611,11 @@ class GrpcTeTrailersTest {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while waiting to release paused gRPC request stream", e);
             }
-            // Keep response demand and flow control out of this request-side backpressure test.
+            // Consume every request before producing responses so response demand and flow control
+            // cannot pace request consumption.
             requests.forEach(_ -> pausedConsumed.incrementAndGet());
-            return Stream.of(Strings.StringMessage.getDefaultInstance());
+            return Stream.generate(Strings.StringMessage::getDefaultInstance)
+                    .limit(BIDI_MESSAGE_COUNT);
         }, observer);
     }
 

--- a/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
+++ b/webclient/tests/grpc/src/test/java/io/helidon/webclient/grpc/tests/GrpcTeTrailersTest.java
@@ -167,7 +167,7 @@ class GrpcTeTrailersTest {
                 .serverStream(Strings.getDescriptor(), "StringService", "ResetAfterOne", GrpcTeTrailersTest::resetAfterOne)
                 .serverStream(Strings.getDescriptor(), "StringService", "PauseAfterTwo", GrpcTeTrailersTest::pauseAfterTwo)
                 .bidi(Strings.getDescriptor(), "StringService", "Echo", GrpcTeTrailersTest::echo)
-                .bidi(Strings.getDescriptor(), "StringService", "PausedEcho", GrpcTeTrailersTest::pausedEcho);
+                .bidi(Strings.getDescriptor(), "StringService", "PausedEcho", GrpcTeTrailersTest::pausedRequests);
     }
 
     @Test
@@ -600,7 +600,7 @@ class GrpcTeTrailersTest {
         return GrpcStreams.bidirectional(requests -> requests.peek(ignored -> echoMessages.incrementAndGet()), observer);
     }
 
-    private static StreamObserver<Strings.StringMessage> pausedEcho(StreamObserver<Strings.StringMessage> observer) {
+    private static StreamObserver<Strings.StringMessage> pausedRequests(StreamObserver<Strings.StringMessage> observer) {
         return GrpcStreams.bidirectional(requests -> {
             pausedStarted.get().countDown();
             try {
@@ -611,7 +611,9 @@ class GrpcTeTrailersTest {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while waiting to release paused gRPC request stream", e);
             }
-            return requests.peek(ignored -> pausedConsumed.incrementAndGet());
+            // Keep response flow control out of this request-side backpressure test.
+            return requests.peek(_ -> pausedConsumed.incrementAndGet())
+                    .map(_ -> Strings.StringMessage.getDefaultInstance());
         }, observer);
     }
 


### PR DESCRIPTION
An unrelated Windows validation failure in #12384 exposed that the request-side gRPC backpressure test also echoed its 32 KiB request payloads, adding response-side flow-control pressure to the same call.

This keeps the large requests used to verify that production stops without server demand, but emits small responses after demand resumes. The test still requires all 128 requests to be produced and consumed and all 128 responses to arrive.
