### PR TITLE
Adopt newer semantic conventions, including exposing newly-stable values

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -83,7 +83,7 @@
         <version.lib.narayana>7.1.0.Final</version.lib.narayana>
         <version.lib.ojdbc.family>23</version.lib.ojdbc.family>
         <version.lib.ojdbc>${version.lib.ojdbc.family}.26.1.0.0</version.lib.ojdbc>
-        <version.lib.opentelemetry.semconv>1.37.0</version.lib.opentelemetry.semconv>
+        <version.lib.opentelemetry.semconv>1.43.0</version.lib.opentelemetry.semconv>
         <version.lib.opentelemetry>1.65.0</version.lib.opentelemetry>
         <version.lib.parsson>1.1.9</version.lib.parsson>
         <version.lib.postgresql>42.7.13</version.lib.postgresql>

--- a/docs/config/io.helidon.telemetry.otelconfig.HelidonOpenTelemetry.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.HelidonOpenTelemetry.md
@@ -66,6 +66,20 @@ OpenTelemetry settings
 </tr>
 <tr>
 <td>
+<a id="resource"></a>
+<a href="io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md">
+<code>resource</code>
+</a>
+</td>
+<td>
+<code>Open<wbr>Telemetry<wbr>Resource<wbr>Config</code>
+</td>
+<td>
+</td>
+<td>Resource settings shared by all configured signals</td>
+</tr>
+<tr>
+<td>
 <code>service</code>
 </td>
 <td>

--- a/docs/config/io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md
+++ b/docs/config/io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md
@@ -1,0 +1,102 @@
+# io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Open<wbr>Telemetry<wbr>Resource<wbr>Config
+
+## Description
+
+OpenTelemetry resource settings shared by all configured signals
+
+## Configuration options
+
+
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>container-<wbr>id</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Identifier of the container in which the service instance is running</td>
+</tr>
+<tr>
+<td>
+<code>service-<wbr>namespace</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Namespace for the service</td>
+</tr>
+<tr>
+<td>
+<code>container-<wbr>image-<wbr>repo-<wbr>digests</code>
+</td>
+<td>
+<code>List&lt;<wbr>String&gt;</code>
+</td>
+<td>Repository digests of the container image as reported by the container runtime</td>
+</tr>
+<tr>
+<td>
+<code>container-<wbr>image-<wbr>name</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Name of the container image on which the container was built</td>
+</tr>
+<tr>
+<td>
+<code>service-<wbr>instance-<wbr>id</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Identifier for this service instance</td>
+</tr>
+<tr>
+<td>
+<code>container-<wbr>image-<wbr>tags</code>
+</td>
+<td>
+<code>List&lt;<wbr>String&gt;</code>
+</td>
+<td>Tags of the container image on which the container was built</td>
+</tr>
+<tr>
+<td>
+<code>attributes</code>
+</td>
+<td>
+<code>Custom<wbr>Methods</code>
+</td>
+<td>Additional resource attributes shared by all configured signals</td>
+</tr>
+<tr>
+<td>
+<code>deployment-<wbr>environment-<wbr>name</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>Name of the deployment environment</td>
+</tr>
+</tbody>
+</table>
+
+
+
+## Usages
+
+- <a href="io.helidon.telemetry.otelconfig.HelidonOpenTelemetry.md#resource"><code>telemetry.<wbr>resource</code></a>
+
+---
+
+See the [manifest](manifest.md) for all available types.

--- a/docs/config/manifest.md
+++ b/docs/config/manifest.md
@@ -91,6 +91,7 @@ See the [root type](config_reference.md).
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Metric<wbr>Reader<wbr>Config](io.helidon.telemetry.otelconfig.MetricReaderConfig.md)
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Open<wbr>Telemetry<wbr>Logging<wbr>Config](io.helidon.telemetry.otelconfig.OpenTelemetryLoggingConfig.md)
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Open<wbr>Telemetry<wbr>Metrics<wbr>Config](io.helidon.telemetry.otelconfig.OpenTelemetryMetricsConfig.md)
+- [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Open<wbr>Telemetry<wbr>Resource<wbr>Config](io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md)
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Open<wbr>Telemetry<wbr>Tracing<wbr>Config](io.helidon.telemetry.otelconfig.OpenTelemetryTracingConfig.md)
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Otlp<wbr>Exporter<wbr>Config](io.helidon.telemetry.otelconfig.OtlpExporterConfig.md)
 - [io.<wbr>helidon.<wbr>telemetry.<wbr>otelconfig.<wbr>Otlp<wbr>Http<wbr>Exporter<wbr>Config](io.helidon.telemetry.otelconfig.OtlpHttpExporterConfig.md)

