### PR TITLE
Upgrade from Prometheus simpleclient to Java client 1.x

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -7333,7 +7333,7 @@ Fourth Party Dependencies
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 micrometer-registry-prometheus  VMware
 Apache 2.0
-Used by: [helidon-integrations-micrometer, helidon-integrations-micrometer-cdi, helidon-metrics-providers-micrometer]
+Used by: [helidon-metrics-providers-micrometer]
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 micrometer-registry-prometheus (io.micrometer:micrometer-registry-prometheus)
   Copyright 2017,2022 VMware, Inc.
@@ -8373,12 +8373,13 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-simpleclient  The Prometheus Authors
+Prometheus Java Client  The Prometheus Authors
 Apache 2.0
-Used by: [helidon-integrations-micrometer, helidon-integrations-micrometer-cdi, helidon-metrics-prometheus]
+Used by: [helidon-metrics-providers-micrometer]
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright: prometheus
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient
+Dependency: io.prometheus:prometheus-metrics-model
+Copyright: The Prometheus Authors
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-model
 License: Apache 2.0
 
  ./LICENSE
@@ -8402,9 +8403,9 @@ Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 -------------- Separator --------------
 
 
-Dependency: io.prometheus:simpleclient_tracer_common
+Dependency: io.prometheus:prometheus-metrics-exposition-textformats
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_common
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-exposition-textformats
 License: Apache 2.0
 
  ./LICENSE
@@ -8421,9 +8422,9 @@ Apache 2.0
 
 
 
-Dependency: io.prometheus:simpleclient_tracer_otel
+Dependency: io.prometheus:prometheus-metrics-tracer-common
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_otel
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-tracer-common
 License: Apache 2.0
 
  ./LICENSE
@@ -8440,9 +8441,10 @@ Apache 2.0
 
 
 
-Dependency: io.prometheus:simpleclient_tracer_otel_agent
+Dependency: io.prometheus:prometheus-metrics-core, io.prometheus:prometheus-metrics-config,
+            io.prometheus:prometheus-metrics-exposition-formats
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_otel_agent
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0
 License: Apache 2.0
 
  ./LICENSE
@@ -8460,7 +8462,6 @@ Apache 2.0
 
 
 
- === Entry created by OSCS on 2022-09-12T08:41:03.530
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 slf4j-api  QOS.ch

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -87,7 +87,7 @@
         <version.lib.opentelemetry>1.65.0</version.lib.opentelemetry>
         <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.13</version.lib.postgresql>
-        <version.lib.prometheus>0.16.0</version.lib.prometheus>
+        <version.lib.prometheus>1.7.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.4</version.lib.reactivestreams>
         <version.lib.slf4j>2.0.17</version.lib.slf4j>
         <version.lib.snakeyaml>2.6</version.lib.snakeyaml>
@@ -227,10 +227,20 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${version.lib.snakeyaml}</version>
             </dependency>
-            <!-- Webserver related -->
+            <!-- Prometheus related -->
             <dependency>
                 <groupId>io.prometheus</groupId>
-                <artifactId>simpleclient_tracer_common</artifactId>
+                <artifactId>prometheus-metrics-exposition-textformats</artifactId>
+                <version>${version.lib.prometheus}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>prometheus-metrics-model</artifactId>
+                <version>${version.lib.prometheus}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>prometheus-metrics-tracer-common</artifactId>
                 <version>${version.lib.prometheus}</version>
             </dependency>
             <dependency>
@@ -259,11 +269,6 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-prometheus</artifactId>
-                <version>${version.lib.micrometer-prometheus}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
                 <version>${version.lib.micrometer-prometheus}</version>
             </dependency>
             <dependency>

--- a/docs/config/io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md
+++ b/docs/config/io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md
@@ -1,0 +1,49 @@
+# io.<wbr>helidon.<wbr>metrics.<wbr>providers.<wbr>micrometer.<wbr>Prometheus<wbr>Naming<wbr>Convention<wbr>Config
+
+## Description
+
+Settings controlling Prometheus naming conventions
+
+## Configuration options
+
+
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>non-<wbr>letter-<wbr>prefix</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Prefix to add to metric names and tag keys which do not begin with a letter; configuring this setting enables legacy simpleclient-compatible normalization, with <code>m_</code> reproducing the naming from earlier Helidon releases, and preserves user-supplied reserved suffixes such as <code>_total</code>, <code>_created</code>, <code>_bucket</code>, and <code>_info</code>, whereas leaving it unset uses the new Prometheus client's normalization</td>
+</tr>
+<tr>
+<td>
+<code>timer-<wbr>suffix</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Suffix which identifies a timer name before Prometheus adds <code>_seconds</code></td>
+</tr>
+</tbody>
+</table>
+
+
+
+## Usages
+
+- <a href="io.helidon.metrics.providers.micrometer.PrometheusPublisher.md#naming-convention"><code>metrics.<wbr>publishers.<wbr>prometheus.<wbr>naming-<wbr>convention</code></a>
+- <a href="io.helidon.metrics.providers.micrometer.PrometheusPublisher.md#naming-convention"><code>server.<wbr>features.<wbr>observe.<wbr>observers.<wbr>metrics.<wbr>publishers.<wbr>prometheus.<wbr>naming-<wbr>convention</code></a>
+
+---
+
+See the [manifest](manifest.md) for all available types.

--- a/docs/config/io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md
+++ b/docs/config/io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md
@@ -23,7 +23,7 @@ Settings controlling Prometheus naming conventions
 <td>
 <code>String</code>
 </td>
-<td>Prefix to add to metric names and tag keys which do not begin with a letter; configuring this setting enables legacy simpleclient-compatible normalization, with <code>m_</code> reproducing the naming from earlier Helidon releases, and preserves user-supplied reserved suffixes such as <code>_total</code>, <code>_created</code>, <code>_bucket</code>, and <code>_info</code>, whereas leaving it unset uses the new Prometheus client's normalization</td>
+<td>Prefix to add to metric names and tag keys which do not begin with a letter; configuring this setting enables legacy simpleclient-compatible normalization, with <code>m_</code> reproducing the naming from earlier Helidon releases, and preserves user-supplied reserved suffixes such as <code>_total</code>, <code>_created</code>, <code>_bucket</code>, and <code>_info</code>, whereas leaving it unset uses the new Prometheus client's normalization; the prefix must be non-empty and match <code>[A-<wbr>Za-z][A-<wbr>Za-z0-<wbr>9_]*</code>, and constructing the publisher fails if the value is invalid</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
+++ b/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
@@ -26,7 +26,7 @@ Settings for a Micrometer Prometheus meter registry
 </td>
 <td>
 </td>
-<td>Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and the legacy <code>prometheus.histogramFlavor</code> property is not supported by the current Prometheus registry</td>
+<td>Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and the legacy <code>prometheus.histogramFlavor</code> property is accepted for compatibility but ignored with a warning</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
+++ b/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
@@ -26,7 +26,21 @@ Settings for a Micrometer Prometheus meter registry
 </td>
 <td>
 </td>
-<td>Property name prefix</td>
+<td>Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and the legacy <code>prometheus.histogramFlavor</code> property is not supported by the current Prometheus registry</td>
+</tr>
+<tr>
+<td>
+<a id="naming-convention"></a>
+<a href="io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md">
+<code>naming-<wbr>convention</code>
+</a>
+</td>
+<td>
+<code>Prometheus<wbr>Naming<wbr>Convention<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Prometheus naming convention settings</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
+++ b/docs/config/io.helidon.metrics.providers.micrometer.PrometheusPublisher.md
@@ -26,7 +26,7 @@ Settings for a Micrometer Prometheus meter registry
 </td>
 <td>
 </td>
-<td>Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and the legacy <code>prometheus.histogramFlavor</code> property is accepted for compatibility but ignored with a warning</td>
+<td>Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and the legacy <code>prometheus.<wbr>histogram<wbr>Flavor</code> property is accepted for compatibility but ignored with a warning</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/manifest.md
+++ b/docs/config/manifest.md
@@ -46,6 +46,7 @@ See the [root type](config_reference.md).
 - [io.<wbr>helidon.<wbr>metrics.<wbr>api.<wbr>Metrics<wbr>Config](io.helidon.metrics.api.MetricsConfig.md)
 - [io.<wbr>helidon.<wbr>metrics.<wbr>api.<wbr>Tag](io.helidon.metrics.api.Tag.md)
 - [io.<wbr>helidon.<wbr>metrics.<wbr>providers.<wbr>micrometer.<wbr>Otlp<wbr>Publisher](io.helidon.metrics.providers.micrometer.OtlpPublisher.md)
+- [io.<wbr>helidon.<wbr>metrics.<wbr>providers.<wbr>micrometer.<wbr>Prometheus<wbr>Naming<wbr>Convention<wbr>Config](io.helidon.metrics.providers.micrometer.PrometheusNamingConventionConfig.md)
 - [io.<wbr>helidon.<wbr>metrics.<wbr>providers.<wbr>micrometer.<wbr>Prometheus<wbr>Publisher](io.helidon.metrics.providers.micrometer.PrometheusPublisher.md)
 - [io.<wbr>helidon.<wbr>openapi.<wbr>Open<wbr>ApiFeature](io.helidon.openapi.OpenApiFeature.md)
 - [io.<wbr>helidon.<wbr>openapi.<wbr>v30.<wbr>Open<wbr>Api30Version](io.helidon.openapi.v30.OpenApi30Version.md)

--- a/docs/includes/tracing/common-callbacks.md
+++ b/docs/includes/tracing/common-callbacks.md
@@ -84,6 +84,7 @@ The following tables list specifically what operations the proxies permit.
 |--------------------------|--------------------------------------------------------------|-----|
 | `asParent(Span.Builder)` | Sets this context as the parent of a new span builder.       | ✓   |
 | `baggage()`              | Returns `Baggage` instance associated with the span context. | ✓   |
+| `sampled()`              | Reports whether the associated span is sampled.              | ✓   |
 | `spanId()`               | Returns the span ID.                                         | ✓   |
 | `traceId()`              | Returns the trace ID.                                        | ✓   |
 

--- a/docs/modules/metrics/exemplar.md
+++ b/docs/modules/metrics/exemplar.md
@@ -76,7 +76,8 @@ provider:
 
 Once you add the appropriate dependencies to your project, exemplar support runs
 automatically as part of the Helidon metrics implementation using Micrometer.
-You do not need to change your application or configuration.
+You do not need to change your application or configuration. Helidon supplies
+exemplars only from the current span when that span is sampled.
 
 ### Interpreting Exemplars
 

--- a/docs/modules/metrics/metrics.md
+++ b/docs/modules/metrics/metrics.md
@@ -694,6 +694,49 @@ The deprecated `metrics.rest-request-enabled` compatibility setting is also
 no longer supported in Helidon 27. Replace it with
 `metrics.rest-request.enabled`.
 
+Helidon 27 uses Prometheus Java Client 1.7.0 through Micrometer instead of the
+legacy Prometheus simpleclient integration. By default, metric and tag names use
+the new client's normalization. In particular, names which do not begin with a
+letter are normalized using the new client's rules, and reserved suffixes such
+as `_total`, `_created`, `_bucket`, and `_info` are removed from base names so
+the writer can add type-appropriate suffixes.
+
+To retain the Prometheus names emitted by earlier Helidon releases for counters,
+functional counters, gauges, timers, and distribution summaries, configure the
+legacy non-letter prefix:
+
+```yaml [application.yaml]
+metrics:
+  publishers:
+    prometheus:
+      naming-convention:
+        non-letter-prefix: "m_"
+```
+
+Setting `non-letter-prefix` selects legacy normalization as a whole, including
+preserving user-supplied reserved suffixes. The value must match
+`[A-Za-z][A-Za-z0-9_]*`; `m_` reproduces the earlier Helidon prefix, while
+another valid value uses the same legacy rules with that prefix. The
+`naming-convention.timer-suffix` setting remains available in both modes. The
+publisher's existing `prefix` setting controls Micrometer property lookup and
+does not prefix metric names.
+
+The former `metrics.prometheus.histogramFlavor` property is accepted so existing
+configuration continues to load, but the new integration ignores it and logs a
+warning.
+
+Code which accesses Prometheus-specific Helidon APIs or implements the exemplar
+SPI needs these type changes:
+
+- `PrometheusPublisher.prometheusRegistry()` now supplies
+  `io.micrometer.prometheusmetrics.PrometheusMeterRegistry` instead of
+  `io.micrometer.prometheus.PrometheusMeterRegistry`.
+- `SpanContextSupplierProvider.get()` now returns
+  `io.prometheus.metrics.tracer.common.SpanContext` instead of
+  `io.prometheus.client.exemplars.tracer.common.SpanContextSupplier`; the new
+  type reports trace ID, span ID, sampled state, and when the current span is
+  selected as an exemplar.
+
 ## Metrics Observer
 
 Helidon can make the registered meters and their current values available

--- a/etc/HELIDON_THIRD_PARTY_LICENSES.xml
+++ b/etc/HELIDON_THIRD_PARTY_LICENSES.xml
@@ -7435,12 +7435,10 @@ Fourth Party Dependencies
         <dependency>
             <id>149612</id>
             <name>micrometer-registry-prometheus</name>
-            <version>1.11.3</version>
+            <version>1.17.1</version>
             <licensor>VMware</licensor>
             <licenseName>Apache 2.0</licenseName>
             <consumers>
-                <consumer>helidon-integrations-micrometer</consumer>
-                <consumer>helidon-integrations-micrometer-cdi</consumer>
                 <consumer>helidon-metrics-providers-micrometer</consumer>
             </consumers>
             <attribution>micrometer-registry-prometheus (io.micrometer:micrometer-registry-prometheus)
@@ -8569,17 +8567,16 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         </dependency>
         <dependency>
             <id>149860</id>
-            <name>simpleclient</name>
-            <version>0.16.0</version>
+            <name>Prometheus Java Client</name>
+            <version>1.7.0</version>
             <licensor>The Prometheus Authors</licensor>
             <licenseName>Apache 2.0</licenseName>
             <consumers>
-                <consumer>helidon-integrations-micrometer</consumer>
-                <consumer>helidon-integrations-micrometer-cdi</consumer>
-                <consumer>helidon-metrics-prometheus</consumer>
+                <consumer>helidon-metrics-providers-micrometer</consumer>
             </consumers>
-            <attribution>Copyright: prometheus
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient
+            <attribution>Dependency: io.prometheus:prometheus-metrics-model
+Copyright: The Prometheus Authors
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-model
 License: Apache 2.0
 
  ./LICENSE
@@ -8603,9 +8600,9 @@ Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 -------------- Separator --------------
 
 
-Dependency: io.prometheus:simpleclient_tracer_common
+Dependency: io.prometheus:prometheus-metrics-exposition-textformats
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_common
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-exposition-textformats
 License: Apache 2.0
 
  ./LICENSE
@@ -8622,9 +8619,9 @@ Apache 2.0
 
 
 
-Dependency: io.prometheus:simpleclient_tracer_otel
+Dependency: io.prometheus:prometheus-metrics-tracer-common
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_otel
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0/prometheus-metrics-tracer-common
 License: Apache 2.0
 
  ./LICENSE
@@ -8641,9 +8638,10 @@ Apache 2.0
 
 
 
