### PR TITLE
Use cached shared header constants (27.x)

### DIFF
--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
@@ -54,7 +54,7 @@ class WsClientImpl implements WsClient {
             "Sec-WebSocket-Version"), SUPPORTED_VERSION);
 
     private static final System.Logger LOGGER = System.getLogger(WsClient.class.getName());
-    private static final Header HEADER_CONN_UPGRADE = HeaderValues.create(HeaderNames.CONNECTION, "Upgrade");
+    private static final Header HEADER_CONN_UPGRADE = HeaderValues.createCached(HeaderNames.CONNECTION, "Upgrade");
     private static final HeaderName HEADER_WS_ACCEPT = HeaderNames.create("Sec-WebSocket-Accept");
     private static final HeaderName HEADER_WS_KEY = HeaderNames.create("Sec-WebSocket-Key");
     private static final LazyValue<Random> RANDOM = LazyValue.create(SecureRandom::new);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -69,7 +69,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      * Stream status trailers.
      */
     protected static final Header STREAM_TRAILERS =
-            HeaderValues.create(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+            HeaderValues.createCached(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
     private static final HeaderName CONTENT_DIGEST_NAME = HeaderNames.create("Content-Digest");
     private static final HeaderName CONTENT_MD5_NAME = HeaderNames.create("Content-MD5");
     private static final HeaderName DIGEST_NAME = HeaderNames.create("Digest");


### PR DESCRIPTION
Resolves #12391

Use cached immutable headers for shared WebSocket connection-token checks and stream-trailer declarations, preventing lazy initialization races across concurrent connections and responses.
