### PR TITLE
Ignore in-flight HTTP/2 frames after local stream reset

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -1096,13 +1096,14 @@ public class Http2ClientConnection {
         Http2ClientStream stream = stream(streamId);
         if (stream == null) {
             validateKnownAbandonedClientStream(streamId, Http2FrameType.DATA);
-            connectionFlowControl.decrementInboundConnectionWindowSize(frameHeader.length());
-            connectionFlowControl.incrementInboundConnectionWindowSize(frameHeader.length());
+            restoreDiscardedConnectionCredit(frameHeader);
             logDroppedFrame(Http2FrameType.DATA, streamId);
             return;
         }
         Http2FrameData frameData = new Http2FrameData(frameHeader, data);
         if (!stream.prepareInboundData(frameData)) {
+            restoreDiscardedConnectionCredit(frameHeader);
+            logDroppedFrame(Http2FrameType.DATA, streamId);
             return;
         }
         stream.flowControl().inbound().decrementWindowSize(frameHeader.length());
@@ -1110,6 +1111,11 @@ public class Http2ClientConnection {
             ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
         }
         stream.push(frameData);
+    }
+
+    private void restoreDiscardedConnectionCredit(Http2FrameHeader frameHeader) {
+        connectionFlowControl.decrementInboundConnectionWindowSize(frameHeader.length());
+        connectionFlowControl.incrementInboundConnectionWindowSize(frameHeader.length());
     }
 
     private boolean handleHeadersFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