-Dependency: io.prometheus:simpleclient_tracer_otel_agent
+Dependency: io.prometheus:prometheus-metrics-core, io.prometheus:prometheus-metrics-config,
+            io.prometheus:prometheus-metrics-exposition-formats
 Copyright: The Prometheus Authors
-=== Source URL: https://github.com/prometheus/client_java/tree/parent-0.16.0/simpleclient_tracer/simpleclient_tracer_otel_agent
+=== Source URL: https://github.com/prometheus/client_java/tree/v1.7.0
 License: Apache 2.0
 
  ./LICENSE
@@ -8661,7 +8659,6 @@ Apache 2.0
 
 
 
- === Entry created by OSCS on 2022-09-12T08:41:03.530
 </attribution>
         </dependency>
         <dependency>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -91,13 +91,6 @@
  -->
 <suppress>
    <notes><![CDATA[
-   file name: micrometer-registry-prometheus-simpleclient-1.13.4.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus-simpleclient@.*$</packageUrl>
-   <cve>CVE-2019-3826</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
    file name: prometheus-metrics-core-1.2.1.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/io\.prometheus/prometheus-metrics-(.*)@.*$</packageUrl>
@@ -107,13 +100,6 @@
 <!-- False Positive.
      This CVE is against prometheus server (not client libraries).
  -->
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
-    <cve>CVE-2026-42154</cve>
-</suppress>
 <suppress>
     <notes><![CDATA[
     file name: prometheus-metrics-core-1.3.10.jar
@@ -127,52 +113,6 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus.*@.*$</packageUrl>
     <cve>CVE-2026-42154</cve>
-</suppress>
-
-<!-- False Positives.
-     These are confusing prometheus simple client tracer for otel with OTel dotnet, Go, python
--->
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2026-40894</cve>
-</suppress>
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2026-39882</cve>
-</suppress>
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2026-41078</cve>
-</suppress>
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2023-47108</cve>
-</suppress>
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2023-45142</cve>
-</suppress>
-<suppress>
-    <notes><![CDATA[
-    file name: simpleclient_tracer_otel-0.16.0.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel.*@.*$</packageUrl>
-    <cve>CVE-2023-43810</cve>
 </suppress>
 
 <!-- False Positives.

--- a/etc/javadoc/prometheus/element-list
+++ b/etc/javadoc/prometheus/element-list
@@ -1,2 +1,4 @@
-io.prometheus.client
-io.prometheus.client.exemplars
+io.prometheus.metrics.expositionformats
+io.prometheus.metrics.model.registry
+io.prometheus.metrics.model.snapshots
+io.prometheus.metrics.tracer.common

--- a/metrics/providers/micrometer/pom.xml
+++ b/metrics/providers/micrometer/pom.xml
@@ -53,10 +53,6 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-otlp</artifactId>
         </dependency>
         <dependency>
@@ -94,7 +90,15 @@
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_tracer_common</artifactId>
+            <artifactId>prometheus-metrics-exposition-textformats</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-tracer-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
@@ -125,7 +125,7 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
     protected LongTaskTimer newLongTaskTimer(Meter.Id id,
                                              DistributionStatisticConfig distributionStatisticConfig) {
         return register(id,
-                        distributionNames(id, distributionStatisticConfig),
+                        longTaskTimerNames(id, distributionStatisticConfig),
                         () -> super.newLongTaskTimer(id, distributionStatisticConfig));
     }
 
@@ -170,6 +170,17 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
                       conventionName + CREATED_SUFFIX);
     }
 
+    private Set<String> longTaskTimerNames(Meter.Id id,
+                                           DistributionStatisticConfig distributionStatisticConfig) {
+        Set<String> result = new LinkedHashSet<>(distributionNames(id, distributionStatisticConfig));
+        if (distributionStatisticConfig.isPublishingHistogram()) {
+            String conventionName = expositionName(id);
+            result.add(conventionName + "_gcount");
+            result.add(conventionName + "_gsum");
+        }
+        return Set.copyOf(result);
+    }
+
     private String expositionName(Meter.Id id) {
         return PrometheusNameSupport.expositionName(id, config().namingConvention());
     }
@@ -202,7 +213,7 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
                                                                + "' is produced by both " + claim.owner + " and " + owner);
                 }
             }
-            names.forEach(name -> claims.compute(name, (ignored, claim) -> claim == null
+            names.forEach(name -> claims.compute(name, (_, claim) -> claim == null
                     ? new Claim(owner)
                     : claim.increment()));
             return new Reservation(names);
@@ -233,7 +244,7 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
     }
 
     private void releaseLocked(Reservation reservation) {
-        reservation.names.forEach(name -> claims.computeIfPresent(name, (ignored, claim) -> claim.decrement()));
+        reservation.names.forEach(name -> claims.computeIfPresent(name, (_, claim) -> claim.decrement()));
     }
 
     private static final class Claim {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.tracer.common.SpanContext;
+
+/**
+ * Prometheus meter registry which detects collisions involving generated Prometheus sample names.
+ *
+ * <p>The Prometheus client validates collector names at registration, but the Micrometer collector used by the
+ * Micrometer Prometheus registry does not describe the secondary names it generates. This registry accounts for those
+ * names for the meter types Helidon creates.</p>
+ */
+class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry {
+
+    private static final String CREATED_SUFFIX = "_created";
+    private static final String TOTAL_SUFFIX = "_total";
+
+    private final Lock reservationLock = new ReentrantLock();
+    private final Map<String, Claim> claims = new HashMap<>();
+    private final Map<Meter.Id, Reservation> reservations = new HashMap<>();
+
+    CollisionDetectingPrometheusMeterRegistry(PrometheusConfig config) {
+        super(config);
+        config().onMeterRemoved(meter -> release(meter.getId()));
+    }
+
+    CollisionDetectingPrometheusMeterRegistry(PrometheusConfig config,
+                                               PrometheusRegistry registry,
+                                               Clock clock,
+                                               SpanContext spanContext) {
+        super(config, registry, clock, spanContext);
+        config().onMeterRemoved(meter -> release(meter.getId()));
+    }
+
+    @Override
+    public Counter newCounter(Meter.Id id) {
+        return register(id, counterNames(id), () -> super.newCounter(id));
+    }
+
+    @Override
+    public DistributionSummary newDistributionSummary(Meter.Id id,
+                                                      DistributionStatisticConfig distributionStatisticConfig,
+                                                      double scale) {
+        return register(id,
+                        distributionNames(id, distributionStatisticConfig),
+                        () -> super.newDistributionSummary(id, distributionStatisticConfig, scale));
+    }
+
+    @Override
+    protected Timer newTimer(Meter.Id id,
+                             DistributionStatisticConfig distributionStatisticConfig,
+                             PauseDetector pauseDetector) {
+        return register(id,
+                        distributionNames(id, distributionStatisticConfig),
+                        () -> super.newTimer(id, distributionStatisticConfig, pauseDetector));
+    }
+
+    @Override
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
+        return register(id, gaugeNames(id), () -> super.newGauge(id, obj, valueFunction));
+    }
+
+    @Override
+    protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
+        return register(id, counterNames(id), () -> super.newFunctionCounter(id, obj, countFunction));
+    }
+
+    private static String owner(Meter.Id id) {
+        return "'" + LegacyPrometheusMeterFilter.originalGaugeName(id.getName()) + "' (type=" + id.getType()
+                + ", baseUnit=" + Objects.toString(id.getBaseUnit(), "<none>") + ")";
+    }
+
+    private Set<String> counterNames(Meter.Id id) {
+        String conventionName = getConventionName(id);
+        String counterName = conventionName.endsWith(TOTAL_SUFFIX) ? conventionName : conventionName + TOTAL_SUFFIX;
+        String baseName = counterName.substring(0, counterName.length() - TOTAL_SUFFIX.length());
+        return Set.of(baseName, counterName, baseName + CREATED_SUFFIX);
+    }
+
+    private Set<String> gaugeNames(Meter.Id id) {
+        String conventionName = getConventionName(id);
+        return id.getName().endsWith(".info")
+                ? Set.of(conventionName, conventionName + "_info")
+                : Set.of(conventionName);
+    }
+
+    private Set<String> distributionNames(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
+        String conventionName = getConventionName(id);
+        Set<String> result = new LinkedHashSet<>();
+        result.add(conventionName);
+        result.add(conventionName + "_count");
+        result.add(conventionName + "_sum");
+        result.add(conventionName + CREATED_SUFFIX);
+        if (distributionStatisticConfig.isPublishingHistogram()) {
+            result.add(conventionName + "_bucket");
+        }
+        result.add(conventionName + "_max");
+        return Set.copyOf(result);
+    }
+
+    private <M extends Meter> M register(Meter.Id id, Set<String> names, Supplier<M> registration) {
+        Reservation reservation = reserve(id, names);
+        try {
+            M meter = registration.get();
+            reservationLock.lock();
+            try {
+                reservations.put(id, reservation);
+            } finally {
+                reservationLock.unlock();
+            }
+            return meter;
+        } catch (RuntimeException | Error e) {
+            release(reservation);
+            throw e;
+        }
+    }
+
+    private Reservation reserve(Meter.Id id, Set<String> names) {
+        String owner = owner(id);
+        reservationLock.lock();
+        try {
+            for (String name : names) {
+                Claim claim = claims.get(name);
+                if (claim != null && !claim.owner.equals(owner)) {
+                    throw new IllegalArgumentException("Prometheus metric name collision: '" + name
+                                                               + "' is produced by both " + claim.owner + " and " + owner);
+                }
+            }
+            names.forEach(name -> claims.compute(name, (ignored, claim) -> claim == null
+                    ? new Claim(owner)
+                    : claim.increment()));
+            return new Reservation(names);
+        } finally {
+            reservationLock.unlock();
+        }
+    }
+
+    private void release(Meter.Id id) {
+        reservationLock.lock();
+        try {
+            Reservation reservation = reservations.remove(id);
+            if (reservation != null) {
+                releaseLocked(reservation);
+            }
+        } finally {
+            reservationLock.unlock();
+        }
+    }
+
+    private void release(Reservation reservation) {
+        reservationLock.lock();
+        try {
+            releaseLocked(reservation);
+        } finally {
+            reservationLock.unlock();
+        }
+    }
+
+    private void releaseLocked(Reservation reservation) {
+        reservation.names.forEach(name -> claims.computeIfPresent(name, (ignored, claim) -> claim.decrement()));
+    }
+
+    private static final class Claim {
+        private final String owner;
+        private int count = 1;
+
+        private Claim(String owner) {
+            this.owner = owner;
+        }
+
+        private Claim increment() {
+            count++;
+            return this;
+        }
+
+        private Claim decrement() {
+            return --count == 0 ? null : this;
+        }
+    }
+
+    private static final class Reservation {
+        private final Set<String> names;
+
+        private Reservation(Set<String> names) {
+            this.names = names;
+        }
+    }
+}

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/CollisionDetectingPrometheusMeterRegistry.java
@@ -21,16 +21,20 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -102,27 +106,50 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
         return register(id, counterNames(id), () -> super.newFunctionCounter(id, obj, countFunction));
     }
 
+    @Override
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id,
+                                                 T obj,
+                                                 ToLongFunction<T> countFunction,
+                                                 ToDoubleFunction<T> totalTimeFunction,
+                                                 TimeUnit totalTimeFunctionUnit) {
+        return register(id,
+                        functionTimerNames(id),
+                        () -> super.newFunctionTimer(id,
+                                                     obj,
+                                                     countFunction,
+                                                     totalTimeFunction,
+                                                     totalTimeFunctionUnit));
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id,
+                                             DistributionStatisticConfig distributionStatisticConfig) {
+        return register(id,
+                        distributionNames(id, distributionStatisticConfig),
+                        () -> super.newLongTaskTimer(id, distributionStatisticConfig));
+    }
+
     private static String owner(Meter.Id id) {
         return "'" + LegacyPrometheusMeterFilter.originalGaugeName(id.getName()) + "' (type=" + id.getType()
                 + ", baseUnit=" + Objects.toString(id.getBaseUnit(), "<none>") + ")";
     }
 
     private Set<String> counterNames(Meter.Id id) {
-        String conventionName = getConventionName(id);
+        String conventionName = expositionName(id);
         String counterName = conventionName.endsWith(TOTAL_SUFFIX) ? conventionName : conventionName + TOTAL_SUFFIX;
         String baseName = counterName.substring(0, counterName.length() - TOTAL_SUFFIX.length());
         return Set.of(baseName, counterName, baseName + CREATED_SUFFIX);
     }
 
     private Set<String> gaugeNames(Meter.Id id) {
-        String conventionName = getConventionName(id);
+        String conventionName = expositionName(id);
         return id.getName().endsWith(".info")
                 ? Set.of(conventionName, conventionName + "_info")
                 : Set.of(conventionName);
     }
 
     private Set<String> distributionNames(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
-        String conventionName = getConventionName(id);
+        String conventionName = expositionName(id);
         Set<String> result = new LinkedHashSet<>();
         result.add(conventionName);
         result.add(conventionName + "_count");
@@ -133,6 +160,18 @@ class CollisionDetectingPrometheusMeterRegistry extends PrometheusMeterRegistry 
         }
         result.add(conventionName + "_max");
         return Set.copyOf(result);
