### PR TITLE
4.x: Fix config docs logging initialization

### DIFF
--- a/config/metadata/docs/pom.xml
+++ b/config/metadata/docs/pom.xml
@@ -26,8 +26,6 @@
         <artifactId>helidon-config-metadata-project</artifactId>
         <version>4.5.4-SNAPSHOT</version>
     </parent>
-
-    <groupId>io.helidon.config.metadata</groupId>
     <artifactId>helidon-config-metadata-docs</artifactId>
     <name>Helidon Config Metadata Docs</name>
 
@@ -44,10 +42,6 @@
         <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata-model</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.logging</groupId>
-            <artifactId>helidon-logging-common</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.jknack</groupId>

--- a/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/Main.java
+++ b/config/metadata/docs/src/main/java/io/helidon/config/metadata/docs/Main.java
@@ -16,18 +16,16 @@
 
 package io.helidon.config.metadata.docs;
 
+import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.logging.LogManager;
 
 import io.helidon.config.metadata.model.CmModel;
-import io.helidon.logging.common.LogConfig;
 
 /**
  * Config docs generator entry point.
  */
 public final class Main {
-    static {
-        LogConfig.initClass();
-    }
 
     private Main() {
     }
@@ -42,10 +40,24 @@ public final class Main {
             System.err.println("Usage: output_directory");
             System.exit(1);
         }
-        LogConfig.configureRuntime();
+        configureLogging();
         var outputDir = Paths.get(args[0]).toAbsolutePath().normalize();
         var metadata = CmModel.loadAll(Main.class.getClassLoader());
         var docs = new CmDocCodegen(outputDir, metadata);
         docs.process();
+    }
+
+    private static void configureLogging() {
+        if (System.getProperty("java.util.logging.config.file") == null
+            && System.getProperty("java.util.logging.config.class") == null) {
+
+            try (var is = Main.class.getResourceAsStream("logging.properties")) {
+                if (is != null) {
+                    LogManager.getLogManager().readConfiguration(is);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/config/metadata/docs/src/main/resources/io/helidon/config/metadata/docs/logging.properties
+++ b/config/metadata/docs/src/main/resources/io/helidon/config/metadata/docs/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/metadata/docs/src/main/resources/io/helidon/config/metadata/docs/logging.properties
+++ b/config/metadata/docs/src/main/resources/io/helidon/config/metadata/docs/logging.properties
@@ -16,6 +16,6 @@
 
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=ALL
-java.util.logging.SimpleFormatter.format=%4$s: %5$s%6$s%n
+java.util.logging.SimpleFormatter.format=%4$s: %5$s%n
 
 .level=INFO

--- a/config/metadata/docs/src/test/java/io/helidon/config/metadata/docs/CmPageResolverTest.java
+++ b/config/metadata/docs/src/test/java/io/helidon/config/metadata/docs/CmPageResolverTest.java
@@ -176,6 +176,7 @@ class CmPageResolverTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void testProviderDuplicateKeyRowAnchors() throws Exception {
         var resolver = resolver("provider-duplicate-keys");
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -76,10 +76,6 @@
                         <configuration>
                             <commandlineArgs>${project.basedir}/config</commandlineArgs>
                             <mainClass>io.helidon.config.metadata.docs.Main</mainClass>
-                            <classpathFilenameExclusions>
-                                <exclusion>helidon-logging-slf4j-${helidon.version}.jar</exclusion>
-                                <exclusion>helidon-logging-log4j-${helidon.version}.jar</exclusion>
-                            </classpathFilenameExclusions>
                         </configuration>
                     </execution>
                 </executions>

--- a/etc/scripts/test-quickstarts.sh
+++ b/etc/scripts/test-quickstarts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/scripts/test-quickstarts.sh
+++ b/etc/scripts/test-quickstarts.sh
@@ -65,7 +65,7 @@ readonly HELIDON_VERSION
 # If needed we clone the helidon-examples repo
 if [ ! -d "${WS_DIR}/helidon-examples" ]; then
   echo "Cloning examples repository into ${WS_DIR}/helidon-examples"
-  git clone --branch dev-4.x --single-branch https://github.com/helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
+  git clone --branch helidon-4.x --single-branch https://github.com/helidon-io/helidon-examples.git "${WS_DIR}/helidon-examples"
 
   # If in a tag, update the version on the fly
   if [ -n "$(git tag --points-at HEAD)" ] ; then


### PR DESCRIPTION
### Description

- Load the default JUL configuration from a package-scoped resource.
- Honor the standard java.util.logging.config.file and
  java.util.logging.config.class overrides.
- Remove the Helidon logging dependency and obsolete runtime classpath
  exclusions.
- Format default config-doc generator logging on one line.

### Documentation

None

### Validation

- .ai/tools/run-mvn-jdk21 -f config/metadata/docs/pom.xml test
- .ai/tools/run-mvn-jdk21 -f config/metadata/docs/pom.xml validate -Pcheckstyle
- .ai/tools/run-mvn-jdk21 -f docs/pom.xml generate-sources
- git diff --check