### PR TITLE
Allow telemetry to be disabled without startup exception

### DIFF
--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
@@ -35,6 +35,10 @@ final class OpenTelemetryConfigSupport {
     private OpenTelemetryConfigSupport() {
     }
 
+    private static OpenTelemetrySdk noopOpenTelemetrySdk() {
+        return OpenTelemetrySdk.builder().build();
+    }
+
     private static OpenTelemetry openTelemetry(OpenTelemetryConfig.BuilderBase<?, ?> target) {
         var openTelemetrySdkBuilder = OpenTelemetrySdk.builder();
 
@@ -100,12 +104,21 @@ final class OpenTelemetryConfigSupport {
             derive from the settings.
              */
             if (target.openTelemetry().isPresent()) {
+                if (target.openTelemetrySdk().isEmpty()) {
+                    var openTelemetry = target.openTelemetry().get();
+                    target.openTelemetrySdk(openTelemetry instanceof OpenTelemetrySdk sdk
+                                                    ? sdk
+                                                    : noopOpenTelemetrySdk());
+                }
                 return;
             }
 
-            target.openTelemetry(target.enabled()
-                                         ? openTelemetry(target)
-                                         : OpenTelemetry.noop());
+            if (target.enabled()) {
+                target.openTelemetry(openTelemetry(target));
+            } else {
+                target.openTelemetrySdk(noopOpenTelemetrySdk())
+                        .openTelemetry(OpenTelemetry.noop());
+            }
         }
 
     }
@@ -149,4 +162,3 @@ final class OpenTelemetryConfigSupport {
     }
 
 }
-

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestBasicConfig.java
@@ -23,12 +23,15 @@ import io.helidon.common.testing.junit5.OptionalMatcher;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -116,6 +119,29 @@ class TestBasicConfig {
         assertThat("Global", openTelemetry.global(), is(true));
         assertThat("Registered", openTelemetry.registered(), is(true));
         assertThat("Enabled", openTelemetry.enabled(), is(true));
+    }
+
+    @Test
+    void testDisabled() {
+        /*
+        The main point of this test is to make sure that we can build the OpenTelemetryConfig object without errors when
+        telemetry is disabled.
+         */
+        var config = Config.just(ConfigSources.create(
+                """
+                        telemetry:
+                          service: test
+                          enabled: false
+                        """,
+                MediaTypes.APPLICATION_YAML));
+
+        OpenTelemetryConfig openTelemetry = OpenTelemetryConfig.create(config.get("telemetry"));
+        assertThat("OpenTelemetry with config disabled", openTelemetry.openTelemetry(), is(equalTo(OpenTelemetry.noop())));
+        assertThat("OpenTelemetry SDK with config disabled", openTelemetry.openTelemetrySdk(), is(notNullValue()));
+        assertThat("OpenTelemetry SDK propagators with config disabled",
+                   openTelemetry.openTelemetrySdk().getPropagators(),
+                   is(equalTo(ContextPropagators.noop())));
+
     }
 
     @Test


### PR DESCRIPTION
### Description
Resolves #12050 

### Release Note
____
Helidon no longer throws an exception about a required `OpenTelemetrySdk` setting when t`elemetry.enabled` is false.
____

## Summary

Forward-ports the 4.x fix for #11964.

- Allows OpenTelemetry configuration to build successfully when telemetry is disabled.
- Supplies an internal no-op SDK when needed while preserving explicitly configured OpenTelemetry instances.
- Adds regression coverage for `telemetry.enabled: false`.

## Testing

- OpenTelemetry configuration module tests
- Checkstyle and copyright validation
Documentation

No impact.

