### PR TITLE
4.x: Backport documentation release and Javadoc fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,6 +185,7 @@ jobs:
           artifact-path: |
             **/target/state-javadoc.xml
             **/target/*-javadoc.jar
+            javadocs/target/*.jar
           run: |
             mvn ${MVN_ARGS} -T8 \
               -Dorg.slf4j.simpleLogger.showThreadName=true \

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -130,17 +130,23 @@ current_version() {
   awk 'BEGIN {FS="[<>]"} ; /<version>/ {print $3; exit 0}' "${WS_DIR}"/pom.xml
 }
 
-# arg1: pattern
-# arg2: include pattern
+# arg1: dir
+# arg2: pattern
+# arg3: include pattern
 search() {
   set +o pipefail
-  grep "${1}" -Er . --include "${2}" | cut -d ':' -f 1 | xargs git ls-files | sort | uniq
+  grep "${2}" -Er "${1}" --include "${3}" | cut -d ':' -f 1 | xargs git ls-files | sort | uniq
 }
 
 replace() {
-  local pattern value replace include
+  local dir pattern value replace include
+
   while (( ${#} > 0 )); do
     case ${1} in
+    "--dir="*)
+      dir=${1#*=}
+      shift
+      ;;
     "--pattern="*)
       pattern=${1#*=}
       shift
@@ -168,7 +174,7 @@ replace() {
     replace=${pattern/\.\*/${value}}
   fi
 
-  for file in $(search "${pattern}" "${include}"); do
+  for file in $(search "${dir:-.}" "${pattern}" "${include}"); do
     echo "Updating ${file}"
     sed -e s@"${pattern}"@"${replace}"@g "${file}" > "${file}.tmp"
     mv "${file}.tmp" "${file}"
@@ -201,9 +207,10 @@ update_version(){
 
   # update docs
   replace \
-    --pattern="^  version: \".*\"$" \
-    --replace="  version: \"${version}\"" \
-    --include="README.md"
+    --pattern="${current_version}" \
+    --replace="${version}" \
+    --dir="docs" \
+    --include="*.md"
 }
 
 create_tag() {

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2026 Oracle and/or its affiliates.
+    Copyright (c) 2026 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscovery.java
+++ b/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscovery.java
@@ -231,8 +231,7 @@ public interface WebClientDiscovery extends RuntimeType.Api<WebClientDiscoveryCo
      *
      * <p>A minimal example of (YAML) configuration follows:</p>
      *
-     * <blockquote style="background-color: var(--snippet-background-color);"><pre>client: # see the <a
-     * href="https://helidon.io/docs/latest/config/io_helidon_webclient_api_WebClient">Helidon Configuration Reference for WebClient</a>
+     * <blockquote style="background-color: var(--snippet-background-color);"><pre>client:
      *  services:
      *    {@linkplain WebClientDiscoveryConfig discovery}:
      *      {@linkplain WebClientDiscoveryConfig#prefixUris() prefix-uris}:
@@ -298,7 +297,6 @@ public interface WebClientDiscovery extends RuntimeType.Api<WebClientDiscoveryCo
      *
      * @return a non-{@code null} {@link WebClientDiscoveryConfig.Builder}
      * @see WebClientDiscoveryConfig#builder()
-     * @see <a href="https://helidon.io/docs/latest/se/builder#_specification_3">Helidon Builder</a>
      */
     static WebClientDiscoveryConfig.Builder builder() {
         return WebClientDiscoveryConfig.builder();
@@ -315,7 +313,6 @@ public interface WebClientDiscovery extends RuntimeType.Api<WebClientDiscoveryCo
      * @see #builder()
      * @see WebClientDiscoveryConfig.Builder#update(Consumer)
      * @see WebClientDiscoveryConfig.Builder#build()
-     * @see <a href="https://helidon.io/docs/latest/se/builder#_specification_3">Helidon Builder</a>
      */
     static WebClientDiscovery create(Consumer<WebClientDiscoveryConfig.Builder> consumer) {
         return builder().update(consumer).build();
@@ -333,7 +330,6 @@ public interface WebClientDiscovery extends RuntimeType.Api<WebClientDiscoveryCo
      * @exception NullPointerException if {@code prototype} is {@code null}
      * @see WebClientDiscoveryConfig.Builder#build()
      * @see WebClientDiscoveryConfig.Builder#buildPrototype()
-     * @see <a href="https://helidon.io/docs/latest/se/builder#_specification_3">Helidon Builder</a>
      */
     static WebClientDiscovery create(WebClientDiscoveryConfig prototype) {
         return new DefaultWebClientDiscovery(prototype);

--- a/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscoveryConfigBlueprint.java
+++ b/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscoveryConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscoveryConfigBlueprint.java
+++ b/webclient/discovery/src/main/java/io/helidon/webclient/discovery/WebClientDiscoveryConfigBlueprint.java
@@ -28,7 +28,6 @@ import io.helidon.discovery.Discovery;
  *
  * @see WebClientDiscovery
  * @see WebClientDiscovery#create(WebClientDiscoveryConfig)
- * @see <a href="https://helidon.io/docs/latest/se/builder#_specification">Helidon Builder</a>
  */
 @Prototype.Blueprint
 @Prototype.Configured


### PR DESCRIPTION
### Description

Backports the 4.x-applicable documentation release and Javadoc fixes from
#12389:

- update release version substitution across tracked Markdown under `docs/`;
- include aggregate Javadoc JARs from `javadocs/target/` in CI artifacts; and
- remove obsolete documentation links from WebClient discovery Javadocs.

Helidon-example links remain on `helidon-4.x`; no examples or public APIs are
changed.

### Documentation

This change fixes documentation release processing and Javadoc references.

### Validation

- `git diff --check`
- `etc/scripts/shellcheck.sh`
- JDK 21 aggregate Javadoc build for `webclient/discovery` and `javadocs` with
  dependencies; all 451 projects passed
- confirmed the aggregate Javadoc JAR under `javadocs/target/`
- detached `release.sh update_version` smoke changed only 790 POMs and
  `docs/README.md`, with no residual old version, unexpected paths, temporary
  files, or whitespace errors
- verified Helidon-example branch links and obsolete WebClient links
