### PR TITLE
Upgrade Protobuf to 4.36.0 (4.x)

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,7 +56,7 @@
         <version.lib.etcd4j>2.18.0</version.lib.etcd4j>
         <version.lib.google-api-client>2.8.1</version.lib.google-api-client>
         <version.lib.google-error-prone-annotations>2.30.0</version.lib.google-error-prone-annotations>
-        <version.lib.google-protobuf>4.31.1</version.lib.google-protobuf>
+        <version.lib.google-protobuf>4.36.0</version.lib.google-protobuf>
         <version.lib.graalvm>23.1.0</version.lib.graalvm>
         <version.lib.graphql-java>22.1</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>22.0</version.lib.graphql-java.extended.scalars>


### PR DESCRIPTION
Updates the managed Protobuf version from 4.31.1 to 4.36.0.

Starting with JDK 24, calls to terminally deprecated `sun.misc.Unsafe` memory-access methods emit startup warnings. Protobuf 4.31.1 initializes this path when standard generated Java messages are used, so Helidon gRPC applications running on newer JDKs can emit warnings from `com.google.protobuf.UnsafeUtil` before serving traffic.

[Protobuf 36.0](https://github.com/protocolbuffers/protobuf/releases/tag/v36.0) removes the `sun.misc.Unsafe` path from standard Java generated code. Updating the single managed version keeps the Protobuf BOM, Java runtime, and `protoc` aligned while removing the Protobuf-specific startup warning.

The upstream warning is tracked in [protocolbuffers/protobuf#20760](https://github.com/protocolbuffers/protobuf/issues/20760).

Forward-development change: #12393