--- a/docs/modules/telemetry/opentelemetry.md
+++ b/docs/modules/telemetry/opentelemetry.md
@@ -38,6 +38,7 @@ The Helidon OpenTelemetry configuration format, the Helidon OpenTelemetry API,
 and this documentation all follow this hierarchy:
 
 - [Top-level telemetry](#configuration-options)
+  - [Resource attributes](#resource-attributes)
   - Signals
     - [Tracing](#tracing-configuration)
     - [Metrics](#metrics-configuration)
@@ -294,8 +295,8 @@ telemetry:
     container-image-name: registry.example.com/retail/checkout
     container-image-tags: [latest, "2.1"]
     container-image-repo-digests:
-      - "checkout@sha256:first"
-      - "checkout@sha256:second"
+      - "registry.example.com/retail/checkout@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      - "mirror.example.com/retail/checkout@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     attributes:
       strings:
         service.version: "2.1"
@@ -320,8 +321,11 @@ OpenTelemetryResourceConfig resourceConfig = OpenTelemetryResourceConfig.builder
         .containerId("container-123")
         .containerImageName("registry.example.com/retail/checkout")
         .containerImageTags(List.of("latest", "2.1"))
-        .containerImageRepoDigests(List.of("checkout@sha256:first",
-                                           "checkout@sha256:second"))
+        .containerImageRepoDigests(List.of(
+                "registry.example.com/retail/checkout@sha256:"
+                        + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                "mirror.example.com/retail/checkout@sha256:"
+                        + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"))
         .attributes(Attributes.builder().put("service.version", "2.1"))
         .build();
 

--- a/docs/modules/telemetry/opentelemetry.md
+++ b/docs/modules/telemetry/opentelemetry.md
@@ -255,13 +255,93 @@ Notes:
   unchanged and uses the existing global as the application `OpenTelemetry`
   instance.
 
+## Resource Attributes
+
+An OpenTelemetry resource describes the entity producing telemetry. Helidon
+always sets `service.name` from the required top-level `telemetry.service`
+setting. You can also configure these stable semantic-convention resource
+attributes under `telemetry.resource`:
+
+- `service-namespace` sets `service.namespace`.
+- `service-instance-id` sets `service.instance.id`.
+- `deployment-environment-name` sets `deployment.environment.name`.
+- `container-id` sets `container.id`.
+- `container-image-name` sets `container.image.name`.
+- `container-image-tags` sets `container.image.tags`.
+- `container-image-repo-digests` sets `container.image.repo_digests`.
+
+Helidon does not invent values for these optional settings. In particular, it
+does not generate a service instance ID or detect container metadata. If a
+setting is absent, Helidon does not explicitly add or override that attribute.
+
+### Configuration options
+
+<!--@include ../../config/io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md#configuration-options delim=--- offset=3 collapseTables=10 -->
+See [Configuration options][io-helidon-telem-resource].
+<!--/include-->
+
+The resource `attributes` section accepts scalar values grouped under
+`strings`, `longs`, `doubles`, and `booleans`.
+
+```yaml
+telemetry:
+  service: checkout
+  resource:
+    service-namespace: retail
+    service-instance-id: checkout-7f3a
+    deployment-environment-name: production
+    container-id: container-123
+    container-image-name: registry.example.com/retail/checkout
+    container-image-tags: [latest, "2.1"]
+    container-image-repo-digests:
+      - "checkout@sha256:first"
+      - "checkout@sha256:second"
+    attributes:
+      strings:
+        service.version: "2.1"
+      longs:
+        application.shard: 3
+```
+
+The resource attributes apply to every signal provider Helidon constructs.
+When the same key is set more than once, the precedence from lowest to highest
+is the OpenTelemetry default resource, common `telemetry.resource.attributes`,
+the signal-specific `telemetry.signals.<signal>.attributes`, and the
+first-class resource settings listed above. The required `telemetry.service`
+setting always determines `service.name`.
+
+Applications can configure the same settings programmatically.
+
+```java
+OpenTelemetryResourceConfig resourceConfig = OpenTelemetryResourceConfig.builder()
+        .serviceNamespace("retail")
+        .serviceInstanceId("checkout-7f3a")
+        .deploymentEnvironmentName("production")
+        .containerId("container-123")
+        .containerImageName("registry.example.com/retail/checkout")
+        .containerImageTags(List.of("latest", "2.1"))
+        .containerImageRepoDigests(List.of("checkout@sha256:first",
+                                           "checkout@sha256:second"))
+        .attributes(Attributes.builder().put("service.version", "2.1"))
+        .build();
+
+OpenTelemetryConfig.Builder telemetryConfigBuilder = OpenTelemetryConfig.builder()
+        .service("checkout")
+        .resource(resourceConfig);
+```
+
+If application code supplies an `OpenTelemetry` instance explicitly to the
+Helidon builder, that instance takes precedence over settings which Helidon
+would otherwise use to construct the SDK. The application is then responsible
+for assigning its resource.
+
 ## Signal Attributes
 
-Attributes are key/value pairs that OpenTelemetry attaches to each transmission
-of a signal.
+The existing attributes under each signal are resource attributes which apply
+only to that signal's provider.
 
-OpenTelemetry supports attributes of type `String`, `long`, `double`, and
-`boolean`.
+Helidon configuration supports scalar OpenTelemetry attributes of type
+`String`, `long`, `double`, and `boolean`.
 
 The Helidon configuration structure groups attributes by type so Helidon can
 indicate precisely to OpenTelemetry what type you intend for each attribute.
@@ -282,19 +362,20 @@ The following example shows attribute settings for the tracing signal.
 ```yaml
 telemetry:
   service: my-helidon-service
-  tracing:
-    attributes:
-      strings:
-        attr1: 12
-        attr5: "any old thing"
-        attr7: something
-      longs:
-        attr2: 12
-      doubles:
-        attr3: 24.5
-        attr6: 12
-      booleans:
-        attr4: true
+  signals:
+    tracing:
+      attributes:
+        strings:
+          attr1: 12
+          attr5: "any old thing"
+          attr7: something
+        longs:
+          attr2: 12
+        doubles:
+          attr3: 24.5
+          attr6: 12
+        booleans:
+          attr4: true
 ```
 
 ## Processors & Readers
@@ -928,7 +1009,7 @@ telemetry:
 - [Intro to OpenTelemetry Java][intro-to-opentel]
 
 [preview-feature]: https://helidon.io/docs/v27/apidocs/io.helidon.common.features.api/io/helidon/common/features/api/Features.Preview.html
-[opentelemetry-se]: https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/http/http-spans.md#http-server
+[opentelemetry-se]: https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/http/http-spans.md#http-server
 [publishing-helid]: ../metrics/metrics.md#publishing-metrics
 [signals]: https://opentelemetry.io/docs/concepts/signals/
 [helidon-opentele]: https://helidon.io/docs/v27/apidocs/io.helidon.telemetry.otelconfig/io/helidon/telemetry/otelconfig/package-summary.html
@@ -949,6 +1030,7 @@ telemetry:
 [oracle-apm]: https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html
 [io-helidon-telem]: ../../config/io.helidon.telemetry.otelconfig.HelidonOpenTelemetry.md#configuration-options
 [io-helidon-telem-2]: ../../config/io.helidon.telemetry.otelconfig.TypedAttributes.md#configuration-options
+[io-helidon-telem-resource]: ../../config/io.helidon.telemetry.otelconfig.OpenTelemetryResourceConfig.md#configuration-options
 [io-helidon-telem-3]: ../../config/io.helidon.telemetry.otelconfig.BatchProcessorConfig.md#configuration-options
 [io-helidon-telem-4]: ../../config/io.helidon.telemetry.otelconfig.OtlpExporterConfig.md#configuration-options
 [io-helidon-telem-5]: ../../config/io.helidon.telemetry.otelconfig.RetryPolicyConfig.md#configuration-options

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -222,21 +222,21 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-29181</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-39883</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-39882</cve>
@@ -280,7 +280,7 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-54285</cve>
@@ -298,14 +298,14 @@
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-24051</cve>
 </suppress>
 <suppress>
     <notes><![CDATA[
-    file name: opentelemetry-semconv-1.37.0.jar
+    file name: opentelemetry-semconv-1.43.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
     <cve>CVE-2026-41178</cve>

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -31,6 +31,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 @Prototype.Blueprint(decorator = OpenTelemetryConfigSupport.BuildDecorator.class)
 @Prototype.Configured("telemetry")
 @Prototype.CustomMethods(OpenTelemetryConfigSupport.CustomMethods.class)
+@Prototype.IncludeDefaultMethods("resource")
 interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTelemetry> {
 
     /**
@@ -48,7 +49,9 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
      * @return resource settings
      */
     @Option.Configured
-    Optional<OpenTelemetryResourceConfig> resource();
+    default Optional<OpenTelemetryResourceConfig> resource() {
+        return Optional.empty();
+    }
 
     /**
      * Whether the OpenTelemetry support is enabled.

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigBlueprint.java
@@ -43,6 +43,14 @@ interface OpenTelemetryConfigBlueprint extends Prototype.Factory<HelidonOpenTele
     String service();
 
     /**
+     * Resource settings shared by all configured signals.
+     *
+     * @return resource settings
+     */
+    @Option.Configured
+    Optional<OpenTelemetryResourceConfig> resource();
+
+    /**
      * Whether the OpenTelemetry support is enabled.
      *
      * @return true if enabled; false otherwise

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryConfigSupport.java
@@ -24,10 +24,14 @@ import io.helidon.builder.api.Prototype;
 import io.helidon.config.Config;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.ContainerAttributes;
+import io.opentelemetry.semconv.DeploymentAttributes;
 import io.opentelemetry.semconv.ServiceAttributes;
 
 final class OpenTelemetryConfigSupport {
@@ -52,10 +56,7 @@ final class OpenTelemetryConfigSupport {
             var tracingBuilderInfo = tracingConfig.tracingBuilderInfo();
             var sdkTracerProviderBuilder = tracingBuilderInfo.sdkTracerProviderBuilder();
 
-            var attributesBuilder = tracingConfig.tracingBuilderInfo().attributesBuilder();
-            attributesBuilder.put(ServiceAttributes.SERVICE_NAME, target.service().orElseThrow());
-
-            var resource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
+            var resource = resource(target, tracingConfig.tracingBuilderInfo().attributesBuilder());
             sdkTracerProviderBuilder.setResource(resource);
 
             openTelemetrySdkBuilder.setTracerProvider(sdkTracerProviderBuilder.build());
@@ -66,10 +67,7 @@ final class OpenTelemetryConfigSupport {
             var metricsBuilderInfo = metricsConfig.metricsBuilderInfo();
             var sdkMeterProviderBuilder = metricsBuilderInfo.sdkMeterProviderBuilder();
 
-            var attributesBuilder = metricsConfig.metricsBuilderInfo().attributesBuilder();
-            attributesBuilder.put(ServiceAttributes.SERVICE_NAME, target.service().orElseThrow());
-
-            var resource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
+            var resource = resource(target, metricsConfig.metricsBuilderInfo().attributesBuilder());
             sdkMeterProviderBuilder.setResource(resource);
 
             openTelemetrySdkBuilder.setMeterProvider(sdkMeterProviderBuilder.build());
@@ -80,10 +78,7 @@ final class OpenTelemetryConfigSupport {
             var loggingBuilderInfo = loggingConfig.loggingBuilderInfo();
             var sdkLoggerProviderBuilder = loggingBuilderInfo.sdkLoggerProviderBuilder();
 
-            var attributesBuilder = loggingConfig.loggingBuilderInfo().attributesBuilder();
-            attributesBuilder.put(ServiceAttributes.SERVICE_NAME, target.service().orElseThrow());
-
-            var resource = Resource.getDefault().merge(Resource.create(attributesBuilder.build()));
+            var resource = resource(target, loggingConfig.loggingBuilderInfo().attributesBuilder());
             sdkLoggerProviderBuilder.setResource(resource);
 
             openTelemetrySdkBuilder.setLoggerProvider(sdkLoggerProviderBuilder.build());
@@ -92,6 +87,43 @@ final class OpenTelemetryConfigSupport {
         var sdk = openTelemetrySdkBuilder.build();
         target.openTelemetrySdk(sdk);
         return sdk;
+    }
+
+    private static Resource resource(OpenTelemetryConfig.BuilderBase<?, ?> target,
+                                     AttributesBuilder signalAttributesBuilder) {
+        var resourceConfig = target.resource();
+        var commonAttributes = resourceConfig
+                .flatMap(OpenTelemetryResourceConfig::attributes)
+                .map(AttributesBuilder::build)
+                .orElseGet(Attributes::empty);
+
+        var semanticAttributesBuilder = Attributes.builder()
+                .put(ServiceAttributes.SERVICE_NAME, target.service().orElseThrow());
+        resourceConfig.ifPresent(config -> {
+            config.serviceNamespace().ifPresent(value -> semanticAttributesBuilder.put(ServiceAttributes.SERVICE_NAMESPACE,
+                                                                                        value));
+            config.serviceInstanceId().ifPresent(value -> semanticAttributesBuilder.put(ServiceAttributes.SERVICE_INSTANCE_ID,
+                                                                                         value));
+            config.deploymentEnvironmentName()
+                    .ifPresent(value -> semanticAttributesBuilder.put(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME,
+                                                                      value));
+            config.containerId().ifPresent(value -> semanticAttributesBuilder.put(ContainerAttributes.CONTAINER_ID,
+                                                                                  value));
+            config.containerImageName()
+                    .ifPresent(value -> semanticAttributesBuilder.put(ContainerAttributes.CONTAINER_IMAGE_NAME, value));
+            if (!config.containerImageTags().isEmpty()) {
+                semanticAttributesBuilder.put(ContainerAttributes.CONTAINER_IMAGE_TAGS, config.containerImageTags());
+            }
+            if (!config.containerImageRepoDigests().isEmpty()) {
+                semanticAttributesBuilder.put(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS,
+                                              config.containerImageRepoDigests());
+            }
+        });
+
+        return Resource.getDefault()
+                .merge(Resource.create(commonAttributes))
+                .merge(Resource.create(signalAttributesBuilder.build()))
+                .merge(Resource.create(semanticAttributesBuilder.build()));
     }
 
     static class BuildDecorator implements Prototype.BuilderDecorator<OpenTelemetryConfig.BuilderBase<?, ?>> {

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryResourceConfigBlueprint.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryResourceConfigBlueprint.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+
+/**
+ * OpenTelemetry resource settings shared by all configured signals.
+ * Optional values left unspecified do not add or override resource attributes.
+ */
+@Prototype.Blueprint
+@Prototype.Configured
+@Prototype.CustomMethods(OpenTelemetryResourceConfigSupport.CustomMethods.class)
+interface OpenTelemetryResourceConfigBlueprint {
+
+    /**
+     * Namespace for the service.
+     *
+     * @return service namespace
+     */
+    @Option.Configured
+    Optional<String> serviceNamespace();
+
+    /**
+     * Identifier for this service instance.
+     *
+     * @return service instance ID
+     */
+    @Option.Configured
+    Optional<String> serviceInstanceId();
+
+    /**
+     * Name of the deployment environment.
+     *
+     * @return deployment environment name
+     */
+    @Option.Configured
+    Optional<String> deploymentEnvironmentName();
+
+    /**
+     * Identifier of the container in which the service instance is running.
+     *
+     * @return container ID
+     */
+    @Option.Configured
+    Optional<String> containerId();
+
+    /**
+     * Name of the container image on which the container was built.
+     *
+     * @return container image name
+     */
+    @Option.Configured
+    Optional<String> containerImageName();
+
+    /**
+     * Tags of the container image on which the container was built.
+     *
+     * @return container image tags
+     */
+    @Option.Configured
+    @Option.Singular
+    List<String> containerImageTags();
+
+    /**
+     * Repository digests of the container image as reported by the container runtime.
+     *
+     * @return container image repository digests
+     */
+    @Option.Configured
+    @Option.Singular
+    List<String> containerImageRepoDigests();
+
+    /**
+     * Additional resource attributes shared by all configured signals.
+     *
+     * @return additional resource attributes
+     */
+    @Option.Configured
+    Optional<AttributesBuilder> attributes();
+}

--- a/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryResourceConfigSupport.java
+++ b/telemetry/opentelemetry-config/src/main/java/io/helidon/telemetry/otelconfig/OpenTelemetryResourceConfigSupport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.config.Config;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+
+final class OpenTelemetryResourceConfigSupport {
+
+    private OpenTelemetryResourceConfigSupport() {
+    }
+
+    static class CustomMethods {
+
+        private CustomMethods() {
+        }
+
+        @Prototype.ConfigFactoryMethod("attributes")
+        static AttributesBuilder createAttributesBuilder(Config config) {
+            return OtelConfigSupport.createAttributesBuilder(config);
+        }
+    }
+}

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestResourceConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestResourceConfig.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.telemetry.otelconfig;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.ContainerAttributes;
+import io.opentelemetry.semconv.DeploymentAttributes;
+import io.opentelemetry.semconv.ServiceAttributes;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+class TestResourceConfig {
+
+    private static final AttributeKey<String> CUSTOM_STRING = AttributeKey.stringKey("custom.string");
+    private static final AttributeKey<Long> CUSTOM_LONG = AttributeKey.longKey("custom.long");
+    private static final AttributeKey<Double> CUSTOM_DOUBLE = AttributeKey.doubleKey("custom.double");
+    private static final AttributeKey<Boolean> CUSTOM_BOOLEAN = AttributeKey.booleanKey("custom.boolean");
+    private static final AttributeKey<String> PRECEDENCE = AttributeKey.stringKey("custom.precedence");
+
+    @Test
+    void testDeclarativeResourceAttributesOnAllSignals() {
+        var config = Config.just(ConfigSources.create(
+                """
+                        telemetry:
+                          service: checkout
+                          global: false
+                          resource:
+                            service-namespace: retail
+                            service-instance-id: checkout-7f3a
+                            deployment-environment-name: production
+                            container-id: container-123
+                            container-image-name: registry.example.com/retail/checkout
+                            container-image-tags: [latest, "2.1"]
+                            container-image-repo-digests:
+                              - "checkout@sha256:first"
+                              - "checkout@sha256:second"
+                            attributes:
+                              strings:
+                                custom.string: common
+                                custom.precedence: common
+                                service.name: common-service
+                                service.namespace: common-namespace
+                              longs:
+                                custom.long: 3
+                              doubles:
+                                custom.double: 4.5
+                              booleans:
+                                custom.boolean: true
+                          signals:
+                            tracing:
+                              attributes:
+                                strings:
+                                  custom.precedence: tracing
+                                  service.name: tracing-service
+                                  service.namespace: tracing-namespace
+                            metrics:
+                              attributes:
+                                strings:
+                                  custom.precedence: metrics
+                                  service.name: metrics-service
+                                  service.namespace: metrics-namespace
+                            logging:
+                              attributes:
+                                strings:
+                                  custom.precedence: logging
+                                  service.name: logging-service
+                                  service.namespace: logging-namespace
+                        """,
+                MediaTypes.APPLICATION_YAML));
+
+        var spanExporter = new CapturingSpanExporter();
+        var metricExporter = new CapturingMetricExporter();
+        var logExporter = new CapturingLogRecordExporter();
+        var builder = OpenTelemetryConfig.builder().config(config.get("telemetry"));
+
+        builder.tracing(OpenTelemetryTracingConfig.builder(builder.tracing().orElseThrow())
+                                .addProcessor(SimpleSpanProcessor.create(spanExporter))
+                                .build());
+        builder.metrics(OpenTelemetryMetricsConfig.builder(builder.metrics().orElseThrow())
+                                .addReader(PeriodicMetricReader.create(metricExporter))
+                                .build());
+        builder.logging(OpenTelemetryLoggingConfig.builder(builder.logging().orElseThrow())
+                                .addProcessor(SimpleLogRecordProcessor.create(logExporter))
+                                .build());
+
+        var telemetryConfig = builder.buildPrototype();
+        var resourceConfig = telemetryConfig.resource().orElseThrow();
+        assertThat(resourceConfig.serviceNamespace().orElseThrow(), is("retail"));
+        assertThat(resourceConfig.serviceInstanceId().orElseThrow(), is("checkout-7f3a"));
+        assertThat(resourceConfig.deploymentEnvironmentName().orElseThrow(), is("production"));
+        assertThat(resourceConfig.containerId().orElseThrow(), is("container-123"));
+        assertThat(resourceConfig.containerImageName().orElseThrow(),
+                   is("registry.example.com/retail/checkout"));
+        assertThat(resourceConfig.containerImageTags(), is(List.of("latest", "2.1")));
+        assertThat(resourceConfig.containerImageRepoDigests(),
+                   is(List.of("checkout@sha256:first", "checkout@sha256:second")));
+
+        try (var sdk = telemetryConfig.openTelemetrySdk()) {
+            sdk.getTracer("resource-test").spanBuilder("test-span").startSpan().end();
+            sdk.getMeter("resource-test").counterBuilder("test-counter").build().add(1);
+            assertThat(sdk.getSdkMeterProvider().forceFlush().join(5, TimeUnit.SECONDS).isSuccess(), is(true));
+            sdk.getLogsBridge().get("resource-test").logRecordBuilder().setBody("test-log").emit();
+
+            assertResource(spanExporter.resource(), "tracing");
+            assertResource(metricExporter.resource(), "metrics");
+            assertResource(logExporter.resource(), "logging");
+        }
+    }
+
+    @Test
+    void testProgrammaticResourceAttributes() {
+        var spanExporter = new CapturingSpanExporter();
+        var resourceConfig = OpenTelemetryResourceConfig.builder()
+                .serviceNamespace("programmatic-namespace")
+                .serviceInstanceId("programmatic-instance")
+                .deploymentEnvironmentName("programmatic-environment")
+                .containerId("programmatic-container")
+                .containerImageName("registry.example.com/programmatic")
+                .containerImageTags(List.of("latest", "3.0"))
+                .containerImageRepoDigests(List.of("programmatic@sha256:first", "programmatic@sha256:second"))
+                .attributes(Attributes.builder()
+                                    .put(CUSTOM_STRING, "programmatic-string")
+                                    .put(CUSTOM_LONG, 7L)
+                                    .put(CUSTOM_DOUBLE, 8.5)
+                                    .put(CUSTOM_BOOLEAN, true))
+                .build();
+        var telemetryConfig = OpenTelemetryConfig.builder()
+                .service("programmatic-service")
+                .global(false)
+                .resource(resourceConfig)
+                .tracing(OpenTelemetryTracingConfig.builder()
+                                 .addProcessor(SimpleSpanProcessor.create(spanExporter))
+                                 .build())
+                .buildPrototype();
+
+        try (var sdk = telemetryConfig.openTelemetrySdk()) {
+            sdk.getTracer("resource-test").spanBuilder("test-span").startSpan().end();
+            var resource = spanExporter.resource();
+            assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAME), is("programmatic-service"));
+            assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAMESPACE), is("programmatic-namespace"));
+            assertThat(resource.getAttribute(ServiceAttributes.SERVICE_INSTANCE_ID), is("programmatic-instance"));
+            assertThat(resource.getAttribute(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME),
+                       is("programmatic-environment"));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_ID), is("programmatic-container"));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_NAME),
+                       is("registry.example.com/programmatic"));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS), is(List.of("latest", "3.0")));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS),
+                       is(List.of("programmatic@sha256:first", "programmatic@sha256:second")));
+            assertThat(resource.getAttribute(CUSTOM_STRING), is("programmatic-string"));
+            assertThat(resource.getAttribute(CUSTOM_LONG), is(7L));
+            assertThat(resource.getAttribute(CUSTOM_DOUBLE), is(8.5));
+            assertThat(resource.getAttribute(CUSTOM_BOOLEAN), is(true));
+        }
+    }
+
+    @Test
+    void testOmittedResourceSettingsPreserveDefaults() {
+        var spanExporter = new CapturingSpanExporter();
+        var telemetryConfig = OpenTelemetryConfig.builder()
+                .service("default-resource-service")
+                .global(false)
+                .tracing(OpenTelemetryTracingConfig.builder()
+                                 .addProcessor(SimpleSpanProcessor.create(spanExporter))
+                                 .build())
+                .buildPrototype();
+
+        try (var sdk = telemetryConfig.openTelemetrySdk()) {
+            sdk.getTracer("resource-test").spanBuilder("test-span").startSpan().end();
+            var resource = spanExporter.resource();
+            var defaultResource = Resource.getDefault();
+            assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAMESPACE),
+                       is(defaultResource.getAttribute(ServiceAttributes.SERVICE_NAMESPACE)));
+            assertThat(resource.getAttribute(ServiceAttributes.SERVICE_INSTANCE_ID),
+                       is(defaultResource.getAttribute(ServiceAttributes.SERVICE_INSTANCE_ID)));
+            assertThat(resource.getAttribute(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME),
+                       is(defaultResource.getAttribute(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME)));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_ID),
+                       is(defaultResource.getAttribute(ContainerAttributes.CONTAINER_ID)));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_NAME),
+                       is(defaultResource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_NAME)));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS),
+                       is(defaultResource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS)));
+            assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS),
+                       is(defaultResource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS)));
+        }
+    }
+
+    @Test
+    void testSuppliedOpenTelemetryTakesPrecedence() {
+        var supplied = OpenTelemetry.noop();
+        var telemetryConfig = OpenTelemetryConfig.builder()
+                .service("ignored-service")
+                .resource(OpenTelemetryResourceConfig.builder()
+                                  .serviceNamespace("ignored-namespace")
+                                  .build())
+                .openTelemetry(supplied)
+                .buildPrototype();
+
+        assertThat(telemetryConfig.openTelemetry(), sameInstance(supplied));
+        telemetryConfig.openTelemetrySdk().close();
+    }
+
+    private static void assertResource(Resource resource, String expectedPrecedence) {
+        assertThat(resource, is(notNullValue()));
+        assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAME), is("checkout"));
+        assertThat(resource.getAttribute(ServiceAttributes.SERVICE_NAMESPACE), is("retail"));
+        assertThat(resource.getAttribute(ServiceAttributes.SERVICE_INSTANCE_ID), is("checkout-7f3a"));
+        assertThat(resource.getAttribute(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME), is("production"));
+        assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_ID), is("container-123"));
+        assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_NAME),
+                   is("registry.example.com/retail/checkout"));
+        assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS), is(List.of("latest", "2.1")));
+        assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS),
+                   is(List.of("checkout@sha256:first", "checkout@sha256:second")));
+        assertThat(resource.getAttribute(CUSTOM_STRING), is("common"));
+        assertThat(resource.getAttribute(CUSTOM_LONG), is(3L));
+        assertThat(resource.getAttribute(CUSTOM_DOUBLE), is(4.5));
+        assertThat(resource.getAttribute(CUSTOM_BOOLEAN), is(true));
+        assertThat(resource.getAttribute(PRECEDENCE), is(expectedPrecedence));
+    }
+
+    private static CompletableResultCode success() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    private static final class CapturingSpanExporter implements SpanExporter {
+        private final AtomicReference<Resource> resource = new AtomicReference<>();
+
+        @Override
+        public CompletableResultCode export(Collection<SpanData> spans) {
+            resource.set(spans.iterator().next().getResource());
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return success();
+        }
+
+        private Resource resource() {
+            return resource.get();
+        }
+    }
+
+    private static final class CapturingMetricExporter implements MetricExporter {
+        private final AtomicReference<Resource> resource = new AtomicReference<>();
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.CUMULATIVE;
+        }
+
+        @Override
+        public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
+            return Aggregation.defaultAggregation();
+        }
+
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            resource.set(metrics.iterator().next().getResource());
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return success();
+        }
+
+        private Resource resource() {
+            return resource.get();
+        }
+    }
+
+    private static final class CapturingLogRecordExporter implements LogRecordExporter {
+        private final AtomicReference<Resource> resource = new AtomicReference<>();
+
+        @Override
+        public CompletableResultCode export(Collection<LogRecordData> logs) {
+            resource.set(logs.iterator().next().getResource());
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return success();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            return success();
+        }
+
+        private Resource resource() {
+            return resource.get();
+        }
+    }
+}