@@ -1173,7 +1179,7 @@ public class Http2ClientConnection {
 
     private void logDroppedFrame(Http2FrameType frameType, int streamId) {
         if (LOGGER.isLoggable(DEBUG)) {
-            ctx.log(LOGGER, DEBUG, "%d: received %s for stream %d, which does not exist",
+            ctx.log(LOGGER, DEBUG, "%d: discarded %s for inactive stream %d",
                     0, frameType, streamId);
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -87,6 +87,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private boolean hasEntity;
     private boolean continue100Received;
     private volatile boolean inboundEndQueued;
+    private volatile boolean locallyReset;
 
     // streamId and buffer can only be created when we are locked in the stream id sequence
     private int streamId;
@@ -332,6 +333,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
                                                           true,
                                                           false,
                                                           false);
+            locallyReset = true;
             this.state = nextState;
         } finally {
             inboundStateLock.unlock();
@@ -411,7 +413,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         boolean endOfStream = (flags & Http2Flag.END_OF_STREAM) == Http2Flag.END_OF_STREAM;
         ReadState currentReadState = readState;
 
-        if (closed) {
+        if (closed || locallyReset) {
             return false;
         }
         if (inboundEndQueued || currentReadState != ReadState.DATA) {
@@ -423,7 +425,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
         inboundStateLock.lock();
         try {
-            if (closed) {
+            if (closed || locallyReset) {
                 return false;
             }
             currentReadState = readState;
@@ -726,9 +728,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     void inboundHeaders(Http2Headers headers, boolean endOfStream) {
         inboundStateLock.lock();
         try {
-            // A locally closed stream must not publish late headers, but the connection
+            // A locally closed or reset stream must not publish late headers, but the connection
             // thread still decodes them to keep HPACK state aligned for other streams.
-            if (closed) {
+            if (closed || locallyReset) {
                 return;
             }
             if (readState == ReadState.CONTINUE_100_HEADERS || readState == ReadState.HEADERS) {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1507,10 +1507,13 @@ class Http2ClientConnectionTest {
                 ArgumentCaptor<BufferData> writes = ArgumentCaptor.forClass(BufferData.class);
                 verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(2)).writeNow(writes.capture());
                 Http2FrameHeader resetHeader = Http2FrameHeader.create(writes.getAllValues().get(0).copy());
-                Http2FrameHeader windowUpdateHeader = Http2FrameHeader.create(writes.getAllValues().get(1).copy());
+                BufferData windowUpdateData = writes.getAllValues().get(1).copy();
+                Http2FrameHeader windowUpdateHeader = Http2FrameHeader.create(windowUpdateData);
+                Http2WindowUpdate windowUpdate = Http2WindowUpdate.create(windowUpdateData);
                 assertThat(resetHeader.type(), is(Http2FrameType.RST_STREAM));
                 assertThat(windowUpdateHeader.type(), is(Http2FrameType.WINDOW_UPDATE));
                 assertThat(windowUpdateHeader.streamId(), is(0));
+                assertThat(windowUpdate.windowSizeIncrement(), is(2 * WindowSize.DEFAULT_MAX_FRAME_SIZE));
             } finally {
                 resetWrite.release();
                 try {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -891,7 +891,7 @@ class Http2ClientConnectionTest {
             assertThat(blockedReset.awaitEntered(), is(true));
 
             try {
-                test.offerInbound(dataFrame(stream.streamId(), "invalid".getBytes(StandardCharsets.UTF_8), false));
+                test.offerInbound(dataFrame(0, "invalid".getBytes(StandardCharsets.UTF_8), false));
                 Http2ClientProtocolConfig noPing = Http2ClientProtocolConfig.builder()
                         .ping(false)
                         .buildPrototype();
@@ -1461,6 +1461,116 @@ class Http2ClientConnectionTest {
 
             secondStream.close();
             connection.close();
+        }
+    }
+
+    @Test
+    void lateDataDuringCancelDoesNotCloseConnection() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream canceledStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+
+            canceledStream.writeHeaders(requestHeaders(), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(canceledStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(canceledStream.readHeaders().status(), is(Status.OK_200));
+
+            clearInvocations(test.dataWriter);
+            MockedConnectionTestContext.BlockedWrite resetWrite = test.blockNextWriteNow();
+            CompletableFuture<Void> cancel = CompletableFuture.runAsync(canceledStream::cancel);
+            try {
+                assertThat(resetWrite.awaitEntered(), is(true));
+                byte[] maxDataFrame = new byte[WindowSize.DEFAULT_MAX_FRAME_SIZE];
+                test.offerInbound(dataFrame(canceledStream.streamId(), maxDataFrame, false),
+                                  dataFrame(canceledStream.streamId(), maxDataFrame, false),
+                                  dataFrame(canceledStream.streamId(), BufferData.EMPTY_BYTES, true),
+                                  encodedHeaderFrame(siblingStream.streamId(),
+                                                     encodedResponseHeaders(false),
+                                                     inboundTable,
+                                                     huffman,
+                                                     true));
+
+                assertThat(siblingStream.readHeaders().status(), is(Status.OK_200));
+                verify(test.clientConnection, never()).closeResource();
+
+                resetWrite.release();
+                cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                ArgumentCaptor<BufferData> writes = ArgumentCaptor.forClass(BufferData.class);
+                verify(test.dataWriter, timeout(TEST_WAIT_TIMEOUT.toMillis()).times(2)).writeNow(writes.capture());
+                Http2FrameHeader resetHeader = Http2FrameHeader.create(writes.getAllValues().get(0).copy());
+                Http2FrameHeader windowUpdateHeader = Http2FrameHeader.create(writes.getAllValues().get(1).copy());
+                assertThat(resetHeader.type(), is(Http2FrameType.RST_STREAM));
+                assertThat(windowUpdateHeader.type(), is(Http2FrameType.WINDOW_UPDATE));
+                assertThat(windowUpdateHeader.streamId(), is(0));
+            } finally {
+                resetWrite.release();
+                try {
+                    cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                } finally {
+                    canceledStream.close();
+                    siblingStream.close();
+                    connection.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    void lateHeadersDuringCancelDoNotCloseConnection() throws Exception {
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(10));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream canceledStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+
+            canceledStream.writeHeaders(requestHeaders(), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            test.offerInbound(encodedHeaderFrame(canceledStream.streamId(),
+                                                 encodedResponseHeaders(false),
+                                                 inboundTable,
+                                                 huffman));
+            assertThat(canceledStream.readHeaders().status(), is(Status.OK_200));
+
+            MockedConnectionTestContext.BlockedWrite resetWrite = test.blockNextWriteNow();
+            CompletableFuture<Void> cancel = CompletableFuture.runAsync(canceledStream::cancel);
+            try {
+                assertThat(resetWrite.awaitEntered(), is(true));
+                test.offerInbound(encodedHeaderFrame(canceledStream.streamId(),
+                                                     encodedTrailers(),
+                                                     inboundTable,
+                                                     huffman,
+                                                     true),
+                                  encodedHeaderFrame(siblingStream.streamId(),
+                                                     encodedResponseHeaders(true),
+                                                     inboundTable,
+                                                     huffman,
+                                                     true));
+
+                Http2Headers siblingHeaders = siblingStream.readHeaders();
+                assertThat(siblingHeaders.status(), is(Status.OK_200));
+                assertThat(siblingHeaders.httpHeaders().get(SHARED_HEADER).get(), is("shared-value"));
+                assertThat(siblingHeaders.httpHeaders().get(HeaderNames.CACHE_CONTROL).get(), is("no-cache"));
+                verify(test.clientConnection, never()).closeResource();
+            } finally {
+                resetWrite.release();
+                cancel.get(TEST_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                canceledStream.close();
+                siblingStream.close();
+                connection.close();
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #12480

Marks locally reset HTTP/2 client streams before publishing the closed protocol state so frames already in flight after `RST_STREAM` are discarded without terminating the shared connection. Restores connection-level flow-control credit for discarded DATA and adds deterministic regressions for DATA, trailing HEADERS and HPACK state, `WINDOW_UPDATE`, and sibling-stream progress.
