### PR TITLE
Use cached shared header constants (4.x)

### DIFF
--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WsClientImpl.java
@@ -54,7 +54,7 @@ class WsClientImpl implements WsClient {
             "Sec-WebSocket-Version"), SUPPORTED_VERSION);
 
     private static final System.Logger LOGGER = System.getLogger(WsClient.class.getName());
-    private static final Header HEADER_CONN_UPGRADE = HeaderValues.create(HeaderNames.CONNECTION, "Upgrade");
+    private static final Header HEADER_CONN_UPGRADE = HeaderValues.createCached(HeaderNames.CONNECTION, "Upgrade");
     private static final HeaderName HEADER_WS_ACCEPT = HeaderNames.create("Sec-WebSocket-Accept");
     private static final HeaderName HEADER_WS_KEY = HeaderNames.create("Sec-WebSocket-Key");
     private static final LazyValue<Random> RANDOM = LazyValue.create(SecureRandom::new);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerResponseBase.java
@@ -73,7 +73,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
      * Stream status trailers.
      */
     protected static final Header STREAM_TRAILERS =
-            HeaderValues.create(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
+            HeaderValues.createCached(HeaderNames.TRAILER, STREAM_RESULT_NAME.defaultCase());
     @SuppressWarnings("rawtypes")
     private static final List<SinkProvider> SINK_PROVIDERS =
             HelidonServiceLoader.builder(ServiceLoader.load(SinkProvider.class)).build().asList();

--- a/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
+++ b/webserver/websocket/src/main/java/io/helidon/webserver/websocket/WsUpgrader.java
@@ -106,7 +106,7 @@ public class WsUpgrader implements Http1Upgrader {
     protected static final Header SUPPORTED_VERSION_HEADER = HeaderValues.create(WS_VERSION, SUPPORTED_VERSION);
     static final Headers EMPTY_HEADERS = WritableHeaders.create();
     private static final System.Logger LOGGER = System.getLogger(WsUpgrader.class.getName());
-    private static final Header CONNECTION_UPGRADE = HeaderValues.create(HeaderNames.CONNECTION, "Upgrade");
+    private static final Header CONNECTION_UPGRADE = HeaderValues.createCached(HeaderNames.CONNECTION, "Upgrade");
     private static final byte[] KEY_SUFFIX = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".getBytes(US_ASCII);
     private static final int KEY_SUFFIX_LENGTH = KEY_SUFFIX.length;
     private static final Base64.Decoder B64_DECODER = Base64.getDecoder();


### PR DESCRIPTION
Resolves #12392

Use cached immutable headers for the 4.x WebSocket upgrade checks and stream-trailer declarations, preventing lazy initialization races across concurrent connections and responses.

Target-line implementation corresponding to #12395. The exact server-side constant is on a 4.x-specific path, so this is not a cherry-pick.