--- a/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestResourceConfig.java
+++ b/telemetry/opentelemetry-config/src/test/java/io/helidon/telemetry/otelconfig/TestResourceConfig.java
@@ -54,6 +54,12 @@ import static org.hamcrest.Matchers.sameInstance;
 
 class TestResourceConfig {
 
+    private static final String IMAGE_DIGEST = "sha256:"
+            + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private static final String CHECKOUT_REPO_DIGEST = "registry.example.com/retail/checkout@" + IMAGE_DIGEST;
+    private static final String CHECKOUT_MIRROR_REPO_DIGEST = "mirror.example.com/retail/checkout@" + IMAGE_DIGEST;
+    private static final String PROGRAMMATIC_REPO_DIGEST = "registry.example.com/programmatic@" + IMAGE_DIGEST;
+    private static final String PROGRAMMATIC_MIRROR_REPO_DIGEST = "mirror.example.com/programmatic@" + IMAGE_DIGEST;
     private static final AttributeKey<String> CUSTOM_STRING = AttributeKey.stringKey("custom.string");
     private static final AttributeKey<Long> CUSTOM_LONG = AttributeKey.longKey("custom.long");
     private static final AttributeKey<Double> CUSTOM_DOUBLE = AttributeKey.doubleKey("custom.double");
@@ -75,8 +81,8 @@ class TestResourceConfig {
                             container-image-name: registry.example.com/retail/checkout
                             container-image-tags: [latest, "2.1"]
                             container-image-repo-digests:
-                              - "checkout@sha256:first"
-                              - "checkout@sha256:second"
+                              - "%s"
+                              - "%s"
                             attributes:
                               strings:
                                 custom.string: common
@@ -108,7 +114,7 @@ class TestResourceConfig {
                                   custom.precedence: logging
                                   service.name: logging-service
                                   service.namespace: logging-namespace
-                        """,
+                        """.formatted(CHECKOUT_REPO_DIGEST, CHECKOUT_MIRROR_REPO_DIGEST),
                 MediaTypes.APPLICATION_YAML));
 
         var spanExporter = new CapturingSpanExporter();
@@ -136,7 +142,7 @@ class TestResourceConfig {
                    is("registry.example.com/retail/checkout"));
         assertThat(resourceConfig.containerImageTags(), is(List.of("latest", "2.1")));
         assertThat(resourceConfig.containerImageRepoDigests(),
-                   is(List.of("checkout@sha256:first", "checkout@sha256:second")));
+                   is(List.of(CHECKOUT_REPO_DIGEST, CHECKOUT_MIRROR_REPO_DIGEST)));
 
         try (var sdk = telemetryConfig.openTelemetrySdk()) {
             sdk.getTracer("resource-test").spanBuilder("test-span").startSpan().end();
@@ -160,7 +166,7 @@ class TestResourceConfig {
                 .containerId("programmatic-container")
                 .containerImageName("registry.example.com/programmatic")
                 .containerImageTags(List.of("latest", "3.0"))
-                .containerImageRepoDigests(List.of("programmatic@sha256:first", "programmatic@sha256:second"))
+                .containerImageRepoDigests(List.of(PROGRAMMATIC_REPO_DIGEST, PROGRAMMATIC_MIRROR_REPO_DIGEST))
                 .attributes(Attributes.builder()
                                     .put(CUSTOM_STRING, "programmatic-string")
                                     .put(CUSTOM_LONG, 7L)
@@ -189,7 +195,7 @@ class TestResourceConfig {
                        is("registry.example.com/programmatic"));
             assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS), is(List.of("latest", "3.0")));
             assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS),
