### PR TITLE
Update OpenTelemetry semantic conventions to 1.43.0 (27.x)

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -83,7 +83,7 @@
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
-        <version.lib.opentelemetry.semconv>1.37.0</version.lib.opentelemetry.semconv>
+        <version.lib.opentelemetry.semconv>1.43.0</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry>1.65.0</version.lib.opentelemetry>
         <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.13</version.lib.postgresql>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -222,21 +222,21 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-29181</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-39883</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-39882</cve>
@@ -280,7 +280,7 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-54285</cve>
@@ -298,14 +298,14 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-24051</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-41178</cve>


### PR DESCRIPTION
Resolves #12313

Updates the managed OpenTelemetry semantic-conventions Java artifact to 1.43.0 and aligns dependency-check suppression notes with the new JAR name.