+    }
+
+    private Set<String> functionTimerNames(Meter.Id id) {
+        String conventionName = expositionName(id);
+        return Set.of(conventionName,
+                      conventionName + "_count",
+                      conventionName + "_sum",
+                      conventionName + CREATED_SUFFIX);
+    }
+
+    private String expositionName(Meter.Id id) {
+        return PrometheusNameSupport.expositionName(id, config().namingConvention());
     }
 
     private <M extends Meter> M register(Meter.Id id, Set<String> names, Supplier<M> registration) {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusMeterFilter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusMeterFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+/**
+ * Prevents the new Prometheus registry from treating a legacy gauge name ending in {@code .info} as an info metric.
+ * The marker also preserves the original gauge name through Micrometer's pre-filter ID mapping so the Prometheus
+ * registry can detect distinct names which normalize to the same name.
+ */
+class LegacyPrometheusMeterFilter implements MeterFilter {
+    private static final String GAUGE_MARKER = "\uE000helidon-legacy-gauge:";
+
+    @Override
+    public Meter.Id map(Meter.Id id) {
+        if (id.getType() != Meter.Type.GAUGE) {
+            return id;
+        }
+        return id.withName(GAUGE_MARKER + id.getName() + GAUGE_MARKER);
+    }
+
+    static String originalGaugeName(String name) {
+        return name.startsWith(GAUGE_MARKER) && name.endsWith(GAUGE_MARKER)
+                ? name.substring(GAUGE_MARKER.length(), name.length() - GAUGE_MARKER.length())
+                : name;
+    }
+}

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusMeterFilter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusMeterFilter.java
@@ -27,17 +27,17 @@ import io.micrometer.core.instrument.config.MeterFilter;
 class LegacyPrometheusMeterFilter implements MeterFilter {
     private static final String GAUGE_MARKER = "\uE000helidon-legacy-gauge:";
 
+    static String originalGaugeName(String name) {
+        return name.startsWith(GAUGE_MARKER) && name.endsWith(GAUGE_MARKER)
+                ? name.substring(GAUGE_MARKER.length(), name.length() - GAUGE_MARKER.length())
+                : name;
+    }
+
     @Override
     public Meter.Id map(Meter.Id id) {
         if (id.getType() != Meter.Type.GAUGE) {
             return id;
         }
         return id.withName(GAUGE_MARKER + id.getName() + GAUGE_MARKER);
-    }
-
-    static String originalGaugeName(String name) {
-        return name.startsWith(GAUGE_MARKER) && name.endsWith(GAUGE_MARKER)
-                ? name.substring(GAUGE_MARKER.length(), name.length() - GAUGE_MARKER.length())
-                : name;
     }
 }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusNamingConvention.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusNamingConvention.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+
+/**
+ * Prometheus naming convention compatible with the legacy simpleclient-based Micrometer registry.
+ */
+class LegacyPrometheusNamingConvention implements NamingConvention {
+    private static final Pattern NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_:]");
+    private static final Pattern TAG_KEY_CHARS = Pattern.compile("[^a-zA-Z0-9_]");
+    private static final Pattern VALID_PREFIX = Pattern.compile("[A-Za-z][A-Za-z0-9_]*");
+
+    private final String timerSuffix;
+    private final String nonLetterPrefix;
+
+    LegacyPrometheusNamingConvention(String timerSuffix, String nonLetterPrefix) {
+        this.timerSuffix = Objects.requireNonNull(timerSuffix);
+        this.nonLetterPrefix = validatePrefix(nonLetterPrefix);
+    }
+
+    @Override
+    public String name(String name, Meter.Type type, String baseUnit) {
+        if (type == Meter.Type.GAUGE) {
+            name = LegacyPrometheusMeterFilter.originalGaugeName(name);
+        }
+        String conventionName = NamingConvention.snakeCase.name(name, type, baseUnit);
+
+        switch (type) {
+        case COUNTER, DISTRIBUTION_SUMMARY, GAUGE -> {
+            if (baseUnit != null && !conventionName.endsWith("_" + baseUnit)) {
+                conventionName += "_" + baseUnit;
+            }
+        }
+        default -> {
+        }
+        }
+
+        conventionName = switch (type) {
+            case COUNTER -> conventionName.endsWith("_total") ? conventionName : conventionName + "_total";
+            case TIMER -> timerName(conventionName);
+            default -> conventionName;
+        };
+
+        return addPrefixIfNeeded(NAME_CHARS.matcher(conventionName).replaceAll("_"));
+    }
+
+    @Override
+    public String tagKey(String key) {
+        String conventionKey = NamingConvention.snakeCase.tagKey(key);
+        return addPrefixIfNeeded(TAG_KEY_CHARS.matcher(conventionKey).replaceAll("_"));
+    }
+
+    static String validatePrefix(String prefix) {
+        Objects.requireNonNull(prefix);
+        if (!VALID_PREFIX.matcher(prefix).matches()) {
+            throw new IllegalArgumentException("Prometheus non-letter prefix must match " + VALID_PREFIX.pattern()
+                                                       + ", but was: " + prefix);
+        }
+        return prefix;
+    }
+
+    private String addPrefixIfNeeded(String value) {
+        return Character.isLetter(value.charAt(0)) ? value : nonLetterPrefix + value;
+    }
+
+    private String timerName(String conventionName) {
+        if (!timerSuffix.isEmpty() && conventionName.endsWith(timerSuffix)) {
+            return conventionName + "_seconds";
+        }
+        return conventionName.endsWith("_seconds") ? conventionName : conventionName + timerSuffix + "_seconds";
+    }
+}

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusNamingConvention.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/LegacyPrometheusNamingConvention.java
@@ -38,6 +38,15 @@ class LegacyPrometheusNamingConvention implements NamingConvention {
         this.nonLetterPrefix = validatePrefix(nonLetterPrefix);
     }
 