-                       is(List.of("programmatic@sha256:first", "programmatic@sha256:second")));
+                       is(List.of(PROGRAMMATIC_REPO_DIGEST, PROGRAMMATIC_MIRROR_REPO_DIGEST)));
             assertThat(resource.getAttribute(CUSTOM_STRING), is("programmatic-string"));
             assertThat(resource.getAttribute(CUSTOM_LONG), is(7L));
             assertThat(resource.getAttribute(CUSTOM_DOUBLE), is(8.5));
@@ -255,7 +261,7 @@ class TestResourceConfig {
                    is("registry.example.com/retail/checkout"));
         assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_TAGS), is(List.of("latest", "2.1")));
         assertThat(resource.getAttribute(ContainerAttributes.CONTAINER_IMAGE_REPO_DIGESTS),
-                   is(List.of("checkout@sha256:first", "checkout@sha256:second")));
+                   is(List.of(CHECKOUT_REPO_DIGEST, CHECKOUT_MIRROR_REPO_DIGEST)));
         assertThat(resource.getAttribute(CUSTOM_STRING), is("common"));
         assertThat(resource.getAttribute(CUSTOM_LONG), is(3L));
         assertThat(resource.getAttribute(CUSTOM_DOUBLE), is(4.5));

--- a/webserver/observe/telemetry/tracing/src/main/java/io/helidon/observe/telemetry/tracing/OpenTelemetryTracingSemanticConventionsProvider.java
+++ b/webserver/observe/telemetry/tracing/src/main/java/io/helidon/observe/telemetry/tracing/OpenTelemetryTracingSemanticConventionsProvider.java
@@ -46,7 +46,7 @@ class OpenTelemetryTracingSemanticConventionsProvider implements TracingSemantic
     /**
      * Supplies span information conforming to the OpenTelemetry semantic conventions for requests.
      * <p>
-     * See <a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/http/http-spans.md">the
+     * See <a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/http/http-spans.md">the
      * OpenTelemetry tracing semantic conventions.</a>
      */
     static class SemanticConventions implements TracingSemanticConventions {


### PR DESCRIPTION
## Release note

OpenTelemetry integration now uses stable semantic conventions 1.43.0. Applications can configure common service, deployment, container, and custom resource attributes under `telemetry.resource`; Helidon applies them consistently to tracing, metrics, and logging providers.

## Summary

Updates Helidon’s stable OpenTelemetry Java semantic-conventions dependency from 1.37.0 to 1.43.0 and adds first-class configuration for newly stable resource attributes.

Fixes #12313.

## Changes

- Upgraded `io.opentelemetry.semconv:opentelemetry-semconv` to `1.43.0`.
- Continued using only the stable semantic-conventions artifact; no incubating dependency was added.
- Added `telemetry.resource` configuration shared by Helidon-created tracing, metrics, and logging providers.
- Added first-class support for these optional, newly stable settings:
  - `service.namespace`
  - `service.instance.id`
  - `deployment.environment.name`
  - `container.id`
  - `container.image.name`
  - `container.image.tags`
  - `container.image.repo_digests`
- Added common custom resource attributes using the existing typed scalar attribute configuration.
- Preserved the required top-level `telemetry.service` setting as the source of `service.name`.
- Applied resource attributes using this precedence, lowest to highest:
  1. OpenTelemetry’s default resource
  2. Common `telemetry.resource.attributes`
  3. Signal-specific attributes
  4. First-class resource settings and `telemetry.service`
- Preserved the behavior in which an explicitly supplied `OpenTelemetry` instance bypasses Helidon SDK construction.
- Updated documentation and semantic-conventions links for release 1.43.0.

Example:

```yaml
telemetry:
  service: checkout
  resource:
    service-namespace: retail
    service-instance-id: checkout-7f3a
    deployment-environment-name: production
    container-id: container-123
    container-image-name: registry.example.com/retail/checkout
    container-image-tags: [latest, "2.1"]
    container-image-repo-digests:
      - "registry.example.com/retail/checkout@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
      - "mirror.example.com/retail/checkout@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
    attributes:
      strings:
        service.version: "2.1"
      longs:
        application.shard: 3
```

## Scope and compatibility

This change adopts only stable semantic-convention APIs. It does not add the incubating artifact or adopt experimental HTTP, RPC, exception-event, schema URL, or connection-metric behavior.

Helidon does not synthesize service instance identifiers or detect container or Kubernetes metadata. Optional resource settings contribute attributes only when explicitly configured.

The semantic-conventions update is source-compatible with Helidon’s existing stable constant usage.

Several of the new settings pertain to container information. This PR does not attempt to infer those values automatically. Applications can supply them through Helidon configuration, including environment variables mapped to the corresponding configuration keys.

## Verification

- Passed the affected 112-module Maven reactor with checkstyle and copyright checks.
- Passed declarative and programmatic resource configuration tests.
- Verified resource attributes on captured spans, metrics, and log records.
- Verified precedence, omitted-value behavior, scalar types, and ordered container-image lists.
- Confirmed dependency resolution includes `opentelemetry-semconv:1.43.0` and no incubating artifact.
- Successfully generated the Helidon documentation.

## Documentation
Update included.