### PR TITLE
Correct several API Javadocs (27.x)

### DIFF
--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsPathConfigBlueprint.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsPathConfigBlueprint.java
@@ -30,7 +30,7 @@ import io.helidon.http.PathMatcher;
  * matches one of the entry's methods. If there no {@code methods} list for the entry, then all HTTP methods match the entry.
  * <p>
  * If a request matches an entry, then the entry's {@code enabled} value (which defaults to {@code}) determines the entry's vote
- * whether the request should be measured. If a request matches multiple entries, the vote of the last matched entry wins.
+ * whether the request should be measured. If a request matches multiple entries, the vote of the first matched entry wins.
  *
  */
 @Prototype.Configured

--- a/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/spi/TracingSemanticConventionsProvider.java
+++ b/webserver/observe/tracing/src/main/java/io/helidon/webserver/observe/tracing/spi/TracingSemanticConventionsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.webserver.http.RoutingRequest;
 import io.helidon.webserver.http.RoutingResponse;
 import io.helidon.webserver.observe.tracing.TracingSemanticConventions;
 
-/**1
+/**
  * Behavior of a provider of tracing semantic conventions.
  */
 @Service.Contract

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/ServerRequest.java
@@ -149,7 +149,7 @@ public interface ServerRequest extends HttpRequest {
     /**
      * The pattern used to match this request. Such as "/foo/{bar}".
      *
-     * @return matching pattern or {@code ""} if not available
+     * @return matching pattern or {@link Optional#empty()} if not available
      */
     default Optional<String> matchingPattern() {
         return Optional.empty();


### PR DESCRIPTION
Resolves #12411
Resolves #12420
Resolves #12435

Correct API Javadocs for auto-metrics path matching, tracing semantic conventions, and unavailable WebServer matching patterns.
