### PR TITLE
3.x: Update build-examples.sh to always update examples with helidon version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -136,14 +136,7 @@ jobs:
           cache: maven
       - name: Maven build
         run: |
-          mvn -B -e "-Dmaven.test.skip=true" $MAVEN_HTTP_ARGS -DskipTests -Ppipeline install
-      - name: Examples checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-          repository: helidon-io/helidon-examples.git
-          ref: dev-3.x
-          path: helidon-examples
+          mvn -B -e "-Dmaven.test.skip=true" $MAVEN_HTTP_ARGS -DskipTests -Ppipeline -T4 install
       - name: Examples build
         run: etc/scripts/build-examples.sh
   archetypes:

--- a/etc/scripts/build-examples.sh
+++ b/etc/scripts/build-examples.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,30 +15,46 @@
 # limitations under the License.
 #
 
-# Build helidon examples, cloning the examples repository if needed
+set -o pipefail || true  # trace ERR through pipes
+set -o errtrace || true # trace ERR through commands and functions
+set -o errexit || true  # exit the script if any statement returns a non-true return value
+
+on_error(){
+    CODE="${?}" && \
+    set +x && \
+    printf "[ERROR] Error(code=%s) occurred at %s:%s command: %s\n" \
+        "${CODE}" "${BASH_SOURCE[0]}" "${LINENO}" "${BASH_COMMAND}"
+}
+trap on_error ERR
 
 # Path to this script
-[ -h "${0}" ] && readonly SCRIPT_PATH="$(readlink "${0}")" || readonly SCRIPT_PATH="${0}"
-
-# Load pipeline environment setup and define WS_DIR
-. $(dirname -- "${SCRIPT_PATH}")/includes/pipeline-env.sh "${SCRIPT_PATH}" '../..'
-
-# Setup error handling using default settings (defined in includes/error_handlers.sh)
-error_trap_setup
-
-# If needed we clone the helidon-examples repo into a subdirectory of the helidon repository
-readonly HELIDON_EXAMPLES_PATH=${WS_DIR}/helidon-examples
-if [ ! -d "${HELIDON_EXAMPLES_PATH}" ]; then
-  echo "Cloning examples repository into ${HELIDON_EXAMPLES_PATH}"
-  git clone --branch dev-3.x --single-branch git@github.com:helidon-io/helidon-examples.git "${HELIDON_EXAMPLES_PATH}"
+if [ -h "${0}" ] ; then
+    SCRIPT_PATH="$(readlink "${0}")"
+else
+    # shellcheck disable=SC155
+    SCRIPT_PATH="${0}"
 fi
+readonly SCRIPT_PATH
 
-# Make sure the helidon version from the example repo aligns with this repository
-readonly HELIDON_VERSION_IN_THIS_REPO=$(mvn --non-recursive -f ${WS_DIR}/pom.xml help:evaluate -Dexpression=helidon.version | grep -v '\[INFO\]')
-readonly HELIDON_VERSION_IN_EXAMPLES=$(mvn --non-recursive -f ${HELIDON_EXAMPLES_PATH}/pom.xml help:evaluate -Dexpression=helidon.version | grep -v '\[INFO\]')
-if [ ${HELIDON_VERSION_IN_THIS_REPO} != ${HELIDON_VERSION_IN_EXAMPLES} ]; then
-  echo "The Helidon version in this repository (${HELIDON_VERSION_IN_THIS_REPO}) does not match the Helidon version in ${HELIDON_EXAMPLES_PATH} (${HELIDON_VERSION_IN_EXAMPLES})"
-  exit 78
-fi
+# Path to the root of the workspace
+# shellcheck disable=SC2046
+WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
+readonly WS_DIR
 
-mvn ${MAVEN_ARGS} -f ${HELIDON_EXAMPLES_PATH}/pom.xml clean install
+version() {
+  awk 'BEGIN {FS="[<>]"} ; /<helidon.version>/ {print $3; exit 0}' "${1}"
+}
+
+HELIDON_VERSION=$(version "${WS_DIR}/bom/pom.xml")
+readonly HELIDON_VERSION
+
+echo "Cloning examples repository into ${WS_DIR}/helidon-examples"
+git clone --branch helidon-3.x --single-branch https://github.com/helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
+
+echo "Updating helidon.version in examples to ${HELIDON_VERSION}"
+"${WS_DIR}/helidon-examples"/etc/scripts/update-version.sh "${HELIDON_VERSION}"
+
+# shellcheck disable=SC2086
+mvn ${MVN_ARGS} \
+    -f "${WS_DIR}/helidon-examples/pom.xml" \
+    clean install

--- a/etc/scripts/build-examples.sh
+++ b/etc/scripts/build-examples.sh
@@ -56,5 +56,5 @@ echo "Updating helidon.version in examples to ${HELIDON_VERSION}"
 
 # shellcheck disable=SC2086
 mvn ${MVN_ARGS} \
-    -f "${WS_DIR}/helidon-examples/pom.xml" \
+    -B -f "${WS_DIR}/helidon-examples/pom.xml" -T4 \
     clean install

--- a/etc/scripts/build-examples.sh
+++ b/etc/scripts/build-examples.sh
@@ -56,5 +56,5 @@ echo "Updating helidon.version in examples to ${HELIDON_VERSION}"
 
 # shellcheck disable=SC2086
 mvn ${MVN_ARGS} \
-    -B -f "${WS_DIR}/helidon-examples/pom.xml" -T4 \
+    -B -f "${WS_DIR}/helidon-examples/pom.xml" \
     clean install


### PR DESCRIPTION
### Description

When building examples using helidon-N.x branch and update version.  

This is in preparation for simplification of helidon-examples repo management and syncs up the script with what is in 4.x.

See https://github.com/helidon-io/helidon-examples/issues/328
