### PR TITLE
Upgrade Checkstyle to support flexible constructor bodies (27.x)

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegen.java
@@ -98,7 +98,7 @@ class BuilderCodegen implements CodegenExtension {
     }
 
     /**
-     *
+     * Generates custom prototype methods.
      * @param classModel     prototype class model builder
      * @param customMethods  custom methods to code generate
      * @param implementation true for implementation, false for prototype

--- a/common/media-type/src/main/java/io/helidon/common/media/type/MediaType.java
+++ b/common/media-type/src/main/java/io/helidon/common/media/type/MediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public interface MediaType {
     String text();
 
     /**
-     * Is the type a wildcard?
+     * Checks whether the type is a wildcard.
      * @return whether this is a wildcard type
      */
     default boolean isWildcardType() {
@@ -63,7 +63,7 @@ public interface MediaType {
     }
 
     /**
-     * Is the subtype a wildcard?
+     * Checks whether the subtype is a wildcard.
      * @return whether this is a wildcard subtype
      */
     default boolean isWildcardSubtype() {

--- a/common/tls/src/main/java/io/helidon/common/tls/RevocationConfigBlueprint.java
+++ b/common/tls/src/main/java/io/helidon/common/tls/RevocationConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,8 +83,8 @@ interface RevocationConfigBlueprint {
     boolean fallbackEnabled();
 
     /**
-     * Allow revocation check to succeed if the revocation status cannot be
-     * determined for one of the following reasons:
+     * Allows a revocation check to succeed when a CRL or OCSP response cannot be obtained due to a network failure, or
+     * the OCSP responder returns {@code internalError} or {@code tryLater}.
      * <ul>
      *  <li>The CRL or OCSP response cannot be obtained because of a
      *      network error.

--- a/config/config/src/main/java/io/helidon/config/ConfigDiff.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,14 +93,16 @@ class ConfigDiff {
     }
 
     /**
+     * Reports whether this diff has no changes.
      *
-     * @return {@code} true if there were no changes; {@code false} otherwise
+     * @return {@code true} if there were no changes; {@code false} otherwise
      */
     boolean isEmpty() {
         return changedKeys.isEmpty();
     }
 
     /**
+     * Returns changed configuration keys.
      *
      * @return the {@code Config.Key}s that were added, removed, or the values
      * for which were changed
@@ -110,6 +112,7 @@ class ConfigDiff {
     }
 
     /**
+     * Returns the newer configuration.
      *
      * @return the newer {@code Config} used in the comparison
      */

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/LocalTxSupport.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/LocalTxSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import io.helidon.transaction.spi.TxSupport;
 
 /**
  * Resource local transaction handling support.
- * This is the resource local TxSupport service linking transaction API with {@link jakarta.persistence.EntityTransaction).
+ * This is the resource local TxSupport service linking transaction API with {@link jakarta.persistence.EntityTransaction}.
  */
 @Service.Singleton
 @Weight(Weighted.DEFAULT_WEIGHT - 10)

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/validation/ValidationHelper.java
@@ -109,7 +109,7 @@ final class ValidationHelper {
     }
 
     /**
-     *
+     * Adds validation code for a constraint.
      * @param context       validation code generation context
      * @param constraint    the constraint - must be an annotation of the element or its type parameters
      * @param location      location of the check (i.e. parameter, return value etc.)

--- a/docs/config/io.helidon.common.tls.RevocationConfig.md
+++ b/docs/config/io.helidon.common.tls.RevocationConfig.md
@@ -27,7 +27,7 @@ Certificate revocation configuration
 <td>
 <code>false</code>
 </td>
-<td>Allow revocation check to succeed if the revocation status cannot be determined for one of the following reasons: <ul>  <li>The CRL or OCSP response cannot be obtained because of a      network error.</li></ul></td>
+<td>Allows a revocation check to succeed when a CRL or OCSP response cannot be obtained due to a network failure, or the OCSP responder returns <code>internal<wbr>Error</code> or <code>try<wbr>Later</code></td>
 </tr>
 <tr>
 <td>

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -126,7 +126,7 @@
         <module name="JavadocVariable">
             <property name="accessModifiers" value="protected,public"/>
         </module>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->

--- a/http/http/src/main/java/io/helidon/http/HttpPrologue.java
+++ b/http/http/src/main/java/io/helidon/http/HttpPrologue.java
@@ -40,6 +40,8 @@ public class HttpPrologue {
     private UriFragment fragment;
 
     /**
+     * Creates an HTTP prologue.
+     *
      * @param protocol        protocol name, should be {@code HTTP} in most cases
      * @param protocolVersion HTTP protocol version of this request
      * @param method          HTTP method of this request

--- a/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscovery.java
+++ b/metadata/metadata/src/main/java/io/helidon/metadata/MetadataDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public interface MetadataDiscovery {
      */
     enum Mode {
         /**
-         * Automatic mode, works as follows:
+         * Automatic mode works as follows.
          * <ul>
          * <li>If {@link MetadataConstants#MANIFEST_FILE} is found, and it is considered merged (more than one line with
          * {@link MetadataConstants#MANIFEST_ID_LINE} exists),

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         Changing these version requires approval for a new third party dependency!
         -->
         <version.lib.asm>9.9.1</version.lib.asm>
-        <version.lib.checkstyle>13.3.0</version.lib.checkstyle>
+        <version.lib.checkstyle>14.1.0</version.lib.checkstyle>
         <!-- Dependencies convergence via jinjava -->
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mockserver>5.15.0</version.lib.mockserver>

--- a/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
+++ b/service/maven-plugin/src/main/java/io/helidon/service/maven/plugin/BindingGenerator.java
@@ -623,6 +623,8 @@ class BindingGenerator {
     }
 
     /**
+     * A binding to matching service descriptors.
+     *
      * @param dependency  to bind to
      * @param descriptors matching descriptors
      */

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServiceRoute.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcServiceRoute.java
@@ -103,7 +103,7 @@ class GrpcServiceRoute extends GrpcRoute {
     }
 
     /**
-     * Creates a gRPC route for a service instance annotated with {@link @Grpc}.
+     * Creates a gRPC route for a generated service descriptor.
      * Registers interceptors for context on all the routes.
      *
      * @param service the service


### PR DESCRIPTION
Resolves #12490

Upgrades Checkstyle to 14.1.0 and updates the Checkstyle configuration and Javadocs for the new parser.