+    static String validatePrefix(String prefix) {
+        Objects.requireNonNull(prefix);
+        if (!VALID_PREFIX.matcher(prefix).matches()) {
+            throw new IllegalArgumentException("Prometheus non-letter prefix must match " + VALID_PREFIX.pattern()
+                                                       + ", but was: " + prefix);
+        }
+        return prefix;
+    }
+
     @Override
     public String name(String name, Meter.Type type, String baseUnit) {
         if (type == Meter.Type.GAUGE) {
@@ -68,15 +77,6 @@ class LegacyPrometheusNamingConvention implements NamingConvention {
     public String tagKey(String key) {
         String conventionKey = NamingConvention.snakeCase.tagKey(key);
         return addPrefixIfNeeded(TAG_KEY_CHARS.matcher(conventionKey).replaceAll("_"));
-    }
-
-    static String validatePrefix(String prefix) {
-        Objects.requireNonNull(prefix);
-        if (!VALID_PREFIX.matcher(prefix).matches()) {
-            throw new IllegalArgumentException("Prometheus non-letter prefix must match " + VALID_PREFIX.pattern()
-                                                       + ", but was: " + prefix);
-        }
-        return prefix;
     }
 
     private String addPrefixIfNeeded(String value) {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerMetricsFactory.java
@@ -47,10 +47,6 @@ import io.helidon.metrics.spi.MeterBuilderCustomizer;
 import io.helidon.metrics.spi.MeterRegistryLifeCycleListener;
 import io.helidon.metrics.spi.MetersProvider;
 
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.exemplars.DefaultExemplarSampler;
-
 /**
  * Implementation of the neutral Helidon metrics factory based on Micrometer.
  */
@@ -364,12 +360,10 @@ class MicrometerMetricsFactory implements MetricsFactory {
             the list of publishers in the build config object is empty. To see
              */
             if (!metricsConfig.publishersConfigured()) {
-                enabledMicrometerPublishers.add(spanContextSupplierProvider instanceof NoOpSpanContextSupplierProvider
-                        ? new PrometheusMeterRegistry(key -> metricsConfig.lookupConfig(key).orElse(null))
-                        : new PrometheusMeterRegistry(key -> metricsConfig.lookupConfig(key).orElse(null),
-                                                      new CollectorRegistry(),
-                                                      io.micrometer.core.instrument.Clock.SYSTEM,
-                                                      new DefaultExemplarSampler(spanContextSupplierProvider.get())));
+                enabledMicrometerPublishers.add(PrometheusPublisher.create()
+                                                        .prometheusRegistry()
+                                                        .apply(key -> metricsConfig.lookupConfig(key).orElse(null),
+                                                               spanContextSupplierProvider));
             }
         } catch (RuntimeException | Error e) {
             enabledMicrometerPublishers.forEach(registry -> {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -15,13 +15,11 @@
  */
 package io.helidon.metrics.providers.micrometer;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,9 +42,20 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.prometheus.client.Collector;
-import io.prometheus.client.exporter.common.TextFormat;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.prometheus.metrics.expositionformats.ExpositionFormatWriter;
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.StateSetSnapshot;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+import io.prometheus.metrics.model.snapshots.UnknownSnapshot;
 
 /**
  * Retrieves and prepares meter output from the specified meter registry according to the formats supported by the Prometheus
@@ -54,8 +63,8 @@ import io.prometheus.client.exporter.common.TextFormat;
  * <p>
  * Because the Prometheus exposition format is flat, and because some meter types have multiple values, the meter names
  * in the output repeat the actual meter name with suffixes to indicate the specific quantities (e.g.,
- * count, total, max) each reported value conveys. Further, meter names in the output might need the prefix
- * "m_" if the actual meter name starts with a digit or underscore and underscores replace special characters.
+ * count, total, max) each reported value conveys. The active Prometheus naming convention controls how meter and tag names
+ * are normalized.
  * </p>
  */
 public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
@@ -63,9 +72,15 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
      * Mapping from supported media types to the corresponding Prometheus registry content types.
      */
     public static final Map<MediaType, String> MEDIA_TYPE_TO_FORMAT = Map.of(
-            MediaTypes.TEXT_PLAIN, TextFormat.CONTENT_TYPE_004,
-            MediaTypes.APPLICATION_OPENMETRICS_TEXT, TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+            MediaTypes.TEXT_PLAIN, PrometheusTextFormatWriter.CONTENT_TYPE,
+            MediaTypes.APPLICATION_OPENMETRICS_TEXT, OpenMetricsTextFormatWriter.CONTENT_TYPE);
 
+    private static final Map<MediaType, ExpositionFormatWriter> MEDIA_TYPE_TO_WRITER = Map.of(
+            MediaTypes.TEXT_PLAIN, PrometheusTextFormatWriter.create(),
+            MediaTypes.APPLICATION_OPENMETRICS_TEXT, OpenMetricsTextFormatWriter.builder()
+                    .setCreatedTimestampsEnabled(false)
+                    .setExemplarsOnAllMetricTypesEnabled(true)
+                    .build());
     private static final Pattern SPECIAL_CHARACTERS_MAPPED_TO_UNDERSCORE_PATTERN = Pattern.compile("[-+.!?@#$%^&*`'\\s]+");
     private static final Pattern NON_DIGIT_OR_UNDERSCORE_PREFIX_PATTERN = Pattern.compile("^[0-9_]+.*");
     private static final Pattern NON_IDENTIFIER_PATTERN = Pattern.compile("[^A-Za-z0-9_:]");
@@ -117,25 +132,11 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         return result;
     }
 
-    /**
-     * Returns the Prometheus-format meter name suffixes for the given meter type.
-     *
-     * @param meterType {@link io.micrometer.core.instrument.Meter.Type} of interest
-     * @return suffixes used in reporting the corresponding meter's value(s)
-     */
-    static Set<String> meterNameSuffixes(Meter.Type meterType) {
-        return switch (meterType) {
-            case COUNTER -> Set.of("_total");
-            case DISTRIBUTION_SUMMARY, LONG_TASK_TIMER, TIMER -> Set.of("_count", "_sum", "_max", "_bucket");
-            case GAUGE, OTHER -> Set.of();
-        };
-    }
-
     static Optional<PrometheusMeterRegistry> prometheusMeterRegistry(MeterRegistry meterRegistry) {
         io.micrometer.core.instrument.MeterRegistry mMeterRegistry;
         try {
             mMeterRegistry = meterRegistry.unwrap(io.micrometer.core.instrument.MeterRegistry.class);
-        } catch (ClassCastException ignored) {
+        } catch (ClassCastException _) {
             return Optional.empty();
         }
         if (mMeterRegistry instanceof CompositeMeterRegistry compositeMeterRegistry) {
@@ -182,27 +183,16 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
     }
 
     /**
-     * Prepares a set containing the names of meters from the specified Prometheus meter registry which match
+     * Prepares a set containing the names of metric families from the specified Prometheus meter registry which match
      * the specified meter name selections.
      * <p>
-     * For meters with multiple values, the Prometheus registry essentially creates and actually displays in its output
-     * additional or "child" meters. A child meter's name is the parent's name plus a suffix consisting
-     * of the child meter's units (if any) plus the child name. For example, the timer {@code myDelay}  has child meters
-     * {@code myDelay_seconds_count}, {@code myDelay_seconds_sum}, and {@code myDelay_seconds_max}. (The output contains
-     * repetitions of the parent meter's name for each quantile, but that does not affect the meter names we need to ask
-     * the Prometheus meter registry to retrieve for us when we scrape.)
-     * </p>
-     * <p>
-     * We interpret any name selection passed to this method as specifying a parent name. We can ask the Prometheus meter
-     * registry to select specific meters by meter name when we scrape, but we need to pass it an expanded name selection that
-     * includes the relevant child meter names as well as the parent name. One way to choose those is first to collect the
-     * names from the Prometheus meter registry itself and derive the names to have the meter registry select by from those
-     * matching meters, their units, etc.
+     * The new Prometheus registry selects metric families, not individual emitted samples. Timers and distribution summaries
+     * use a base family for count, sum, buckets, and quantiles and a separate family for the maximum value.
      * </p>
      *
      * @param prometheusMeterRegistry Prometheus meter registry to query
      * @param names           meter names to select
-     * @return set of matching meter names (with units and suffixes as needed) to match the names as stored in the meter registry
+     * @return names of matching metric families as stored in the Prometheus registry
      */
     Set<String> meterNamesOfInterest(PrometheusMeterRegistry prometheusMeterRegistry,
                                      Set<String> names) {
@@ -210,31 +200,19 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         Set<String> result = new HashSet<>();
 
         for (Meter meter : prometheusMeterRegistry.getMeters()) {
-            String meterName = meter.getId().getName();
+            Meter.Id meterId = meter.getId();
+            String meterName = LegacyPrometheusMeterFilter.originalGaugeName(meterId.getName());
             if (!names.isEmpty() && !names.contains(meterName)) {
                 continue;
             }
-            Set<String> allUnitsForMeterName = new HashSet<>();
-            allUnitsForMeterName.add("");
-            Set<String> allSuffixesForMeterName = new HashSet<>();
-            allSuffixesForMeterName.add("");
 
-            prometheusMeterRegistry.find(meterName)
-                    .meters()
-                    .forEach(m -> {
-                        Meter.Id meterId = m.getId();
-                        String normalizedUnit = normalizeUnit(meterId.getBaseUnit());
-                        if (!normalizedUnit.isBlank()) {
-                            allUnitsForMeterName.add("_" + normalizedUnit);
-                        }
-                        allSuffixesForMeterName.addAll(meterNameSuffixes(meterId.getType()));
-                    });
-
-            String normalizedMeterName = normalizeNameToPrometheus(meterName);
-
-            allUnitsForMeterName
-                    .forEach(units -> allSuffixesForMeterName
-                            .forEach(suffix -> result.add(normalizedMeterName + units + suffix)));
+            String conventionName = prometheusMeterRegistry.config()
+                    .namingConvention()
+                    .name(meterId.getName(), meterId.getType(), meterId.getBaseUnit());
+            result.add(conventionName);
+            if (meterId.getType() == Meter.Type.TIMER || meterId.getType() == Meter.Type.DISTRIBUTION_SUMMARY) {
+                result.add(conventionName + "_max");
+            }
         }
         return result;
     }
@@ -254,21 +232,6 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         helpAndType.setLength(0);
         metricData.setLength(0);
         return result.toString();
-    }
-
-    private static String normalizeUnit(String unit) {
-        return unit == null ? "" : unit;
-    }
-
-    private static Set<String> commonLabelNames(List<Collector.MetricFamilySamples.Sample> samples) {
-        if (samples.isEmpty()) {
-            return Set.of();
-        }
-        Set<String> result = new HashSet<>(samples.getFirst().labelNames);
-        samples.stream()
-                .skip(1)
-                .forEach(sample -> result.retainAll(sample.labelNames));
-        return result;
     }
 
     private static Map<String, Set<String>> meterTagNamesByFamily(PrometheusMeterRegistry prometheusMeterRegistry) {
@@ -291,11 +254,58 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         return result;
     }
 
+    private static MetricSnapshot withDataPoints(MetricSnapshot snapshot,
+                                                 List<? extends DataPointSnapshot> dataPoints) {
+        if (snapshot instanceof CounterSnapshot counterSnapshot) {
+            return new CounterSnapshot(counterSnapshot.getMetadata(),
+                                       dataPoints.stream()
+                                               .map(CounterSnapshot.CounterDataPointSnapshot.class::cast)
+                                               .toList());
+        }
+        if (snapshot instanceof GaugeSnapshot gaugeSnapshot) {
+            return new GaugeSnapshot(gaugeSnapshot.getMetadata(),
+                                     dataPoints.stream()
+                                             .map(GaugeSnapshot.GaugeDataPointSnapshot.class::cast)
+                                             .toList());
+        }
+        if (snapshot instanceof HistogramSnapshot histogramSnapshot) {
+            return new HistogramSnapshot(histogramSnapshot.isGaugeHistogram(),
+                                         histogramSnapshot.getMetadata(),
+                                         dataPoints.stream()
+                                                 .map(HistogramSnapshot.HistogramDataPointSnapshot.class::cast)
+                                                 .toList());
+        }
+        if (snapshot instanceof SummarySnapshot summarySnapshot) {
+            return new SummarySnapshot(summarySnapshot.getMetadata(),
+                                       dataPoints.stream()
+                                               .map(SummarySnapshot.SummaryDataPointSnapshot.class::cast)
+                                               .toList());
+        }
+        if (snapshot instanceof InfoSnapshot infoSnapshot) {
+            return new InfoSnapshot(infoSnapshot.getMetadata(),
+                                    dataPoints.stream()
+                                            .map(InfoSnapshot.InfoDataPointSnapshot.class::cast)
+                                            .toList());
+        }
+        if (snapshot instanceof StateSetSnapshot stateSetSnapshot) {
+            return new StateSetSnapshot(stateSetSnapshot.getMetadata(),
+                                        dataPoints.stream()
+                                                .map(StateSetSnapshot.StateSetDataPointSnapshot.class::cast)
+                                                .toList());
+        }
+        if (snapshot instanceof UnknownSnapshot unknownSnapshot) {
+            return new UnknownSnapshot(unknownSnapshot.getMetadata(),
+                                       dataPoints.stream()
+                                               .map(UnknownSnapshot.UnknownDataPointSnapshot.class::cast)
+                                               .toList());
+        }
+        throw new IllegalStateException("Unsupported Prometheus metric snapshot type: " + snapshot.getClass().getName());
+    }
+
     private String scrapeSelected(PrometheusMeterRegistry prometheusMeterRegistry, Set<String> meterNamesOfInterest) {
-        Enumeration<Collector.MetricFamilySamples> metricFamilySamples = meterNamesOfInterest == null
-                ? prometheusMeterRegistry.getPrometheusRegistry().metricFamilySamples()
-                : prometheusMeterRegistry.getPrometheusRegistry().filteredMetricFamilySamples(meterNamesOfInterest);
-        List<Collector.MetricFamilySamples> matchingFamilies = new ArrayList<>();
+        MetricSnapshots snapshots = meterNamesOfInterest == null
+                ? prometheusMeterRegistry.getPrometheusRegistry().scrape()
+                : prometheusMeterRegistry.getPrometheusRegistry().scrape(meterNamesOfInterest::contains);
         var namingConvention = prometheusMeterRegistry.config().namingConvention();
         boolean selectsGeneratedLabel = tagSelection.keySet().stream()
                 .map(namingConvention::tagKey)
@@ -303,48 +313,46 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         Map<String, Set<String>> meterTagNamesByFamily = selectsGeneratedLabel
                 ? meterTagNamesByFamily(prometheusMeterRegistry)
                 : Map.of();
+        MetricSnapshots.Builder matchingSnapshotsBuilder = MetricSnapshots.builder();
 
-        while (metricFamilySamples.hasMoreElements()) {
-            Collector.MetricFamilySamples family = metricFamilySamples.nextElement();
+        for (MetricSnapshot snapshot : snapshots) {
             Set<String> meterTagNames = selectsGeneratedLabel
-                    ? meterTagNamesByFamily.getOrDefault(family.name, Set.of())
-                    : commonLabelNames(family.samples);
-            List<Collector.MetricFamilySamples.Sample> matchingSamples = family.samples.stream()
-                    .filter(sample -> matchesTagSelection(prometheusMeterRegistry, meterTagNames, sample))
+                    ? meterTagNamesByFamily.getOrDefault(snapshot.getMetadata().getPrometheusName(), Set.of())
+                    : Set.of();
+            List<? extends DataPointSnapshot> matchingDataPoints = snapshot.getDataPoints().stream()
+                    .filter(dataPoint -> matchesTagSelection(prometheusMeterRegistry,
+                                                             meterTagNames,
+                                                             dataPoint))
                     .toList();
-            if (!matchingSamples.isEmpty()) {
-                matchingFamilies.add(new Collector.MetricFamilySamples(family.name,
-                                                                        family.unit,
-                                                                        family.type,
-                                                                        family.help,
-                                                                        matchingSamples));
+            if (!matchingDataPoints.isEmpty()) {
+                matchingSnapshotsBuilder.metricSnapshot(withDataPoints(snapshot, matchingDataPoints));
             }
         }
-        if (matchingFamilies.isEmpty()) {
+
+        MetricSnapshots matchingSnapshots = matchingSnapshotsBuilder.build();
+        if (matchingSnapshots.size() == 0) {
             return "";
         }
 
-        StringWriter result = new StringWriter();
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
         try {
-            TextFormat.writeFormat(MEDIA_TYPE_TO_FORMAT.get(resultMediaType),
-                                   result,
-                                   Collections.enumeration(matchingFamilies));
+            MEDIA_TYPE_TO_WRITER.get(resultMediaType).write(result, matchingSnapshots);
         } catch (IOException e) {
             throw new UncheckedIOException("Error preparing Prometheus metrics output", e);
         }
-        return result.toString();
+        return result.toString(StandardCharsets.UTF_8);
     }
 
     private boolean matchesTagSelection(PrometheusMeterRegistry prometheusMeterRegistry,
                                         Set<String> meterTagNames,
-                                        Collector.MetricFamilySamples.Sample sample) {
+                                        DataPointSnapshot dataPoint) {
         for (Map.Entry<String, Set<String>> selection : tagSelection.entrySet()) {
             String tagName = prometheusMeterRegistry.config().namingConvention().tagKey(selection.getKey());
-            if (!meterTagNames.contains(tagName)) {
+            if (MICROMETER_GENERATED_LABEL_NAMES.contains(tagName) && !meterTagNames.contains(tagName)) {
                 return false;
             }
-            int labelIndex = sample.labelNames.indexOf(tagName);
-            if (labelIndex < 0 || !selection.getValue().contains(sample.labelValues.get(labelIndex))) {
+            String tagValue = dataPoint.getLabels().get(tagName);
+            if (tagValue == null || !selection.getValue().contains(tagValue)) {
                 return false;
             }
         }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -206,11 +206,11 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
                 continue;
             }
 
-            String conventionName = prometheusMeterRegistry.config()
-                    .namingConvention()
-                    .name(meterId.getName(), meterId.getType(), meterId.getBaseUnit());
+            String conventionName = PrometheusNameSupport.expositionName(
+                    meterId,
+                    prometheusMeterRegistry.config().namingConvention());
             result.add(conventionName);
-            if (meterId.getType() == Meter.Type.TIMER || meterId.getType() == Meter.Type.DISTRIBUTION_SUMMARY) {
+            if (meter instanceof Timer || meter instanceof DistributionSummary || meter instanceof LongTaskTimer) {
                 result.add(conventionName + "_max");
             }
         }
@@ -239,7 +239,7 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         var namingConvention = prometheusMeterRegistry.config().namingConvention();
         prometheusMeterRegistry.forEachMeter(meter -> {
             Meter.Id meterId = meter.getId();
-            String conventionName = meterId.getConventionName(namingConvention);
+            String conventionName = PrometheusNameSupport.expositionName(meterId, namingConvention);
             String familyName = meterId.getType() == Meter.Type.COUNTER && conventionName.endsWith("_total")
                     ? conventionName.substring(0, conventionName.length() - "_total".length())
                     : conventionName;

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/MicrometerPrometheusFormatter.java
@@ -240,15 +240,12 @@ public class MicrometerPrometheusFormatter implements MeterRegistryFormatter {
         prometheusMeterRegistry.forEachMeter(meter -> {
             Meter.Id meterId = meter.getId();
             String conventionName = PrometheusNameSupport.expositionName(meterId, namingConvention);
-            String familyName = meterId.getType() == Meter.Type.COUNTER && conventionName.endsWith("_total")
-                    ? conventionName.substring(0, conventionName.length() - "_total".length())
-                    : conventionName;
-            result.computeIfAbsent(familyName,
+            result.computeIfAbsent(conventionName,
                                    _ -> meterId.getConventionTags(namingConvention).stream()
                                            .map(Tag::getKey)
                                            .collect(Collectors.toUnmodifiableSet()));
             if (meter instanceof Timer || meter instanceof DistributionSummary || meter instanceof LongTaskTimer) {
-                result.putIfAbsent(conventionName + "_max", result.get(familyName));
+                result.putIfAbsent(conventionName + "_max", result.get(conventionName));
             }
         });
         return result;

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/NoOpSpanContextSupplierProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/NoOpSpanContextSupplierProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,32 @@ package io.helidon.metrics.providers.micrometer;
 
 import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
 
-import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+import io.prometheus.metrics.tracer.common.SpanContext;
 
 /**
  * No-op implementation for providing exemplar trace information.
  */
 class NoOpSpanContextSupplierProvider implements SpanContextSupplierProvider {
     @Override
-    public SpanContextSupplier get() {
-        return new SpanContextSupplier() {
+    public SpanContext get() {
+        return new SpanContext() {
             @Override
-            public String getTraceId() {
+            public String getCurrentTraceId() {
                 return null;
             }
 
             @Override
-            public String getSpanId() {
+            public String getCurrentSpanId() {
                 return null;
             }
 
             @Override
-            public boolean isSampled() {
+            public boolean isCurrentSpanSampled() {
                 return false;
+            }
+
+            @Override
+            public void markCurrentSpanAsExemplar() {
             }
         };
     }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNameSupport.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNameSupport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
+
+final class PrometheusNameSupport {
+
+    private PrometheusNameSupport() {
+    }
+
+    static String expositionName(Meter.Id meterId, NamingConvention namingConvention) {
+        // Apply the writer's final character escaping after the convention has appended any base unit and type suffix.
+        // Do not use sanitizeMetricName here because compatibility naming deliberately preserves reserved suffixes.
+        return PrometheusNaming.prometheusName(meterId.getConventionName(namingConvention));
+    }
+}

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNamingConventionConfigBlueprint.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNamingConventionConfigBlueprint.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Settings controlling Prometheus naming conventions.
+ */
+@Prototype.Configured
+@Prototype.Blueprint
+interface PrometheusNamingConventionConfigBlueprint {
+
+    /**
+     * Suffix which identifies a timer name before Prometheus adds {@code _seconds}.
+     *
+     * @return timer suffix
+     */
+    @Option.Configured
+    @Option.Default("")
+    String timerSuffix();
+
+    /**
+     * Prefix to add to metric names and tag keys which do not begin with a letter; configuring this setting enables
+     * legacy simpleclient-compatible normalization, with {@code m_} reproducing the naming from earlier Helidon releases,
+     * and preserves user-supplied reserved suffixes such as {@code _total}, {@code _created}, {@code _bucket}, and
+     * {@code _info}, whereas leaving it unset uses the new Prometheus client's normalization.
+     *
+     * @return non-letter prefix
+     */
+    @Option.Configured
+    Optional<String> nonLetterPrefix();
+}

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNamingConventionConfigBlueprint.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusNamingConventionConfigBlueprint.java
@@ -41,7 +41,8 @@ interface PrometheusNamingConventionConfigBlueprint {
      * Prefix to add to metric names and tag keys which do not begin with a letter; configuring this setting enables
      * legacy simpleclient-compatible normalization, with {@code m_} reproducing the naming from earlier Helidon releases,
      * and preserves user-supplied reserved suffixes such as {@code _total}, {@code _created}, {@code _bucket}, and
-     * {@code _info}, whereas leaving it unset uses the new Prometheus client's normalization.
+     * {@code _info}, whereas leaving it unset uses the new Prometheus client's normalization; the prefix must be non-empty
+     * and match {@code [A-Za-z][A-Za-z0-9_]*}, and constructing the publisher fails if the value is invalid.
      *
      * @return non-letter prefix
      */

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
@@ -17,6 +17,7 @@
 package io.helidon.metrics.providers.micrometer;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -26,10 +27,10 @@ import io.helidon.builder.api.RuntimeType;
 import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.exemplars.DefaultExemplarSampler;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusNamingConvention;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
 /**
  * Metrics publisher for Prometheus output.
@@ -40,7 +41,10 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
     private final PrometheusPublisherConfig config;
 
     private PrometheusPublisher(PrometheusPublisherConfig config) {
-        this.config = config;
+        this.config = Objects.requireNonNull(config);
+        config.namingConvention()
+                .flatMap(PrometheusNamingConventionConfig::nonLetterPrefix)
+                .ifPresent(LegacyPrometheusNamingConvention::validatePrefix);
     }
 
     /**
@@ -62,7 +66,7 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
     }
 
     /**
-     * Creates a new Prometheus published using the provided configuration.
+     * Creates a new Prometheus publisher using the provided configuration.
      *
      * @param config Prometheus publisher config
      *
@@ -105,19 +109,23 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
 
     /**
      * Returns a factory function accepting a property look-up function and the Micrometer span context supplier provider
-     * and producing a {@link io.micrometer.prometheus.PrometheusMeterRegistry}.
+     * and producing a {@link io.micrometer.prometheusmetrics.PrometheusMeterRegistry}.
      *
      * @return factory function
      */
     public BiFunction<Function<String, String>, SpanContextSupplierProvider, PrometheusMeterRegistry> prometheusRegistry() {
 
-        return (lookupFunction, spanContextSupplierProvider) ->
-            spanContextSupplierProvider instanceof NoOpSpanContextSupplierProvider
-                ? new PrometheusMeterRegistry(prometheusConfig(lookupFunction))
-                : new PrometheusMeterRegistry(prometheusConfig(lookupFunction),
-                                         new CollectorRegistry(),
-                                         io.micrometer.core.instrument.Clock.SYSTEM,
-                                         new DefaultExemplarSampler(spanContextSupplierProvider.get()));
+        return (lookupFunction, spanContextSupplierProvider) -> {
+            PrometheusConfig prometheusConfig = prometheusConfig(lookupFunction);
+            PrometheusMeterRegistry registry = spanContextSupplierProvider instanceof NoOpSpanContextSupplierProvider
+                    ? new PrometheusMeterRegistry(prometheusConfig)
+                    : new PrometheusMeterRegistry(prometheusConfig,
+                                                  new PrometheusRegistry(),
+                                                  io.micrometer.core.instrument.Clock.SYSTEM,
+                                                  spanContextSupplierProvider.get());
+            configureNaming(registry);
+            return registry;
+        };
     }
 
     @Override
@@ -151,5 +159,15 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
                 return config.interval().orElse(PrometheusConfig.super.step());
             }
         };
+    }
+
+    private void configureNaming(PrometheusMeterRegistry registry) {
+        PrometheusNamingConventionConfig namingConfig = config.namingConvention()
+                .orElseGet(() -> PrometheusNamingConventionConfig.builder().build());
+
+        namingConfig.nonLetterPrefix().ifPresentOrElse(prefix -> {
+            registry.config().meterFilter(new LegacyPrometheusMeterFilter());
+            registry.config().namingConvention(new LegacyPrometheusNamingConvention(namingConfig.timerSuffix(), prefix));
+        }, () -> registry.config().namingConvention(new PrometheusNamingConvention(namingConfig.timerSuffix())));
     }
 }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
@@ -38,6 +38,9 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 public class PrometheusPublisher implements MicrometerMetricsPublisher,
                                             RuntimeType.Api<PrometheusPublisherConfig> {
 
+    private static final System.Logger LOGGER = System.getLogger(PrometheusPublisher.class.getName());
+    private static final String HISTOGRAM_FLAVOR_PROPERTY = "histogramFlavor";
+
     private final PrometheusPublisherConfig config;
 
     private PrometheusPublisher(PrometheusPublisherConfig config) {
@@ -117,6 +120,7 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
 
         return (lookupFunction, spanContextSupplierProvider) -> {
             PrometheusConfig prometheusConfig = prometheusConfig(lookupFunction);
+            warnIfLegacyHistogramFlavorConfigured(prometheusConfig);
             PrometheusMeterRegistry registry = spanContextSupplierProvider instanceof NoOpSpanContextSupplierProvider
                     ? new PrometheusMeterRegistry(prometheusConfig)
                     : new PrometheusMeterRegistry(prometheusConfig,
@@ -159,6 +163,14 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
                 return config.interval().orElse(PrometheusConfig.super.step());
             }
         };
+    }
+
+    private void warnIfLegacyHistogramFlavorConfigured(PrometheusConfig prometheusConfig) {
+        String propertyName = prometheusConfig.prefix() + "." + HISTOGRAM_FLAVOR_PROPERTY;
+        if (prometheusConfig.get(propertyName) != null) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                       "Configuration property " + propertyName + " is no longer supported and is ignored");
+        }
     }
 
     private void configureNaming(PrometheusMeterRegistry registry) {

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisher.java
@@ -122,12 +122,13 @@ public class PrometheusPublisher implements MicrometerMetricsPublisher,
             PrometheusConfig prometheusConfig = prometheusConfig(lookupFunction);
             warnIfLegacyHistogramFlavorConfigured(prometheusConfig);
             PrometheusMeterRegistry registry = spanContextSupplierProvider instanceof NoOpSpanContextSupplierProvider
-                    ? new PrometheusMeterRegistry(prometheusConfig)
-                    : new PrometheusMeterRegistry(prometheusConfig,
-                                                  new PrometheusRegistry(),
-                                                  io.micrometer.core.instrument.Clock.SYSTEM,
-                                                  spanContextSupplierProvider.get());
+                    ? new CollisionDetectingPrometheusMeterRegistry(prometheusConfig)
+                    : new CollisionDetectingPrometheusMeterRegistry(prometheusConfig,
+                                                                    new PrometheusRegistry(),
+                                                                    io.micrometer.core.instrument.Clock.SYSTEM,
+                                                                    spanContextSupplierProvider.get());
             configureNaming(registry);
+            registry.throwExceptionOnRegistrationFailure();
             return registry;
         };
     }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherConfigBlueprint.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherConfigBlueprint.java
@@ -42,9 +42,10 @@ interface PrometheusPublisherConfigBlueprint extends MetricsPublisherConfig, Pro
     boolean enabled();
 
     /**
-     * Property name prefix.
+     * Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and
+     * the legacy {@code prometheus.histogramFlavor} property is not supported by the current Prometheus registry.
      *
-     * @return property name prefix
+     * @return property lookup prefix
      */
     @Option.Configured
     Optional<String> prefix();
@@ -65,5 +66,13 @@ interface PrometheusPublisherConfigBlueprint extends MetricsPublisherConfig, Pro
      */
     @Option.Configured
     Optional<Duration> interval();
+
+    /**
+     * Prometheus naming convention settings.
+     *
+     * @return naming convention settings
+     */
+    @Option.Configured
+    Optional<PrometheusNamingConventionConfig> namingConvention();
 
 }

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherConfigBlueprint.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/PrometheusPublisherConfigBlueprint.java
@@ -43,7 +43,7 @@ interface PrometheusPublisherConfigBlueprint extends MetricsPublisherConfig, Pro
 
     /**
      * Prefix for Micrometer Prometheus property lookups; this setting does not add a prefix to exported metric names, and
-     * the legacy {@code prometheus.histogramFlavor} property is not supported by the current Prometheus registry.
+     * the legacy {@code prometheus.histogramFlavor} property is accepted for compatibility but ignored with a warning.
      *
      * @return property lookup prefix
      */

--- a/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/spi/SpanContextSupplierProvider.java
+++ b/metrics/providers/micrometer/src/main/java/io/helidon/metrics/providers/micrometer/spi/SpanContextSupplierProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,18 @@
  */
 package io.helidon.metrics.providers.micrometer.spi;
 
-import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+import io.prometheus.metrics.tracer.common.SpanContext;
 
 /**
- * Returns a {@link io.prometheus.client.exemplars.tracer.common.SpanContextSupplier} for use in linking trace information
+ * Returns a {@link io.prometheus.metrics.tracer.common.SpanContext} for use in linking trace information
  * to meters via exemplars.
  */
 public interface SpanContextSupplierProvider {
 
     /**
-     * Returns a {@link io.prometheus.client.exemplars.tracer.common.SpanContextSupplier} for supporting exemplars.
+     * Returns a {@link io.prometheus.metrics.tracer.common.SpanContext} for supporting exemplars.
      *
      * @return a span context supplier
      */
-    SpanContextSupplier get();
+    SpanContext get();
 }

--- a/metrics/providers/micrometer/src/main/java/module-info.java
+++ b/metrics/providers/micrometer/src/main/java/module-info.java
@@ -31,17 +31,15 @@ module io.helidon.metrics.providers.micrometer {
 
     requires io.helidon.metrics.api;
     requires micrometer.core;
-    requires static micrometer.registry.prometheus;
-    requires static micrometer.registry.prometheus.simpleclient;
+    requires transitive micrometer.registry.prometheus;
     requires io.helidon.common;
     requires io.helidon.common.media.type;
     requires io.helidon.config;
-    requires simpleclient.common;
-    requires simpleclient.tracer.common;
-    requires simpleclient;
     requires micrometer.registry.otlp;
     requires io.helidon.service.registry;
     requires io.prometheus.metrics.model;
+    requires transitive io.prometheus.metrics.tracer.common;
+    requires io.prometheus.writer.text;
 
     exports io.helidon.metrics.providers.micrometer;
     exports io.helidon.metrics.providers.micrometer.spi;

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
@@ -52,10 +52,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestPrometheusFormatting {
 
@@ -301,8 +303,8 @@ class TestPrometheusFormatting {
                    OptionalMatcher.optionalEmpty());
         assertThat("Actual meter tag selection retains the complete custom meter family",
                    checkAndCast(realTagFormatter.format()),
-                   allOf(containsString("generatedCommonLabel{real=\"yes\",statistic=\"COUNT\"} 1.0"),
-                         containsString("generatedCommonLabel_sum{real=\"yes\",statistic=\"TOTAL\"} 2.0")));
+                   allOf(containsString("generatedCommonLabel_total{real=\"yes\",statistic=\"COUNT\"} 1.0"),
+                         containsString("generatedCommonLabel_sum_total{real=\"yes\",statistic=\"TOTAL\"} 2.0")));
         assertThat("Actual meter tag which shares a generated label name remains selectable",
                    checkAndCast(actualStatisticTagFormatter.format()),
                    containsString("actualStatisticTag{statistic=\"COUNT\"} 3.0"));
@@ -339,7 +341,7 @@ class TestPrometheusFormatting {
                          containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"+Inf\"} 1"),
                          containsString("actualTagDistribution_count{kind=\"selected\"} 1"),
                          containsString("actualTagDistribution_sum{kind=\"selected\"} 1.0"),
-                         containsString("actualTagDistribution{kind=\"selected\",quantile=\"0.5\"} 1.0"),
+                         containsString("actualTagDistribution_max{kind=\"selected\"} 1.0"),
                          not(containsString("kind=\"other\""))));
     }
 
@@ -623,6 +625,34 @@ class TestPrometheusFormatting {
                              not(containsString("unselected_total"))));
         } finally {
             legacyRegistry.close();
+        }
+    }
+
+    @Test
+    void testRejectedPrometheusMeterIsNotAvailableForSelectiveScrape() {
+        MetricsConfig localConfig = MetricsConfig.builder()
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry localRegistry = metricsFactory.createMeterRegistry(localConfig);
+        try {
+            localRegistry.getOrCreate(metricsFactory.timerBuilder("collision"));
+            AtomicLong gaugeValue = new AtomicLong(1);
+            Gauge.Builder<Double> gaugeBuilder = metricsFactory.gaugeBuilder("collision_seconds_count",
+                                                                             gaugeValue,
+                                                                             AtomicLong::doubleValue);
+            gaugeBuilder.unwrap(io.micrometer.core.instrument.Gauge.Builder.class).strongReference(true);
+
+            assertThrows(IllegalArgumentException.class, () -> localRegistry.getOrCreate(gaugeBuilder));
+            assertThat(localRegistry.meters().stream().map(meter -> meter.id().name()).toList(),
+                       not(hasItem("collision_seconds_count")));
+
+            var formatter = MicrometerPrometheusFormatter.builder(localRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .meterNameSelection(Set.of("collision_seconds_count"))
+                    .build();
+            assertThat(formatter.format(), OptionalMatcher.optionalEmpty());
+        } finally {
+            localRegistry.close();
         }
     }
 

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
@@ -21,12 +21,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.testing.junit5.OptionalMatcher;
 import io.helidon.metrics.api.Counter;
 import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.Gauge;
 import io.helidon.metrics.api.MeterRegistry;
 import io.helidon.metrics.api.MeterRegistryFormatter;
 import io.helidon.metrics.api.MetricsConfig;
@@ -39,8 +41,8 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,7 +146,7 @@ class TestPrometheusFormatting {
                          containsString(scopeExpr("t1_seconds_count",
                                                   "this_scope",
                                                   "other",
-                                                  "1.0")),
+                                                  "1")),
                          containsString(scopeExpr("t1_seconds_sum",
                                                   "this_scope",
                                                   "other",
@@ -152,7 +154,7 @@ class TestPrometheusFormatting {
                          containsString(scopeExpr("t1_1_seconds_count",
                                                   "this_scope",
                                                   "app",
-                                                  "1.0")),
+                                                  "1")),
                          endsWith(OPENMETRICS_EOF)));
 
     }
@@ -236,7 +238,7 @@ class TestPrometheusFormatting {
                          containsString(scopeExpr("t3_1_seconds_count",
                                                   "this_scope",
                                                   "app",
-                                                  "1.0")),
+                                                  "1")),
                          endsWith(OPENMETRICS_EOF)));
     }
 
@@ -332,10 +334,10 @@ class TestPrometheusFormatting {
 
         assertThat("Actual meter tag selection retains the complete distribution family",
                    checkAndCast(formatter.format()),
-                   allOf(containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"1.0\"} 1.0"),
-                         containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"2.0\"} 1.0"),
-                         containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"+Inf\"} 1.0"),
-                         containsString("actualTagDistribution_count{kind=\"selected\"} 1.0"),
+                   allOf(containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"1.0\"} 1"),
+                         containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"2.0\"} 1"),
+                         containsString("actualTagDistribution_bucket{kind=\"selected\",le=\"+Inf\"} 1"),
+                         containsString("actualTagDistribution_count{kind=\"selected\"} 1"),
                          containsString("actualTagDistribution_sum{kind=\"selected\"} 1.0"),
                          containsString("actualTagDistribution{kind=\"selected\",quantile=\"0.5\"} 1.0"),
                          not(containsString("kind=\"other\""))));
@@ -576,6 +578,52 @@ class TestPrometheusFormatting {
         assertThat("Provider scope selection is ignored",
                    checkAndCast(providerFormatter.format()),
                    containsString("counterByIgnoredScope_total 8.0"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testLegacyNamingSelectiveScrapeUsesOriginalNamesAndIncludesMaxFamilies() {
+        MetricsConfig legacyConfig = MetricsConfig.builder()
+                .addPublisher(PrometheusPublisher.builder()
+                                      .namingConvention(builder -> builder.nonLetterPrefix("m_"))
+                                      .build())
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry legacyRegistry = metricsFactory.createMeterRegistry(legacyConfig);
+        try {
+            AtomicLong gaugeValue = new AtomicLong(4);
+            Gauge.Builder<Double> gaugeBuilder = metricsFactory.gaugeBuilder("build.info",
+                                                                             gaugeValue,
+                                                                             AtomicLong::doubleValue);
+            gaugeBuilder.unwrap(io.micrometer.core.instrument.Gauge.Builder.class).strongReference(true);
+            legacyRegistry.getOrCreate(gaugeBuilder);
+
+            legacyRegistry.getOrCreate(metricsFactory.counterBuilder("1counter")).increment();
+            Timer timer = legacyRegistry.getOrCreate(metricsFactory.timerBuilder("request.time"));
+            timer.record(2, TimeUnit.SECONDS);
+            DistributionSummary summary = legacyRegistry.getOrCreate(metricsFactory.distributionSummaryBuilder(
+                    "payload.size",
+                    metricsFactory.distributionStatisticsConfigBuilder()));
+            summary.record(5);
+            legacyRegistry.getOrCreate(metricsFactory.counterBuilder("unselected")).increment();
+
+            var formatter = MicrometerPrometheusFormatter.builder(legacyRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .meterNameSelection(Set.of("1counter", "build.info", "request.time", "payload.size"))
+                    .build();
+
+            assertThat("Legacy selective output",
+                       checkAndCast(formatter.format()),
+                       allOf(containsString("m_1counter_total 1.0"),
+                             containsString("build_info 4.0"),
+                             containsString("request_time_seconds_count 1"),
+                             containsString("request_time_seconds_max 2.0"),
+                             containsString("payload_size_count 1"),
+                             containsString("payload_size_max 5.0"),
+                             not(containsString("unselected_total"))));
+        } finally {
+            legacyRegistry.close();
+        }
     }
 
     private static String scopeExpr(String meterName, String key, String value, String suffix) {

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
@@ -36,6 +36,8 @@ import io.helidon.metrics.api.MetricsFactory;
 import io.helidon.metrics.api.Timer;
 import io.helidon.service.registry.Services;
 
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Metrics;
@@ -651,6 +653,101 @@ class TestPrometheusFormatting {
                     .meterNameSelection(Set.of("collision_seconds_count"))
                     .build();
             assertThat(formatter.format(), OptionalMatcher.optionalEmpty());
+        } finally {
+            localRegistry.close();
+        }
+    }
+
+    @Test
+    void testSelectiveScrapeUsesExpositionName() {
+        MetricsConfig localConfig = MetricsConfig.builder()
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry localRegistry = metricsFactory.createMeterRegistry(localConfig);
+        try {
+            PrometheusMeterRegistry prometheusRegistry = MicrometerPrometheusFormatter
+                    .prometheusMeterRegistry(localRegistry)
+                    .orElseThrow();
+            io.micrometer.core.instrument.Gauge.builder("payload", () -> 1)
+                    .baseUnit("bytes/second")
+                    .tag("le", "actual")
+                    .register(prometheusRegistry);
+
+            var formatter = MicrometerPrometheusFormatter.builder(localRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .meterNameSelection(Set.of("payload"))
+                    .tagSelection(Map.of("le", Set.of("actual")))
+                    .build();
+
+            assertThat(checkAndCast(formatter.format()),
+                       containsString("payload_bytes_second{le=\"actual\"} 1.0"));
+        } finally {
+            localRegistry.close();
+        }
+    }
+
+    @Test
+    void testFunctionTimerSelectiveScrapeDoesNotIncludeUnrelatedMaxFamily() {
+        MetricsConfig localConfig = MetricsConfig.builder()
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry localRegistry = metricsFactory.createMeterRegistry(localConfig);
+        try {
+            PrometheusMeterRegistry prometheusRegistry = MicrometerPrometheusFormatter
+                    .prometheusMeterRegistry(localRegistry)
+                    .orElseThrow();
+            AtomicLong count = new AtomicLong(1);
+            AtomicLong totalTime = new AtomicLong(2);
+            FunctionTimer.builder("operation", count,
+                                  AtomicLong::get,
+                                  _ -> totalTime.get(),
+                                  TimeUnit.SECONDS)
+                    .register(prometheusRegistry);
+            io.micrometer.core.instrument.Gauge.builder("operation_seconds_max", () -> 3)
+                    .register(prometheusRegistry);
+
+            var formatter = MicrometerPrometheusFormatter.builder(localRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .meterNameSelection(Set.of("operation"))
+                    .build();
+            String output = checkAndCast(formatter.format());
+
+            assertThat(output,
+                       allOf(containsString("operation_seconds_count 1"),
+                             containsString("operation_seconds_sum 2.0"),
+                             not(containsString("operation_seconds_max"))));
+        } finally {
+            localRegistry.close();
+        }
+    }
+
+    @Test
+    void testLongTaskTimerSelectiveScrapeIncludesMaxFamily() {
+        MetricsConfig localConfig = MetricsConfig.builder()
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry localRegistry = metricsFactory.createMeterRegistry(localConfig);
+        try {
+            PrometheusMeterRegistry prometheusRegistry = MicrometerPrometheusFormatter
+                    .prometheusMeterRegistry(localRegistry)
+                    .orElseThrow();
+            LongTaskTimer longTaskTimer = LongTaskTimer.builder("operation")
+                    .register(prometheusRegistry);
+            LongTaskTimer.Sample sample = longTaskTimer.start();
+            try {
+                var formatter = MicrometerPrometheusFormatter.builder(localRegistry)
+                        .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                        .meterNameSelection(Set.of("operation"))
+                        .build();
+                String output = checkAndCast(formatter.format());
+
+                assertThat(output,
+                           allOf(containsString("operation_seconds_count 1"),
+                                 containsString("operation_seconds_sum"),
+                                 containsString("operation_seconds_max")));
+            } finally {
+                sample.stop();
+            }
         } finally {
             localRegistry.close();
         }

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusFormatting.java
@@ -275,6 +275,34 @@ class TestPrometheusFormatting {
     }
 
     @Test
+    void testLegacyCounterActualGeneratedNameTagIsSelectable() {
+        MetricsConfig legacyConfig = MetricsConfig.builder()
+                .addPublisher(PrometheusPublisher.builder()
+                                      .namingConvention(builder -> builder.nonLetterPrefix("m_"))
+                                      .build())
+                .warnOnMultipleRegistries(false)
+                .build();
+        MeterRegistry legacyRegistry = metricsFactory.createMeterRegistry(legacyConfig);
+        try {
+            legacyRegistry.getOrCreate(metricsFactory.counterBuilder("jobs")
+                                               .addTag(metricsFactory.tagCreate("le", "actual")))
+                    .increment();
+
+            var formatter = MicrometerPrometheusFormatter.builder(legacyRegistry)
+                    .resultMediaType(MediaTypes.APPLICATION_OPENMETRICS_TEXT)
+                    .meterNameSelection(Set.of("jobs"))
+                    .tagSelection(Map.of("le", Set.of("actual")))
+                    .build();
+
+            assertThat("Actual counter tag which shares a generated label name remains selectable with legacy naming",
+                       checkAndCast(formatter.format()),
+                       containsString("jobs_total{le=\"actual\"} 1.0"));
+        } finally {
+            legacyRegistry.close();
+        }
+    }
+
+    @Test
     void testGeneratedCommonLabelDoesNotSatisfyTagSelection() {
         Meter.builder("generatedCommonLabel",
                       Meter.Type.OTHER,

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.providers.micrometer;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
+import io.prometheus.metrics.tracer.common.SpanContext;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestPrometheusNaming {
+
+    @Test
+    void testNewClientNamingByDefault() {
+        PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
+        try {
+            registry.counter("1request", "1tag", "value").increment();
+
+            String output = scrape(registry);
+
+            assertThat(output,
+                       allOf(containsString("_request_total{_tag=\"value\"} 1.0"),
+                             not(containsString("m_1request"))));
+        } finally {
+            registry.close();
+        }
+
+        registry = registry(PrometheusPublisher.create());
+        try {
+            registry.counter("_request", "_tag", "value").increment();
+            Gauge.builder("queue_total", () -> 3).register(registry);
+            registry.counter("requests_created").increment();
+
+            String output = scrape(registry);
+
+            assertThat(output,
+                       allOf(containsString("_request_total{_tag=\"value\"} 1.0"),
+                             containsString("queue 3.0"),
+                             containsString("requests_total 1.0"),
+                             not(containsString("queue_total 3.0")),
+                             not(containsString("requests_created_total"))));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testLegacyCompatibleNaming() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(PrometheusNamingConventionConfig.builder()
+                                          .nonLetterPrefix("m_")
+                                          .build())
+                .build();
+
+        PrometheusMeterRegistry registry = registry(publisher);
+        try {
+            AtomicLong functionCount = new AtomicLong(2);
+            registry.counter("1request", "1tag", "value").increment();
+            FunctionCounter.builder("_function", functionCount, AtomicLong::get).register(registry);
+            Gauge.builder("queue_total", () -> 3).register(registry);
+            Gauge.builder("queue_created", () -> 5).register(registry);
+            Gauge.builder("queue_bucket", () -> 6).register(registry);
+            Gauge.builder("queue_info", () -> 7).register(registry);
+            Gauge.builder("build.info", () -> 4).register(registry);
+            registry.counter("requests_created").increment();
+            registry.counter("requests_total").increment();
+            Timer timer = registry.timer("latency");
+            timer.record(Duration.ofSeconds(1));
+            DistributionSummary summary = registry.summary("payload");
+            summary.record(5);
+
+            String output = scrape(registry);
+
+            assertThat(output,
+                       allOf(containsString("m_1request_total{m_1tag=\"value\"} 1.0"),
+                             containsString("m__function_total 2.0"),
+                             containsString("queue_total 3.0"),
+                             containsString("queue_created 5.0"),
+                             containsString("queue_bucket 6.0"),
+                             containsString("queue_info 7.0"),
+                             containsString("build_info 4.0"),
+                             containsString("requests_created_total 1.0"),
+                             containsString("requests_total 1.0"),
+                             not(containsString("requests_total_total")),
+                             containsString("latency_seconds_count 1"),
+                             containsString("latency_seconds_sum 1.0"),
+                             containsString("payload_count 1"),
+                             containsString("payload_sum 5.0")));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testCustomTimerSuffix() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(builder -> builder.timerSuffix("_duration")
+                        .nonLetterPrefix("m_"))
+                .build();
+
+        PrometheusMeterRegistry registry = registry(publisher);
+        try {
+            registry.timer("latency_duration").record(Duration.ofSeconds(1));
+
+            assertThat(scrape(registry), containsString("latency_duration_seconds_count 1"));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testCustomLegacyPrefix() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(builder -> builder.nonLetterPrefix("legacy_"))
+                .build();
+
+        PrometheusMeterRegistry registry = registry(publisher);
+        try {
+            registry.counter("1request").increment();
+
+            assertThat(scrape(registry), containsString("legacy_1request_total 1.0"));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testLegacyInfoGaugeCollisionIsRejected() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(builder -> builder.nonLetterPrefix("m_"))
+                .build();
+
+        PrometheusMeterRegistry registry = registry(publisher).throwExceptionOnRegistrationFailure();
+        try {
+            Gauge.builder("build.info", () -> 1)
+                    .tag("source", "dot")
+                    .register(registry);
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("build_info", () -> 2)
+                                 .tag("source", "underscore")
+                                 .register(registry));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testLegacySupportedMeterOutputInBothFormats() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(builder -> builder.nonLetterPrefix("m_"))
+                .build();
+        PrometheusMeterRegistry registry = registry(publisher);
+        try {
+            io.micrometer.core.instrument.Counter.builder("jobs")
+                    .baseUnit("tasks")
+                    .description("Completed jobs")
+                    .tag("kind", "batch")
+                    .register(registry)
+                    .increment(2);
+            Gauge.builder("temperature", () -> 21)
+                    .baseUnit("celsius")
+                    .description("Current temperature")
+                    .tag("kind", "batch")
+                    .register(registry);
+            Timer timer = Timer.builder("latency")
+                    .description("Request latency")
+                    .tag("kind", "batch")
+                    .publishPercentileHistogram()
+                    .register(registry);
+            timer.record(Duration.ofSeconds(1));
+            DistributionSummary summary = DistributionSummary.builder("payload")
+                    .baseUnit("bytes")
+                    .description("Payload size")
+                    .tag("kind", "batch")
+                    .publishPercentileHistogram()
+                    .register(registry);
+            summary.record(5);
+
+            String prometheusText = registry.scrape(PrometheusTextFormatWriter.CONTENT_TYPE);
+            String openMetricsText = scrape(registry);
+
+            for (String output : new String[] {prometheusText, openMetricsText}) {
+                assertThat(output,
+                           allOf(containsString("# HELP jobs_tasks"),
+                                 containsString("jobs_tasks_total{kind=\"batch\"} 2.0"),
+                                 not(containsString("jobs_tasks_created")),
+                                 containsString("temperature_celsius{kind=\"batch\"} 21.0"),
+                                 containsString("latency_seconds_count{kind=\"batch\"} 1"),
+                                 containsString("latency_seconds_sum{kind=\"batch\"} 1.0"),
+                                 containsString("latency_seconds_max{kind=\"batch\"} 1.0"),
+                                 containsString("latency_seconds_bucket{"),
+                                 containsString("payload_bytes_count{kind=\"batch\"} 1"),
+                                 containsString("payload_bytes_sum{kind=\"batch\"} 5.0"),
+                                 containsString("payload_bytes_max{kind=\"batch\"} 5.0"),
+                                 containsString("payload_bytes_bucket{")));
+            }
+            assertThat(openMetricsText, containsString("# EOF\n"));
+            assertThat(prometheusText, not(containsString("# EOF")));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testExemplarUsesNewSpanContextApi() {
+        AtomicBoolean markedAsExemplar = new AtomicBoolean();
+        SpanContext spanContext = new SpanContext() {
+            @Override
+            public String getCurrentTraceId() {
+                return "0123456789abcdef0123456789abcdef";
+            }
+
+            @Override
+            public String getCurrentSpanId() {
+                return "0123456789abcdef";
+            }
+
+            @Override
+            public boolean isCurrentSpanSampled() {
+                return true;
+            }
+
+            @Override
+            public void markCurrentSpanAsExemplar() {
+                markedAsExemplar.set(true);
+            }
+        };
+        SpanContextSupplierProvider provider = () -> spanContext;
+        PrometheusMeterRegistry registry = PrometheusPublisher.create()
+                .prometheusRegistry()
+                .apply(_ -> null, provider);
+        try {
+            registry.counter("exemplar.counter").increment();
+
+            assertThat(scrape(registry),
+                       allOf(containsString("trace_id=\"0123456789abcdef0123456789abcdef\""),
+                             containsString("span_id=\"0123456789abcdef\"")));
+            assertThat("Current span was marked as an exemplar", markedAsExemplar.get());
+        } finally {
+            registry.close();
+        }
+    }
+
+    private static PrometheusMeterRegistry registry(PrometheusPublisher publisher) {
+        return publisher.prometheusRegistry().apply(_ -> null, new NoOpSpanContextSupplierProvider());
+    }
+
+    private static String scrape(PrometheusMeterRegistry registry) {
+        return registry.scrape(OpenMetricsTextFormatWriter.CONTENT_TYPE);
+    }
+}

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -94,7 +96,6 @@ class TestPrometheusNaming {
             Gauge.builder("queue_info", () -> 7).register(registry);
             Gauge.builder("build.info", () -> 4).register(registry);
             registry.counter("requests_created").increment();
-            registry.counter("requests_total").increment();
             Timer timer = registry.timer("latency");
             timer.record(Duration.ofSeconds(1));
             DistributionSummary summary = registry.summary("payload");
@@ -111,12 +112,27 @@ class TestPrometheusNaming {
                              containsString("queue_info 7.0"),
                              containsString("build_info 4.0"),
                              containsString("requests_created_total 1.0"),
-                             containsString("requests_total 1.0"),
-                             not(containsString("requests_total_total")),
                              containsString("latency_seconds_count 1"),
                              containsString("latency_seconds_sum 1.0"),
                              containsString("payload_count 1"),
                              containsString("payload_sum 5.0")));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testLegacyCounterAlreadyEndingInTotalReceivesNoSecondSuffix() {
+        PrometheusPublisher publisher = PrometheusPublisher.builder()
+                .namingConvention(builder -> builder.nonLetterPrefix("m_"))
+                .build();
+        PrometheusMeterRegistry registry = registry(publisher);
+        try {
+            registry.counter("requests_total").increment();
+
+            assertThat(scrape(registry),
+                       allOf(containsString("requests_total 1.0"),
+                             not(containsString("requests_total_total"))));
         } finally {
             registry.close();
         }
@@ -161,7 +177,7 @@ class TestPrometheusNaming {
                 .namingConvention(builder -> builder.nonLetterPrefix("m_"))
                 .build();
 
-        PrometheusMeterRegistry registry = registry(publisher).throwExceptionOnRegistrationFailure();
+        PrometheusMeterRegistry registry = registry(publisher);
         try {
             Gauge.builder("build.info", () -> 1)
                     .tag("source", "dot")
@@ -177,6 +193,48 @@ class TestPrometheusNaming {
     }
 
     @Test
+    void testGeneratedNameCollisionsAreRejectedDuringRegistration() {
+        PrometheusMeterRegistry timerRegistry = registry(PrometheusPublisher.create());
+        try {
+            timerRegistry.timer("request");
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("request_seconds_count", () -> 1).register(timerRegistry));
+            assertThat(scrape(timerRegistry), containsString("request_seconds_count 0"));
+        } finally {
+            timerRegistry.close();
+        }
+
+        PrometheusMeterRegistry summaryRegistry = registry(PrometheusPublisher.create());
+        try {
+            Gauge gauge = Gauge.builder("payload_max", () -> 1).register(summaryRegistry);
+
+            assertThrows(IllegalArgumentException.class, () -> summaryRegistry.summary("payload"));
+
+            summaryRegistry.remove(gauge);
+            summaryRegistry.summary("payload").record(1);
+            assertThat(scrape(summaryRegistry), containsString("payload_max 1.0"));
+        } finally {
+            summaryRegistry.close();
+        }
+    }
+
+    @Test
+    void testTagVariantsShareGeneratedNames() {
+        PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
+        try {
+            registry.counter("requests", "method", "GET").increment();
+            registry.counter("requests", "method", "POST").increment(2);
+
+            assertThat(scrape(registry),
+                       allOf(containsString("requests_total{method=\"GET\"} 1.0"),
+                             containsString("requests_total{method=\"POST\"} 2.0")));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testLegacySupportedMeterOutputInBothFormats() {
         PrometheusPublisher publisher = PrometheusPublisher.builder()
@@ -184,7 +242,7 @@ class TestPrometheusNaming {
                 .build();
         PrometheusMeterRegistry registry = registry(publisher);
         try {
-            io.micrometer.core.instrument.Counter.builder("jobs")
+            Counter.builder("jobs")
                     .baseUnit("tasks")
                     .description("Completed jobs")
                     .tag("kind", "batch")
@@ -268,7 +326,7 @@ class TestPrometheusNaming {
             assertThat(scrape(registry),
                        allOf(containsString("trace_id=\"0123456789abcdef0123456789abcdef\""),
                              containsString("span_id=\"0123456789abcdef\"")));
-            assertThat("Current span was marked as an exemplar", markedAsExemplar.get());
+            assertThat("Current span was marked as an exemplar", markedAsExemplar.get(), is(true));
         } finally {
             registry.close();
         }

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
@@ -17,6 +17,7 @@
 package io.helidon.metrics.providers.micrometer;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -25,7 +26,9 @@ import io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
@@ -216,6 +219,60 @@ class TestPrometheusNaming {
             assertThat(scrape(summaryRegistry), containsString("payload_max 1.0"));
         } finally {
             summaryRegistry.close();
+        }
+    }
+
+    @Test
+    void testExpositionNameCollisionsAreRejectedDuringRegistration() {
+        PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
+        try {
+            Gauge.builder("payload", () -> 1)
+                    .baseUnit("bytes/second")
+                    .register(registry);
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("payload_bytes_second", () -> 2).register(registry));
+            assertThat(scrape(registry), containsString("payload_bytes_second 1.0"));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testFunctionTimerGeneratedNameCollisionsAreRejectedDuringRegistration() {
+        PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
+        try {
+            AtomicLong count = new AtomicLong(1);
+            AtomicLong totalTime = new AtomicLong(2);
+            FunctionTimer.builder("operation", count,
+                                  AtomicLong::get,
+                                  _ -> totalTime.get(),
+                                  TimeUnit.SECONDS)
+                    .register(registry);
+            Gauge.builder("operation_seconds_max", () -> 3).register(registry);
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("operation_seconds_count", () -> 4).register(registry));
+            assertThat(scrape(registry),
+                       allOf(containsString("operation_seconds_count 1"),
+                             containsString("operation_seconds_sum 2.0"),
+                             containsString("operation_seconds_max 3.0")));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testLongTaskTimerGeneratedNameCollisionsAreRejectedDuringRegistration() {
+        PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
+        try {
+            LongTaskTimer.builder("operation").register(registry);
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("operation_seconds_max", () -> 1).register(registry));
+            assertThat(scrape(registry), containsString("operation_seconds_max 0.0"));
+        } finally {
+            registry.close();
         }
     }
 

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPrometheusNaming.java
@@ -266,11 +266,20 @@ class TestPrometheusNaming {
     void testLongTaskTimerGeneratedNameCollisionsAreRejectedDuringRegistration() {
         PrometheusMeterRegistry registry = registry(PrometheusPublisher.create());
         try {
-            LongTaskTimer.builder("operation").register(registry);
+            LongTaskTimer.builder("operation")
+                    .publishPercentileHistogram()
+                    .register(registry);
 
             assertThrows(IllegalArgumentException.class,
                          () -> Gauge.builder("operation_seconds_max", () -> 1).register(registry));
-            assertThat(scrape(registry), containsString("operation_seconds_max 0.0"));
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("operation_seconds_gcount", () -> 1).register(registry));
+            assertThrows(IllegalArgumentException.class,
+                         () -> Gauge.builder("operation_seconds_gsum", () -> 1).register(registry));
+            assertThat(scrape(registry),
+                       allOf(containsString("operation_seconds_gcount 0"),
+                             containsString("operation_seconds_gsum 0.0"),
+                             containsString("operation_seconds_max 0.0")));
         } finally {
             registry.close();
         }

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPublisherConfig.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPublisherConfig.java
@@ -16,6 +16,13 @@
 
 package io.helidon.metrics.providers.micrometer;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MetricsConfig;
@@ -135,5 +142,53 @@ class TestPublisherConfig {
                      () -> PrometheusPublisher.builder()
                              .namingConvention(builder -> builder.nonLetterPrefix(""))
                              .build());
+    }
+
+    @Test
+    void testLegacyHistogramFlavorIsAcceptedAndIgnored() {
+        String configText = """
+                metrics:
+                  prometheus:
+                    histogramFlavor: VictoriaMetrics
+                  publishers:
+                    prometheus:
+                """;
+
+        var metricsConfig = MetricsConfig.create(Config.just(configText, MediaTypes.APPLICATION_YAML)
+                                                         .get("metrics"));
+        var publisher = (PrometheusPublisher) metricsConfig.publishers().getFirst();
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        Logger logger = Logger.getLogger(PrometheusPublisher.class.getName());
+        logger.addHandler(handler);
+
+        PrometheusMeterRegistry registry = null;
+        try {
+            registry = publisher.prometheusRegistry()
+                    .apply(key -> metricsConfig.lookupConfig(key).orElse(null), new NoOpSpanContextSupplierProvider());
+            assertThat("Warning count", logRecords, hasSize(1));
+            assertThat("Warning level", logRecords.getFirst().getLevel(), is(Level.WARNING));
+            assertThat("Warning message",
+                       logRecords.getFirst().getMessage(),
+                       containsString("prometheus.histogramFlavor is no longer supported and is ignored"));
+        } finally {
+            if (registry != null) {
+                registry.close();
+            }
+            logger.removeHandler(handler);
+        }
     }
 }

--- a/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPublisherConfig.java
+++ b/metrics/providers/micrometer/src/test/java/io/helidon/metrics/providers/micrometer/TestPublisherConfig.java
@@ -20,10 +20,14 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.metrics.api.MetricsConfig;
 
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestPublisherConfig {
 
@@ -85,5 +89,51 @@ class TestPublisherConfig {
         assertThat("Publishers",
                    metricsConfig.publishers(),
                    hasSize(2));
+    }
+
+    @Test
+    void testPrometheusNamingConventionConfig() {
+        String configText = """
+                metrics:
+                  publishers:
+                    prometheus:
+                      naming-convention:
+                        timer-suffix: "_duration"
+                        non-letter-prefix: "m_"
+                """;
+
+        var metricsConfig = MetricsConfig.create(Config.just(configText, MediaTypes.APPLICATION_YAML)
+                                                         .get("metrics"));
+        var publisher = (PrometheusPublisher) metricsConfig.publishers().getFirst();
+        var namingConfig = publisher.prototype().namingConvention().orElseThrow();
+
+        assertThat("Timer suffix", namingConfig.timerSuffix(), is("_duration"));
+        assertThat("Non-letter prefix", namingConfig.nonLetterPrefix().orElseThrow(), is("m_"));
+
+        PrometheusMeterRegistry registry = publisher.prometheusRegistry()
+                .apply(_ -> null, new NoOpSpanContextSupplierProvider());
+        try {
+            registry.counter("1request").increment();
+            assertThat("Config selects legacy naming",
+                       registry.scrape(),
+                       containsString("m_1request_total 1.0"));
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void testInvalidNonLetterPrefix() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                                                   () -> PrometheusPublisher.builder()
+                                                           .namingConvention(builder -> builder.nonLetterPrefix("1_"))
+                                                           .build());
+
+        assertThat(ex.getMessage(), containsString("must match [A-Za-z][A-Za-z0-9_]*"));
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> PrometheusPublisher.builder()
+                             .namingConvention(builder -> builder.nonLetterPrefix(""))
+                             .build());
     }
 }

--- a/metrics/trace-exemplar/src/main/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProvider.java
+++ b/metrics/trace-exemplar/src/main/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProvider.java
@@ -15,11 +15,13 @@
  */
 package io.helidon.metrics.exemplartrace;
 
+import java.util.Optional;
+
 import io.helidon.common.Api;
 import io.helidon.common.context.Contexts;
-import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.Span;
 
-import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+import io.prometheus.metrics.tracer.common.SpanContext;
 
 /**
  * Full-featured implementation of provider for trace information to support exemplars.
@@ -35,31 +37,40 @@ public class MicrometerSpanContextSupplierProvider
     }
 
     @Override
-    public SpanContextSupplier get() {
-        return new SpanContextSupplierImpl();
+    public SpanContext get() {
+        return new SpanContextImpl();
     }
 
-    private record SpanContextSupplierImpl() implements SpanContextSupplier {
+    private record SpanContextImpl() implements SpanContext {
 
         @Override
-        public String getTraceId() {
-            return spanContext() != null ? spanContext().traceId() : null;
+        public String getCurrentTraceId() {
+            return spanContext().map(io.helidon.tracing.SpanContext::traceId).orElse(null);
         }
 
         @Override
-        public String getSpanId() {
-            return spanContext() != null ? spanContext().spanId() : null;
+        public String getCurrentSpanId() {
+            return spanContext().map(io.helidon.tracing.SpanContext::spanId).orElse(null);
         }
 
         @Override
-        public boolean isSampled() {
-            return spanContext() != null;
+        public boolean isCurrentSpanSampled() {
+            return spanContext().map(io.helidon.tracing.SpanContext::sampled).orElse(false);
         }
 
-        public SpanContext spanContext() {
+        @Override
+        public void markCurrentSpanAsExemplar() {
+            span().ifPresent(span -> span.tag(SpanContext.EXEMPLAR_ATTRIBUTE_NAME,
+                                              SpanContext.EXEMPLAR_ATTRIBUTE_VALUE));
+        }
+
+        private Optional<io.helidon.tracing.SpanContext> spanContext() {
             return Contexts.context()
-                    .flatMap(c -> c.get(SpanContext.class))
-                    .orElse(null);
+                    .flatMap(c -> c.get(io.helidon.tracing.SpanContext.class));
+        }
+
+        private Optional<Span> span() {
+            return Contexts.context().flatMap(c -> c.get(Span.class));
         }
     }
 }

--- a/metrics/trace-exemplar/src/main/java/module-info.java
+++ b/metrics/trace-exemplar/src/main/java/module-info.java
@@ -26,8 +26,6 @@ module io.helidon.metrics.traceexemplar {
     requires io.helidon.metrics.api;
     requires io.helidon.metrics.providers.micrometer;
 
-    requires simpleclient.tracer.common;
-
     provides io.helidon.metrics.providers.micrometer.spi.SpanContextSupplierProvider
             with io.helidon.metrics.exemplartrace.MicrometerSpanContextSupplierProvider;
 }

--- a/metrics/trace-exemplar/src/test/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProviderTest.java
+++ b/metrics/trace-exemplar/src/test/java/io/helidon/metrics/exemplartrace/MicrometerSpanContextSupplierProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics.exemplartrace;
+
+import java.util.Map;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.tracing.Baggage;
+import io.helidon.tracing.Scope;
+import io.helidon.tracing.Span;
+import io.helidon.tracing.SpanContext;
+import io.helidon.tracing.WritableBaggage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MicrometerSpanContextSupplierProviderTest {
+
+    @Test
+    void testUsesPropagatedContextForSamplingAndMarking() {
+        TestSpanContext helidonSpanContext = new TestSpanContext(false);
+        TestSpan helidonSpan = new TestSpan(helidonSpanContext);
+        Context context = Context.create();
+        context.register(helidonSpanContext);
+        context.register(helidonSpan);
+
+        io.prometheus.metrics.tracer.common.SpanContext prometheusSpanContext =
+                new MicrometerSpanContextSupplierProvider().get();
+
+        Contexts.runInContext(context, () -> {
+            assertThat(prometheusSpanContext.getCurrentTraceId(), is("trace-id"));
+            assertThat(prometheusSpanContext.getCurrentSpanId(), is("span-id"));
+            assertThat(prometheusSpanContext.isCurrentSpanSampled(), is(false));
+            prometheusSpanContext.markCurrentSpanAsExemplar();
+        });
+
+        assertThat(helidonSpan.exemplar(), is(true));
+    }
+
+    private static class TestSpan implements Span {
+        private final SpanContext spanContext;
+        private boolean exemplar;
+
+        private TestSpan(SpanContext spanContext) {
+            this.spanContext = spanContext;
+        }
+
+        @Override
+        public Span tag(String key, String value) {
+            if (io.prometheus.metrics.tracer.common.SpanContext.EXEMPLAR_ATTRIBUTE_NAME.equals(key)
+                    && io.prometheus.metrics.tracer.common.SpanContext.EXEMPLAR_ATTRIBUTE_VALUE.equals(value)) {
+                exemplar = true;
+            }
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Boolean value) {
+            return this;
+        }
+
+        @Override
+        public Span tag(String key, Number value) {
+            return this;
+        }
+
+        @Override
+        public void status(Status status) {
+        }
+
+        @Override
+        public SpanContext context() {
+            return spanContext;
+        }
+
+        @Override
+        public void addEvent(String name, Map<String, ?> attributes) {
+        }
+
+        @Override
+        public void end() {
+        }
+
+        @Override
+        public void end(Throwable t) {
+        }
+
+        @Override
+        public Scope activate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WritableBaggage baggage() {
+            throw new UnsupportedOperationException();
+        }
+
+        private boolean exemplar() {
+            return exemplar;
+        }
+    }
+
+    private record TestSpanContext(boolean sampled) implements SpanContext {
+
+        @Override
+        public String traceId() {
+            return "trace-id";
+        }
+
+        @Override
+        public String spanId() {
+            return "span-id";
+        }
+
+        @Override
+        public void asParent(Span.Builder<?> spanBuilder) {
+        }
+
+        @Override
+        public Baggage baggage() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <javadoc.link.jackson-databind>https://fasterxml.github.io/jackson-databind/javadoc/${javadoc.jackson.version}/</javadoc.link.jackson-databind>
         <javadoc.link.reactive-streams>https://www.reactive-streams.org/reactive-streams-${version.lib.reactivestreams}-javadoc</javadoc.link.reactive-streams>
         <javadoc.link.typesafe-config>https://static.javadoc.io/com.typesafe/config/${version.lib.typesafe-config}</javadoc.link.typesafe-config>
-        <javadoc.link.prometheus>https://static.javadoc.io/io.prometheus/simpleclient/${version.lib.prometheus}</javadoc.link.prometheus>
+        <javadoc.link.prometheus>https://prometheus.github.io/client_java/api/</javadoc.link.prometheus>
         <javadoc.link.grpc-api>https://grpc.github.io/grpc-java/javadoc</javadoc.link.grpc-api>
 
         <!--suppress UnresolvedMavenProperty -->

--- a/tests/benchmark/jmh/src/main/java/io/helidon/metrics/benchmark/jmh/MetricsFormatterJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/metrics/benchmark/jmh/MetricsFormatterJmhBenchmark.java
@@ -65,6 +65,8 @@ public class MetricsFormatterJmhBenchmark {
     private MeterRegistryFormatter prometheusAllSelectedFormatter;
     private MeterRegistryFormatter prometheusDistinctFamiliesOneSelectedFormatter;
     private MeterRegistryFormatter prometheusDistinctFamiliesAllSelectedFormatter;
+    private MeterRegistryFormatter prometheusDistinctFamiliesNameSelectedFormatter;
+    private MeterRegistryFormatter prometheusDistinctFamiliesNameAndTagSelectedFormatter;
     private MeterRegistryFormatter jsonUnfilteredFormatter;
     private MeterRegistryFormatter jsonOneSelectedFormatter;
     private MeterRegistryFormatter jsonAllSelectedFormatter;
@@ -100,6 +102,17 @@ public class MetricsFormatterJmhBenchmark {
                                                                     metricsConfig,
                                                                     distinctFamiliesAllMatchMeterRegistry,
                                                                     selection());
+        Set<String> selectedMeterName = Set.of(METER_NAME + "." + (cardinality - 1));
+        prometheusDistinctFamiliesNameSelectedFormatter = formatter(MediaTypes.TEXT_PLAIN,
+                                                                     metricsConfig,
+                                                                     distinctFamiliesOneMatchMeterRegistry,
+                                                                     Map.of(),
+                                                                     selectedMeterName);
+        prometheusDistinctFamiliesNameAndTagSelectedFormatter = formatter(MediaTypes.TEXT_PLAIN,
+                                                                           metricsConfig,
+                                                                           distinctFamiliesOneMatchMeterRegistry,
+                                                                           selection(),
+                                                                           selectedMeterName);
         jsonUnfilteredFormatter = formatter(MediaTypes.APPLICATION_JSON,
                                             metricsConfig,
                                             oneMatchMeterRegistry,
@@ -148,6 +161,16 @@ public class MetricsFormatterJmhBenchmark {
     }
 
     @Benchmark
+    public Object formatPrometheusDistinctFamiliesNameSelected() {
+        return prometheusDistinctFamiliesNameSelectedFormatter.format().orElseThrow();
+    }
+
+    @Benchmark
+    public Object formatPrometheusDistinctFamiliesNameAndTagSelected() {
+        return prometheusDistinctFamiliesNameAndTagSelectedFormatter.format().orElseThrow();
+    }
+
+    @Benchmark
     public Object formatJsonUnfiltered() {
         return jsonUnfilteredFormatter.format().orElseThrow();
     }
@@ -187,12 +210,20 @@ public class MetricsFormatterJmhBenchmark {
                                               MetricsConfig metricsConfig,
                                               MeterRegistry meterRegistry,
                                               Map<String, Collection<String>> tagSelection) {
+        return formatter(mediaType, metricsConfig, meterRegistry, tagSelection, List.of());
+    }
+
+    private MeterRegistryFormatter formatter(MediaType mediaType,
+                                              MetricsConfig metricsConfig,
+                                              MeterRegistry meterRegistry,
+                                              Map<String, Collection<String>> tagSelection,
+                                              Collection<String> meterNameSelection) {
         return Services.all(MeterRegistryFormatterProvider.class).stream()
                 .map(provider -> provider.formatter(mediaType,
                                                     metricsConfig,
                                                     meterRegistry,
                                                     tagSelection,
-                                                    List.of()))
+                                                    meterNameSelection))
                 .flatMap(Optional::stream)
                 .findFirst()
                 .orElseThrow();

--- a/tests/benchmark/jmh/src/main/java/io/helidon/metrics/benchmark/jmh/MetricsRecordingJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/metrics/benchmark/jmh/MetricsRecordingJmhBenchmark.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.metrics.api.Counter;
+import io.helidon.metrics.api.DistributionSummary;
+import io.helidon.metrics.api.MeterRegistry;
+import io.helidon.metrics.api.MetricsConfig;
+import io.helidon.metrics.api.MetricsFactory;
+import io.helidon.metrics.api.Timer;
+import io.helidon.service.registry.Services;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class MetricsRecordingJmhBenchmark {
+    private MeterRegistry meterRegistry;
+    private Counter counter;
+    private Timer timer;
+    private DistributionSummary distributionSummary;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        MetricsFactory metricsFactory = Services.get(MetricsFactory.class);
+        meterRegistry = metricsFactory.createMeterRegistry(MetricsConfig.builder()
+                                                                     .warnOnMultipleRegistries(false)
+                                                                     .build());
+        counter = meterRegistry.getOrCreate(metricsFactory.counterBuilder("metrics.recording.counter"));
+        timer = meterRegistry.getOrCreate(metricsFactory.timerBuilder("metrics.recording.timer"));
+        distributionSummary = meterRegistry.getOrCreate(metricsFactory.distributionSummaryBuilder(
+                "metrics.recording.summary",
+                metricsFactory.distributionStatisticsConfigBuilder()));
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        meterRegistry.close();
+    }
+
+    @Benchmark
+    public void recordCounter() {
+        counter.increment();
+    }
+
+    @Benchmark
+    public void recordTimer() {
+        timer.record(1, TimeUnit.MILLISECONDS);
+    }
+
+    @Benchmark
+    public void recordDistributionSummary() {
+        distributionSummary.record(1);
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/metrics/benchmark/jmh/MetricsRecordingJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/metrics/benchmark/jmh/MetricsRecordingJmhRunnerTest.java
@@ -27,24 +27,22 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-class MetricsFormatterJmhRunnerTest {
+class MetricsRecordingJmhRunnerTest {
     @Test
     void runExactBenchmark() throws RunnerException {
-        String benchmark = Pattern.quote(MetricsFormatterJmhBenchmark.class.getName());
-        String defaultInclude = "^" + benchmark
-                + "\\.format(Json|Prometheus)(Unfiltered|TagSelected(One|All)"
-                + "|DistinctFamilies(NameSelected|NameAndTagSelected|TagSelected(One|All)))$";
-        String include = System.getProperty("metrics.formatter.jmh.include", defaultInclude);
-        String result = System.getProperty("metrics.formatter.jmh.result", "target/metrics-formatter-jmh.json");
+        String benchmark = Pattern.quote(MetricsRecordingJmhBenchmark.class.getName());
+        String defaultInclude = "^" + benchmark + "\\.record(Counter|DistributionSummary|Timer)$";
+        String include = System.getProperty("metrics.recording.jmh.include", defaultInclude);
+        String result = System.getProperty("metrics.recording.jmh.result", "target/metrics-recording-jmh.json");
 
         Options options = new OptionsBuilder()
                 .include(include)
                 .threads(1)
-                .forks(Integer.getInteger("metrics.formatter.jmh.forks", 3))
-                .warmupIterations(Integer.getInteger("metrics.formatter.jmh.warmupIterations", 3))
-                .warmupTime(TimeValue.milliseconds(Long.getLong("metrics.formatter.jmh.warmupMillis", 1000)))
-                .measurementIterations(Integer.getInteger("metrics.formatter.jmh.measurementIterations", 5))
-                .measurementTime(TimeValue.milliseconds(Long.getLong("metrics.formatter.jmh.measurementMillis", 2000)))
+                .forks(Integer.getInteger("metrics.recording.jmh.forks", 3))
+                .warmupIterations(Integer.getInteger("metrics.recording.jmh.warmupIterations", 3))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("metrics.recording.jmh.warmupMillis", 1000)))
+                .measurementIterations(Integer.getInteger("metrics.recording.jmh.measurementIterations", 5))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("metrics.recording.jmh.measurementMillis", 2000)))
                 .addProfiler(GCProfiler.class)
                 .shouldFailOnError(true)
                 .resultFormat(ResultFormatType.JSON)

--- a/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
+++ b/tracing/providers/opentelemetry/src/main/java/io/helidon/tracing/providers/opentelemetry/OpenTelemetrySpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ class OpenTelemetrySpanContext implements SpanContext {
     @Override
     public String spanId() {
         return Span.fromContext(context).getSpanContext().getSpanId();
+    }
+
+    @Override
+    public boolean sampled() {
+        return Span.fromContext(context).getSpanContext().isSampled();
     }
 
     @Override

--- a/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestDataPropagation.java
+++ b/tracing/providers/opentelemetry/src/test/java/io/helidon/tracing/providers/opentelemetry/TestDataPropagation.java
@@ -28,6 +28,7 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.testing.junit5.OptionalMatcher;
 import io.helidon.service.registry.Services;
 import io.helidon.tracing.Scope;
+import io.helidon.tracing.SamplerType;
 import io.helidon.tracing.Span;
 import io.helidon.tracing.SpanContext;
 import io.helidon.tracing.Tracer;
@@ -42,6 +43,21 @@ class TestDataPropagation {
 
     private final OpenTelemetryDataPropagationProvider provider = new OpenTelemetryDataPropagationProvider();
     private final ExecutorService executor = Contexts.wrap(Executors.newVirtualThreadPerTaskExecutor());
+
+    @Test
+    void testUnsampledSpanContext() {
+        Tracer tracer = OpenTelemetryTracer.builder()
+                .serviceName("test-unsampled")
+                .samplerType(SamplerType.RATIO)
+                .samplerParam(0)
+                .build();
+        Span span = tracer.spanBuilder("test-span").start();
+        try {
+            assertThat("Span is not sampled", span.context().sampled(), is(false));
+        } finally {
+            span.end();
+        }
+    }
 
     @Test
     void testSyncPropagation() {

--- a/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/NoOpTracer.java
@@ -202,6 +202,11 @@ class NoOpTracer implements Tracer {
         }
 
         @Override
+        public boolean sampled() {
+            return false;
+        }
+
+        @Override
         public void asParent(io.helidon.tracing.Span.Builder<?> spanBuilder) {
         }
 

--- a/tracing/tracing/src/main/java/io/helidon/tracing/SpanContext.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/SpanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,17 @@ public interface SpanContext {
      * @return span id
      */
     String spanId();
+
+    /**
+     * Whether the associated span is sampled.
+     * Implementations should override this method to report the tracer's sampling decision. The default returns
+     * {@code true} for compatibility with existing implementations.
+     *
+     * @return whether the span is sampled
+     */
+    default boolean sampled() {
+        return true;
+    }
 
     /**
      * Configure this context as a parent of the provided builder.

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestRegistrySpecificPublisher.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestRegistrySpecificPublisher.java
@@ -29,7 +29,7 @@ import io.helidon.service.registry.ServiceRegistryManager;
 import io.helidon.service.registry.Services;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
### Description

## Release Note
____
Helidon now uses Prometheus Java Client 1.7.0 instead of the deprecated `simpleclient` integration. The new client’s metric-name normalization applies by default; applications requiring naming compatible with earlier Helidon releases can set `metrics.publishers.prometheus.naming-convention.non-letter-prefix` to `m_`. The legacy `metrics.prometheus.histogramFlavor` setting remains accepted but is ignored with a warning.
____

## Summary

Fixes #12487 by replacing the deprecated Prometheus `simpleclient` integration with Prometheus Java Client 1.7.0 through Micrometer’s `micrometer-registry-prometheus` module.

Resolves #9258.

The new Prometheus Java client uses updated normalization rules for metric names that begin with non-letter characters and strips reserved suffixes such as _total, _created, _bucket, and _info before applying type-specific suffixes. With this PR, Helidon's default is to adopt the new Prometheus Java client rules. Most applications using "well-behaved" meter names will see no difference in the Prometheus output. Applications that need output naming compatible with earlier Helidon releases can opt into legacy normalization using the new `naming-convention.non-letter-prefix` setting.

## Configuration

Adds `PrometheusNamingConventionConfig` with:

- `timer-suffix`, defaulting to `""`
- Optional `non-letter-prefix`

For example, the following selects the earlier Helidon/simpleclient naming behavior:

```yaml
metrics:
  publishers:
    prometheus:
      naming-convention:
        non-letter-prefix: "m_"
```

Equivalent programmatic configuration:

```java
PrometheusPublisher.builder()
        .namingConvention(builder -> builder.nonLetterPrefix("m_"))
        .build();
```

Valid non-letter prefixes must match `[A-Za-z][A-Za-z0-9_]*`.

If `non-letter-prefix` is absent, Helidon uses the new client’s naming convention. Setting it enables legacy-compatible normalization and also preserves user-supplied reserved suffixes such as `_total`, `_created`, `_bucket`, and `_info`.

The existing publisher `prefix` remains unchanged and controls Micrometer property lookup, not exported metric-name prefixing. The documentation also notes that the legacy `prometheus.histogramFlavor` property is no longer supported, although Helidon accepts it if present and logs a warning that it is ignored.

## Implementation

- Replaces `micrometer-registry-prometheus-simpleclient` and Prometheus simpleclient dependencies with the new Prometheus client model, registry, tracer, and exposition modules.
- Updates Maven dependency management, JPMS declarations, Javadocs, third-party licenses, and dependency-check metadata.
- Centralizes Prometheus registry construction in `PrometheusPublisher`.
- Adds a Helidon-owned legacy naming convention compatible with simpleclient behavior for supported Helidon meters.
- Preserves legacy counter, gauge, timer, and distribution-summary output suffixes.
- Prevents the new registry from interpreting legacy gauges ending in `.info` as Prometheus info metrics.
- Rejects primary and generated metric-family name collisions during registration so they cannot cause scrape failures.
- Updates selective scraping to match original Helidon meter names while deriving selectable families only from meters accepted by the Prometheus child registry, including separate `_max` families.
- Uses the new Prometheus text and OpenMetrics writers, with created-timestamp output disabled by default.
- Retains the existing public behavior of `normalizeNameToPrometheus(String)`.

## Exemplars

- Migrates from the simpleclient exemplar APIs to `io.prometheus.metrics.tracer.common.SpanContext`.
- Adds sampling-state reporting to Helidon `SpanContext`.
- Reports the actual OpenTelemetry sampling decision.
- Uses the propagated Helidon context consistently for trace ID, span ID, sampling state, and exemplar marking.

## Compatibility scope

Legacy-compatible naming covers meter types created by Helidon:

- Counters and functional counters
- Gauges
- Timers
- Distribution summaries

Long-task timers and arbitrary custom Micrometer meters are outside the compatibility scope.

## Testing

Added or updated tests covering:

- Default new-client normalization
- Legacy-compatible metric and tag naming
- Reserved-suffix preservation
- `.info` gauge behavior and naming collisions
- Registration-time collisions involving generated metric-family names
- Rejected normalized aliases remaining unavailable to selective scrape
- Counter, gauge, timer, and distribution-summary output
- Prometheus text and OpenMetrics formats
- Base units, descriptions, tags, histograms, and scopes
- Selective scraping and separate `_max` families
- Config and programmatic configuration
- Valid and invalid custom prefixes
- Custom timer suffixes
- Exemplar output, sampling state, and propagated-context marking
- Absence of simpleclient artifacts and use of Prometheus Java Client 1.7.0

Focused metrics, tracing, and exemplar tests pass, together with compilation, dependency convergence, Checkstyle, copyright validation, Javadocs, and whitespace checks.

### Documentation
Updated
