### PR TITLE
Avoid redundant HTTP/2 stream setup

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -515,7 +515,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         case WRITE_SERVER_SETTINGS -> writeServerSettings();
         case WINDOW_UPDATE -> readWindowUpdateFrame();
         case SETTINGS -> doSettings();
-        case ACK_SETTINGS -> ackSettings();
+        case ACK_SETTINGS -> ackSettings(limit);
         case DATA -> dataFrame();
         case HEADERS -> doHeaders(limit);
         case PRIORITY -> doPriority();
@@ -717,7 +717,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
         }
     }
 
-    private void ackSettings() {
+    private void ackSettings(Limit limit) {
         Http2Flag.SettingsFlags flags = Http2Flag.SettingsFlags.create(Http2Flag.ACK);
         Http2FrameHeader header = Http2FrameHeader.create(0, Http2FrameTypes.SETTINGS, flags, 0);
         writeConnectionFrame(new Http2FrameData(header, BufferData.empty()));
@@ -730,6 +730,7 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
             Http2ServerStream stream = stream(1).stream();
             activateStream(1);
             stream.prologue(upgradePrologue);
+            stream.requestLimit(limit);
             stream.headers(upgradeHeaders, !hasEntity);
             upgradeHeaders = null;
             ctx.executor()

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -32,7 +31,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.concurrency.limits.FixedLimit;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
 import io.helidon.common.socket.SocketWriterException;
@@ -138,9 +136,8 @@ class Http2ServerStream implements Runnable, Http2Stream {
     private Http2RstStream pendingSubProtocolReset;
     private long expectedLength = -1;
     private HttpPrologue prologue;
-    // create a limit if accessed before we get the one from connection
     // must be volatile, as it is accessed both from connection thread and from stream thread
-    private volatile Limit requestLimit = FixedLimit.create(new Semaphore(1));
+    private volatile Limit requestLimit;
 
     /**
      * A new HTTP/2 server stream.
@@ -582,9 +579,6 @@ class Http2ServerStream implements Runnable, Http2Stream {
         } finally {
             runnerLock.unlock();
         }
-        Thread.currentThread()
-                .setName("[" + ctx.socketId() + " "
-                                 + ctx.childSocketId() + " ] - " + streamId);
         boolean completed = false;
         boolean connectionFailed = false;
         boolean resetSent = false;

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.SocketWriter;
@@ -46,6 +47,7 @@ import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
+import io.helidon.http.encoding.ContentEncodingContext;
 import io.helidon.http.http2.Http2ErrorCode;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
@@ -407,6 +409,51 @@ class Http2ConnectionTest {
     }
 
     @Test
+    void requestUsesConnectionLimitWithoutRenamingHandlerThread() {
+        Queue<byte[]> input = new ConcurrentLinkedQueue<>();
+        input.add(requestHeadersFrame());
+        ConnectionContext ctx = runnableConnectionContext(input);
+        Limit limit = throwingLimit();
+        String originalThreadName = Thread.currentThread().getName();
+
+        try {
+            assertThrows(CloseConnectionException.class,
+                         () -> new Http2Connection(ctx, Http2Config.create(), List.of()).handle(limit));
+            assertThat(Thread.currentThread().getName(), is(originalThreadName));
+        } finally {
+            Thread.currentThread().setName(originalThreadName);
+        }
+        verify(limit).tryAcquireOutcome(true);
+    }
+
+    @Test
+    void h2cUpgradeUsesConnectionLimit() {
+        Queue<byte[]> input = new ConcurrentLinkedQueue<>();
+        input.add(frameBytes(Http2Settings.builder()
+                                     .build()
+                                     .toFrameData(null, 0, Http2Flag.SettingsFlags.create(0))));
+        ConnectionContext ctx = runnableConnectionContext(input);
+        Limit limit = throwingLimit();
+        Http2Connection connection = new Http2Connection(ctx, Http2Config.create(), List.of());
+        Http2Headers headers = Http2Headers.create(WritableHeaders.create());
+        headers.method(Method.GET);
+        headers.path("/upgrade");
+        headers.scheme("http");
+        headers.authority("localhost");
+        connection.upgradeConnectionData(HttpPrologue.create("HTTP/1.1",
+                                                             "HTTP",
+                                                             "1.1",
+                                                             Method.GET,
+                                                             "/upgrade",
+                                                             false),
+                                         headers);
+
+        assertThrows(CloseConnectionException.class, () -> connection.handle(limit));
+
+        verify(limit).tryAcquireOutcome(true);
+    }
+
+    @Test
     void windowUpdateForActiveStreamRefreshesIdleTime() throws InterruptedException {
         Queue<byte[]> input = new ConcurrentLinkedQueue<>();
         Http2Headers h2Headers = Http2Headers.create(WritableHeaders.create());
@@ -615,6 +662,49 @@ class Http2ConnectionTest {
         when(ctx.dataWriter()).thenReturn(writer);
         when(ctx.dataReader()).thenReturn(reader);
         return ctx;
+    }
+
+    private static ConnectionContext runnableConnectionContext(Queue<byte[]> input) {
+        ConnectionContext ctx = http2Context(mock(DataWriter.class), DataReader.create(input::poll));
+        ExecutorService executor = mock(ExecutorService.class);
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(executor).submit(any(Runnable.class));
+        when(ctx.executor()).thenReturn(executor);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        ContentEncodingContext contentEncodingContext = mock(ContentEncodingContext.class);
+        when(listenerContext.contentEncodingContext()).thenReturn(contentEncodingContext);
+        when(ctx.listenerContext()).thenReturn(listenerContext);
+        PeerInfo peerInfo = mock(PeerInfo.class);
+        when(peerInfo.tlsCertificates()).thenReturn(Optional.empty());
+        when(ctx.remotePeer()).thenReturn(peerInfo);
+        when(ctx.proxyProtocolData()).thenReturn(Optional.empty());
+        return ctx;
+    }
+
+    private static Limit throwingLimit() {
+        Limit limit = mock(Limit.class);
+        doThrow(new IllegalStateException("connection limit used")).when(limit).tryAcquireOutcome(true);
+        return limit;
+    }
+
+    private static byte[] requestHeadersFrame() {
+        Http2Headers headers = Http2Headers.create(WritableHeaders.create());
+        headers.method(Method.GET);
+        headers.path("/");
+        headers.scheme("http");
+        headers.authority("localhost");
+        BufferData headersData = BufferData.growing(512);
+        headers.write(Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue()),
+                      Http2HuffmanEncoder.create(),
+                      headersData);
+        return frameBytes(new Http2FrameData(Http2FrameHeader.create(headersData.available(),
+                                                                     Http2FrameTypes.HEADERS,
+                                                                     Http2Flag.HeaderFlags.create(Http2Flag.END_OF_HEADERS
+                                                                                                           | Http2Flag.END_OF_STREAM),
+                                                                     1),
+                                             headersData));
     }
 
     private static byte[] frameBytes(Http2FrameData frameData) {


### PR DESCRIPTION
Removes redundant work from HTTP/2 request dispatch.

- Reuses the listener request limit for ordinary streams and h2c upgrade stream 1.
- Removes the per-stream fallback `FixedLimit` and semaphore construction now that every production dispatch path installs the listener limit before execution.
- Keeps the executor-provided handler thread name instead of rebuilding it for every stream.
- Adds focused coverage for normal and h2c admission paths and thread-name preservation.

Each HTTP/2 stream previously initialized a private semaphore-backed `FixedLimit`, even though ordinary streams replaced it before execution. This change removes that source-level construction; no measured allocation reduction is claimed.

A short targeted JMH comparison was effectively flat (24.0388 versus 23.9350 ops/s, +0.43%), so no throughput regression was observed in that benchmark. In source-bound HttpArena TLS/ALPN runs against the commit’s exact parent, the 128-connection/100-stream shape improved mean throughput by 6.1% and mean latency by 6.5%, with both A/B pairs positive. The 64x100 result was +2.9%, within the base run spread.

These were two-sample, 15-second measurements and should be treated as directional. Reported p99 latency was 12.3% and 23.3% higher at the two shapes, so no tail-latency improvement is claimed.
