### PR TITLE
Generalize fault tolerance retry handling

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/RetryHandler.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/faulttolerance/RetryHandler.java
@@ -174,55 +174,18 @@ final class RetryHandler extends FtHandler {
                                                  RETRY_ANNOTATION,
                                                  "jitter",
                                                  annotation.stringValue("jitter").orElse("PT-1S"));
+        double jitterFactor = annotation.doubleValue("jitterFactor").orElse(-1.0);
+        String maxDelayDuration = validateDuration(typeName,
+                                                   element,
+                                                   RETRY_ANNOTATION,
+                                                   "maxDelay",
+                                                   annotation.stringValue("maxDelay").orElse("PT-1S"));
         String overallTimeoutDuration = validateDuration(typeName,
                                                          element,
                                                          RETRY_ANNOTATION,
                                                          "overallTimeout",
                                                          annotation.stringValue("overallTimeout").orElse("PT1S"));
 
-        /*
-        First build the retry policy
-         */
-        builder.addContent("var policy = ")
-                .addContent(RETRY)
-                .addContent(".");
-
-        if (jitterDuration.equals("PT-1S") || delayFactor > 0) {
-            delayFactor = delayFactor > 0 ? delayFactor : 2.0;
-            // delaying
-            builder.addContentLine("DelayingRetryPolicy.builder()")
-                    .increaseContentPadding()
-                    .increaseContentPadding()
-                    .addContent(".delayFactor(")
-                    .addContent(String.valueOf(delayFactor))
-                    .addContentLine(")");
-        } else {
-            // jittery
-            builder.addContentLine("JitterRetryPolicy.builder()")
-                    .increaseContentPadding()
-                    .increaseContentPadding()
-                    .addContent(".jitter(")
-                    .addContent(Duration.class)
-                    .addContent(".parse(\"")
-                    .addContent(jitterDuration)
-                    .addContentLine("\"))");
-        }
-        builder.addContent(".calls(")
-                .addContent(String.valueOf(calls))
-                .addContentLine(")");
-        builder.addContent(".delay(")
-                .addContent(Duration.class)
-                .addContent(".parse(\"")
-                .addContent(delayDuration)
-                .addContentLine("\"))");
-        builder.addContentLine(".build();")
-                .decreaseContentPadding()
-                .decreaseContentPadding();
-        builder.addContentLine();
-
-        /*
-        Now build the retry itself
-         */
         builder.addContent("return ")
                 .addContent(RETRY_CONFIG)
                 .addContentLine(".builder()")
@@ -230,8 +193,33 @@ final class RetryHandler extends FtHandler {
                 .increaseContentPadding()
                 .addContentLine(".applyOn(APPLY_ON)")
                 .addContentLine(".skipOn(SKIP_ON)")
-                .addContentLine(".retryPolicy(policy)")
-                .addContent(".overallTimeout(")
+                .addContent(".calls(")
+                .addContent(String.valueOf(calls))
+                .addContentLine(")")
+                .addContent(".delay(")
+                .addContent(Duration.class)
+                .addContent(".parse(\"")
+                .addContent(delayDuration)
+                .addContentLine("\"))")
+                .addContent(".delayFactor(")
+                .addContent(String.valueOf(delayFactor))
+                .addContentLine(")")
+                .addContent(".jitter(")
+                .addContent(Duration.class)
+                .addContent(".parse(\"")
+                .addContent(jitterDuration)
+                .addContentLine("\"))")
+                .addContent(".jitterFactor(")
+                .addContent(String.valueOf(jitterFactor))
+                .addContentLine(")");
+        if (!Duration.parse(maxDelayDuration).equals(Duration.ofSeconds(-1))) {
+            builder.addContent(".maxDelay(")
+                    .addContent(Duration.class)
+                    .addContent(".parse(\"")
+                    .addContent(maxDelayDuration)
+                    .addContentLine("\"))");
+        }
+        builder.addContent(".overallTimeout(")
                 .addContent(Duration.class)
                 .addContent(".parse(\"")
                 .addContent(overallTimeoutDuration)

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/FactoryProvidedContractAnnotationsCodegenTest.java
@@ -26,6 +26,7 @@ import io.helidon.codegen.testing.TestCompiler;
 import io.helidon.common.Generated;
 import io.helidon.common.GenericType;
 import io.helidon.common.types.Annotation;
+import io.helidon.config.Config;
 import io.helidon.faulttolerance.Ft;
 import io.helidon.faulttolerance.Retry;
 import io.helidon.metrics.api.Gauge;
@@ -39,7 +40,9 @@ import io.helidon.tracing.Tracing;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class FactoryProvidedContractAnnotationsCodegenTest {
@@ -48,6 +51,7 @@ class FactoryProvidedContractAnnotationsCodegenTest {
             GenericType.class,
             Annotation.class,
             Prototype.class,
+            Config.class,
             Service.class,
             Ft.class,
             Retry.class,
@@ -59,6 +63,44 @@ class FactoryProvidedContractAnnotationsCodegenTest {
             Span.class,
             Tracer.class
     );
+
+    @Test
+    void testRetryUsesCanonicalConfig() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .addSource("RetriedService.java", """
+                        package com.example;
+
+                        import io.helidon.faulttolerance.Ft;
+                        import io.helidon.service.registry.Service;
+
+                        @Service.Singleton
+                        class RetriedService {
+                            @Ft.Retry(calls = 7,
+                                      delay = "PT0.1S",
+                                      delayFactor = 2,
+                                      jitterFactor = 0.2,
+                                      maxDelay = "PT5S",
+                                      overallTimeout = "PT1M")
+                            String value() {
+                                return "value";
+                            }
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        String generated = Files.readString(result.sourceOutput().resolve("com/example/RetriedService_value__Retry.java"));
+        assertThat(generated, containsString("RetryConfig.builder()"));
+        assertThat(generated, containsString(".jitterFactor(0.2)"));
+        assertThat(generated, containsString(".maxDelay(Duration.parse(\"PT5S\"))"));
+        assertThat(generated, not(containsString("DelayingRetryPolicy.builder()")));
+    }
 
     @Test
     void testSupplierProvidedFtContractDoesNotGenerateInterceptor() throws IOException {

--- a/docs/config/io.helidon.faulttolerance.Retry.md
+++ b/docs/config/io.helidon.faulttolerance.Retry.md
@@ -27,7 +27,7 @@
 <td>
 <code>PT1S</code>
 </td>
-<td>Overall timeout of all retries combined</td>
+<td>Positive overall timeout used to bound the complete retry sequence</td>
 </tr>
 <tr>
 <td>
@@ -38,7 +38,7 @@
 </td>
 <td>
 </td>
-<td>Maximum delay between invocation attempts, including jitter</td>
+<td>Optional non-negative maximum delay applied after jitter; when absent, the delay is not capped</td>
 </tr>
 <tr>
 <td>
@@ -50,7 +50,7 @@
 <td>
 <code>PT0.<wbr>2S</code>
 </td>
-<td>Base delay between try and retry</td>
+<td>Non-negative base delay between the initial call and retries, which defaults to <code>200 ms</code></td>
 </tr>
 <tr>
 <td>
@@ -62,7 +62,7 @@
 <td>
 <code>PT-<wbr>1S</code>
 </td>
-<td>Random jitter applied to the delay</td>
+<td>Absolute random jitter that must be <code>PT-<wbr>1S</code> (disabled) or non-negative; it cannot be combined with <code>jitter-<wbr>factor</code>, is applied after <code>delay-<wbr>factor</code>, and is capped by <code>max-<wbr>delay</code> when present</td>
 </tr>
 <tr>
 <td>
@@ -74,7 +74,7 @@
 <td>
 <code>3</code>
 </td>
-<td>Number of calls (first try + retries)</td>
+<td>Number of calls, including the initial call and retries, which must be at least <code>1</code></td>
 </tr>
 <tr>
 <td>
@@ -86,7 +86,7 @@
 <td>
 <code>-1.<wbr>0</code>
 </td>
-<td>Random jitter relative to the calculated delay</td>
+<td>Relative random jitter that must be <code>-1</code> (disabled) or from <code>0</code> (inclusive) to <code>1</code> (exclusive); it cannot be combined with <code>jitter</code>, is applied after <code>delay-<wbr>factor</code>, and is capped by <code>max-<wbr>delay</code> when present</td>
 </tr>
 <tr>
 <td>
@@ -98,7 +98,7 @@
 <td>
 <code>-1.<wbr>0</code>
 </td>
-<td>Delay retry policy factor</td>
+<td>Delay multiplier that must be <code>-1</code> or finite and non-negative; <code>-1</code> selects <code>2</code> unless either jitter option is configured, and an explicit multiplier is applied before jitter</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.faulttolerance.Retry.md
+++ b/docs/config/io.helidon.faulttolerance.Retry.md
@@ -31,6 +31,17 @@
 </tr>
 <tr>
 <td>
+<code>max-<wbr>delay</code>
+</td>
+<td>
+<code>Duration</code>
+</td>
+<td>
+</td>
+<td>Maximum delay between invocation attempts, including jitter</td>
+</tr>
+<tr>
+<td>
 <code>delay</code>
 </td>
 <td>
@@ -51,7 +62,7 @@
 <td>
 <code>PT-<wbr>1S</code>
 </td>
-<td>Jitter for <code>Retry.<wbr>Jitter<wbr>Retry<wbr>Policy</code></td>
+<td>Random jitter applied to the delay</td>
 </tr>
 <tr>
 <td>
@@ -64,6 +75,18 @@
 <code>3</code>
 </td>
 <td>Number of calls (first try + retries)</td>
+</tr>
+<tr>
+<td>
+<code>jitter-<wbr>factor</code>
+</td>
+<td>
+<code>Double</code>
+</td>
+<td>
+<code>-1.<wbr>0</code>
+</td>
+<td>Random jitter relative to the calculated delay</td>
 </tr>
 <tr>
 <td>

--- a/docs/config/io.helidon.faulttolerance.Retry.md
+++ b/docs/config/io.helidon.faulttolerance.Retry.md
@@ -62,7 +62,7 @@
 <td>
 <code>PT-<wbr>1S</code>
 </td>
-<td>Absolute random jitter that must be <code>PT-<wbr>1S</code> (disabled) or non-negative; it cannot be combined with <code>jitter-<wbr>factor</code>, is applied after <code>delay-<wbr>factor</code>, and is capped by <code>max-<wbr>delay</code> when present</td>
+<td>Absolute random jitter that must be <code>PT-<wbr>1S</code> (disabled) or non-negative; it cannot be combined with <code>jitter-<wbr>factor</code>, is applied independently after <code>delay-<wbr>factor</code>, does not affect later base-delay calculations, and is capped by <code>max-<wbr>delay</code> when present</td>
 </tr>
 <tr>
 <td>
@@ -86,7 +86,7 @@
 <td>
 <code>-1.<wbr>0</code>
 </td>
-<td>Relative random jitter that must be <code>-1</code> (disabled) or from <code>0</code> (inclusive) to <code>1</code> (exclusive); it cannot be combined with <code>jitter</code>, is applied after <code>delay-<wbr>factor</code>, and is capped by <code>max-<wbr>delay</code> when present</td>
+<td>Relative random jitter that must be <code>-1</code> (disabled) or from <code>0</code> (inclusive) to <code>1</code> (exclusive); it cannot be combined with <code>jitter</code>, is applied independently after <code>delay-<wbr>factor</code>, does not affect later base-delay calculations, and is capped by <code>max-<wbr>delay</code> when present</td>
 </tr>
 <tr>
 <td>

--- a/docs/modules/fault-tolerance.md
+++ b/docs/modules/fault-tolerance.md
@@ -109,12 +109,16 @@ try {
 }
 ```
 
-Exponential delay can use either an absolute `jitter` duration or a relative
-`jitter-factor`; the two jitter options are mutually exclusive. `max-delay`
-caps the final delay after jitter. A contextual invocation can also supply a
-`Retry.WaitStrategy` to maintain an external resource while waiting or cancel
-another attempt by returning `false`. A strategy returning `true` must complete
-the requested wait and must restore the thread interrupt status if interrupted.
+`calls` must be at least one, `delay` must be non-negative, and
+`overall-timeout` must be positive. Exponential delay can use either a
+non-negative absolute `jitter` duration (`PT-1S` disables it) or a relative
+`jitter-factor` from zero inclusive to one exclusive (`-1` disables it); the
+two jitter options are mutually exclusive. The optional non-negative
+`max-delay` caps the final delay after jitter. A contextual invocation can also
+supply a `Retry.WaitStrategy` to maintain an external resource while waiting
+or cancel another attempt by returning `false`. A strategy returning `true`
+must complete the requested wait and must restore the thread interrupt status
+if interrupted.
 
 ### Timeouts
 

--- a/docs/modules/fault-tolerance.md
+++ b/docs/modules/fault-tolerance.md
@@ -84,6 +84,38 @@ control is possible by creating a retry policy and using methods such as
 Throwable>... classes)` to control the exceptions that must be retried and those
 that must be ignored.
 
+An overload accepting `Function<RetryContext, T>` provides the current attempt
+number, elapsed time, preceding delay, and preceding failure to each invocation.
+If the invocation does not succeed, `RetryException` exposes a `RetryOutcome`
+with the termination reason and final attempt metadata. The original
+`Supplier` overload continues to propagate the terminal application exception
+or `RetryTimeoutException`.
+
+```java
+Retry retry = Retry.builder()
+        .calls(100)
+        .delay(Duration.ofMillis(100))
+        .delayFactor(2)
+        .jitterFactor(0.2)
+        .maxDelay(Duration.ofSeconds(5))
+        .overallTimeout(Duration.ofMinutes(5))
+        .build();
+
+try {
+    T result = retry.invoke(context -> retryOnFailure(context.attempt()));
+} catch (RetryException e) {
+    RetryOutcome outcome = e.outcome();
+    // Inspect outcome.termination(), outcome.attempts(), and outcome.lastThrowable().
+}
+```
+
+Exponential delay can use either an absolute `jitter` duration or a relative
+`jitter-factor`; the two jitter options are mutually exclusive. `max-delay`
+caps the final delay after jitter. A contextual invocation can also supply a
+`Retry.WaitStrategy` to maintain an external resource while waiting or cancel
+another attempt by returning `false`. A strategy returning `true` must complete
+the requested wait and must restore the thread interrupt status if interrupted.
+
 ### Timeouts
 
 A request to a service that is inaccessible or simply unavailable should be

--- a/docs/modules/fault-tolerance.md
+++ b/docs/modules/fault-tolerance.md
@@ -120,6 +120,12 @@ or cancel another attempt by returning `false`. A strategy returning `true`
 must complete the requested wait and must restore the thread interrupt status
 if interrupted.
 
+In Helidon 27, configuring both `delay-factor` and absolute `jitter` applies
+the delay factor first and then applies jitter. Earlier releases ignored
+`jitter` when both options were configured. The defaults are unchanged: three
+total calls, a 200 ms base delay with a factor of two, no jitter, no maximum
+delay, and a one-second overall timeout.
+
 ### Timeouts
 
 A request to a service that is inaccessible or simply unavailable should be

--- a/docs/modules/fault-tolerance.md
+++ b/docs/modules/fault-tolerance.md
@@ -114,7 +114,9 @@ try {
 non-negative absolute `jitter` duration (`PT-1S` disables it) or a relative
 `jitter-factor` from zero inclusive to one exclusive (`-1` disables it); the
 two jitter options are mutually exclusive. The optional non-negative
-`max-delay` caps the final delay after jitter. A contextual invocation can also
+`max-delay` caps the final delay after jitter. Jitter is applied independently
+to each calculated exponential delay and does not affect later base-delay
+calculations. A contextual invocation can also
 supply a `Retry.WaitStrategy` to maintain an external resource while waiting
 or cancel another attempt by returning `false`. A strategy returning `true`
 must complete the requested wait and must restore the thread interrupt status

--- a/fault-tolerance/README.md
+++ b/fault-tolerance/README.md
@@ -17,24 +17,29 @@ In case the target method fails, it would first be retried, and then a fallback 
 
 # Retry
 
-| Option             | Value                   |
-|--------------------|-------------------------|
-| Interface          | `Retry`                 |
-| Can be injected    | yes                     |
-| Named              | yes                     |
-| Config interface   | `RetryConfig`           |
-| Config driven      | yes                     |
-| Implementation     | `RetryImpl`             |
-| Interceptor        | `RetryInterceptor`      |
-| Generated code     | yes                     |
-| Generated contract | `RetryMethod`           |
-| Throwables         | `RetryTimeoutException` |
-| Annotation(s)      | `FaultTolerance.Retry`  |
+| Option             | Value                                    |
+|--------------------|------------------------------------------|
+| Interface          | `Retry`                                  |
+| Can be injected    | yes                                      |
+| Named              | yes                                      |
+| Config interface   | `RetryConfig`                            |
+| Config driven      | yes                                      |
+| Implementation     | `RetryImpl`                              |
+| Interceptor        | `RetryInterceptor`                       |
+| Generated code     | yes                                      |
+| Generated contract | `RetryMethod`                            |
+| Throwables         | `RetryTimeoutException`, `RetryException` |
+| Annotation(s)      | `Ft.Retry`                               |
 
-Retry can have named instances (either from configuration of from custom `Provider`). Each such instance can have a different
-configuration and can be references from annotations.
-When used with `@FtRetry`, a named instance is located, and if not present, a custom instance is created based on the annotation
+Retry can have named instances (either from configuration or from a custom `Provider`). Each such instance can have a different
+configuration and can be referenced from annotations.
+When used with `@Ft.Retry`, a named instance is located, and if not present, a custom instance is created based on the annotation
 setup.
+
+The contextual `Retry.invoke` overload provides immutable metadata for each attempt and reports unsuccessful completion
+using `RetryException`, including the final outcome and termination reason. A custom `Retry.WaitStrategy` can keep an
+external resource alive while waiting or cancel further attempts. Exponential delay and jitter can be combined and
+bounded using `RetryConfig.maxDelay`; `RetryConfig.jitterFactor` applies jitter relative to the calculated delay.
 
 # Bulkhead
 

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.builder.api.Prototype;
 /**
  * {@link Async} configuration bean.
  */
-@Prototype.Blueprint(decorator = AsyncConfigBlueprint.BuilderDecorator.class)
+@Prototype.Blueprint(decorator = FtBuilderSupport.AsyncBuilderDecorator.class)
 @Prototype.Configured
 interface AsyncConfigBlueprint extends Prototype.Factory<Async> {
     /**
@@ -59,13 +59,4 @@ interface AsyncConfigBlueprint extends Prototype.Factory<Async> {
      */
     Optional<CompletableFuture<Async>> onStart();
 
-    class BuilderDecorator implements Prototype.BuilderDecorator<AsyncConfig.BuilderBase<?, ?>> {
-        @Override
-        public void decorate(AsyncConfig.BuilderBase<?, ?> target) {
-            if (target.name().isEmpty()) {
-                target.config()
-                        .ifPresent(cfg -> target.name(cfg.name()));
-            }
-        }
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.builder.api.Prototype;
  * {@link Bulkhead} configuration bean.
  */
 @Prototype.Configured("fault-tolerance.bulkheads")
-@Prototype.Blueprint(decorator = BulkheadConfigBlueprint.BuilderDecorator.class)
+@Prototype.Blueprint(decorator = FtBuilderSupport.BulkheadBuilderDecorator.class)
 interface BulkheadConfigBlueprint extends Prototype.Factory<Bulkhead> {
     /**
      * Default limit.
@@ -91,13 +91,4 @@ interface BulkheadConfigBlueprint extends Prototype.Factory<Bulkhead> {
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
 
-    class BuilderDecorator implements Prototype.BuilderDecorator<BulkheadConfig.BuilderBase<?, ?>> {
-        @Override
-        public void decorate(BulkheadConfig.BuilderBase<?, ?> target) {
-            if (target.name().isEmpty()) {
-                target.config()
-                        .ifPresent(cfg -> target.name(cfg.name()));
-            }
-        }
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import io.helidon.builder.api.Prototype;
 /**
  * Configuration of a circuit breaker.
  */
-@Prototype.Blueprint(decorator = CircuitBreakerConfigBlueprint.BuilderDecorator.class)
+@Prototype.Blueprint(decorator = FtBuilderSupport.CircuitBreakerBuilderDecorator.class)
 @Prototype.Configured("fault-tolerance.circuit-breakers")
 interface CircuitBreakerConfigBlueprint extends Prototype.Factory<CircuitBreaker> {
     /**
@@ -132,13 +132,4 @@ interface CircuitBreakerConfigBlueprint extends Prototype.Factory<CircuitBreaker
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
 
-    class BuilderDecorator implements Prototype.BuilderDecorator<CircuitBreakerConfig.BuilderBase<?, ?>> {
-        @Override
-        public void decorate(CircuitBreakerConfig.BuilderBase<?, ?> target) {
-            if (target.name().isEmpty()) {
-                target.config()
-                        .ifPresent(cfg -> target.name(cfg.name()));
-            }
-        }
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
@@ -63,24 +63,44 @@ public final class Ft {
         String delay() default "PT0.2S";
 
         /**
-         * Delay retry policy factor. If unspecified (value of {@code -1}), Jitter retry policy would be used, unless
-         * jitter time is also unspecified.
+         * Delay retry policy factor. If unspecified (value of {@code -1}), a factor of {@code 2} is used unless jitter
+         * is configured, in which case the delay remains constant.
          * <p>
-         * Default when {@link io.helidon.faulttolerance.Retry.DelayingRetryPolicy} is used is {@code 2}.
+         * When both this option and {@link #jitter()} are configured, the delay factor is applied first and jitter is
+         * applied to the resulting delay.
          *
          * @return delay factor for delaying retry policy
          */
         double delayFactor() default -1;
 
         /**
-         * Jitter for {@link io.helidon.faulttolerance.Retry.JitterRetryPolicy}. If unspecified (value of {@code -1}),
-         * delaying retry policy is used. If both this value, and {@link #delayFactor()} are specified, delaying retry policy
-         * would be used.
+         * Random jitter applied to the delay. If unspecified (value of {@code PT-1S}), jitter is not applied.
+         * When both this option and {@link #delayFactor()} are configured, the delay factor is applied first and jitter
+         * is applied to the resulting delay. The final delay is capped by {@link #maxDelay()}, when configured.
          *
          * @return jitter duration
          * @see java.time.Duration#parse(CharSequence)
          */
         String jitter() default "PT-1S";
+
+        /**
+         * Random jitter relative to the calculated delay, from {@code 0} (inclusive) to {@code 1} (exclusive). For
+         * example, a value of {@code 0.2} applies a random jitter of up to twenty percent in either direction. This
+         * option cannot be combined with an explicitly configured {@link #jitter() absolute jitter}. A value of
+         * {@code -1} means relative jitter is not configured.
+         *
+         * @return relative jitter factor
+         */
+        double jitterFactor() default -1;
+
+        /**
+         * Maximum delay between invocation attempts, including jitter. If unspecified (value of {@code PT-1S}), the
+         * delay is not capped.
+         *
+         * @return maximum delay
+         * @see java.time.Duration#parse(CharSequence)
+         */
+        String maxDelay() default "PT-1S";
 
         /**
          * Duration of overall timeout.

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
@@ -67,7 +67,7 @@ public final class Ft {
          * is configured, in which case the delay remains constant.
          * <p>
          * When both this option and {@link #jitter()} are configured, the delay factor is applied first and jitter is
-         * applied to the resulting delay.
+         * applied independently to the resulting delay. A jittered delay does not affect later base-delay calculations.
          *
          * @return delay factor for delaying retry policy
          */
@@ -76,7 +76,8 @@ public final class Ft {
         /**
          * Random jitter applied to the delay. If unspecified (value of {@code PT-1S}), jitter is not applied.
          * When both this option and {@link #delayFactor()} are configured, the delay factor is applied first and jitter
-         * is applied to the resulting delay. The final delay is capped by {@link #maxDelay()}, when configured.
+         * is applied independently to the resulting delay. A jittered delay does not affect later base-delay calculations.
+         * The final delay is capped by {@link #maxDelay()}, when configured.
          *
          * @return jitter duration
          * @see java.time.Duration#parse(CharSequence)
@@ -86,7 +87,8 @@ public final class Ft {
         /**
          * Random jitter relative to the calculated delay, from {@code 0} (inclusive) to {@code 1} (exclusive). For
          * example, a value of {@code 0.2} applies a random jitter of up to twenty percent in either direction. This
-         * option cannot be combined with an explicitly configured {@link #jitter() absolute jitter}. A value of
+         * option cannot be combined with an explicitly configured {@link #jitter() absolute jitter}. Each retry applies
+         * relative jitter independently, and a jittered delay does not affect later base-delay calculations. A value of
          * {@code -1} means relative jitter is not configured.
          *
          * @return relative jitter factor

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Ft.java
@@ -133,7 +133,9 @@ public final class Ft {
      * The fallback method must have the same signature (types and number of parameters), or have one additional parameter of
      * type {@code Throwable} to receive the last exception thrown.
      * <p>
-     * Fault tolerance will add all intermediate exceptions as {@link Throwable#addSuppressed(Throwable)}.
+     * When retries fail, fault tolerance adds up to 15 of the most recent intermediate exceptions as
+     * {@link Throwable#addSuppressed(Throwable) suppressed exceptions} to the last failure. Older intermediate
+     * exceptions are discarded.
      */
     @Retention(RetentionPolicy.CLASS)
     @Documented

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+
+import io.helidon.builder.api.Prototype;
+
+final class FtBuilderSupport {
+    private FtBuilderSupport() {
+    }
+
+    static class AsyncBuilderDecorator implements Prototype.BuilderDecorator<AsyncConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(AsyncConfig.BuilderBase<?, ?> target) {
+            if (target.name().isEmpty()) {
+                target.config()
+                        .ifPresent(cfg -> target.name(cfg.name()));
+            }
+        }
+    }
+
+    static class BulkheadBuilderDecorator implements Prototype.BuilderDecorator<BulkheadConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(BulkheadConfig.BuilderBase<?, ?> target) {
+            if (target.name().isEmpty()) {
+                target.config()
+                        .ifPresent(cfg -> target.name(cfg.name()));
+            }
+        }
+    }
+
+    static class CircuitBreakerBuilderDecorator
+            implements Prototype.BuilderDecorator<CircuitBreakerConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(CircuitBreakerConfig.BuilderBase<?, ?> target) {
+            if (target.name().isEmpty()) {
+                target.config()
+                        .ifPresent(cfg -> target.name(cfg.name()));
+            }
+        }
+    }
+
+    static class RetryBuilderDecorator implements Prototype.BuilderDecorator<RetryConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(RetryConfig.BuilderBase<?, ?> target) {
+            validate(target);
+            if (target.name().isEmpty()) {
+                target.config()
+                        .ifPresent(cfg -> target.name(cfg.name()));
+            }
+            if (target.retryPolicy().isEmpty()) {
+                target.retryPolicy(retryPolicy(target));
+            }
+        }
+
+        /**
+         * Retry policy created from this configuration.
+         *
+         * @return retry policy to use
+         */
+        private Retry.RetryPolicy retryPolicy(RetryConfig.BuilderBase<?, ?> target) {
+            boolean jitterConfigured = !target.jitter().equals(Duration.ofSeconds(-1));
+            boolean jitterFactorConfigured = target.jitterFactor() != -1;
+            Retry.DelayingRetryPolicy.Builder delayBuilder = Retry.DelayingRetryPolicy.builder()
+                    .calls(target.calls())
+                    .delay(target.delay());
+
+            if (target.delayFactor() != -1) {
+                delayBuilder.delayFactor(target.delayFactor());
+            } else if (jitterConfigured || jitterFactorConfigured) {
+                delayBuilder.delayFactor(1);
+            }
+            if (jitterConfigured) {
+                delayBuilder.jitter(target.jitter());
+            }
+            if (jitterFactorConfigured) {
+                delayBuilder.jitterFactor(target.jitterFactor());
+            }
+            target.maxDelay().ifPresent(delayBuilder::maxDelay);
+            return delayBuilder.build();
+        }
+
+        private void validate(RetryConfig.BuilderBase<?, ?> target) {
+            if (target.calls() < 1) {
+                throw new IllegalArgumentException("Retry calls must be at least 1");
+            }
+            if (target.delay().isNegative()) {
+                throw new IllegalArgumentException("Retry delay must not be negative");
+            }
+            if (target.overallTimeout().isNegative() || target.overallTimeout().isZero()) {
+                throw new IllegalArgumentException("Retry overall timeout must be positive");
+            }
+            double delayFactor = target.delayFactor();
+            if (delayFactor != -1 && (!Double.isFinite(delayFactor) || delayFactor < 0)) {
+                throw new IllegalArgumentException("Retry delay factor must be -1 or a finite, non-negative number");
+            }
+            Duration jitter = target.jitter();
+            if (jitter.isNegative() && !jitter.equals(Duration.ofSeconds(-1))) {
+                throw new IllegalArgumentException("Retry jitter must be PT-1S or non-negative");
+            }
+            double jitterFactor = target.jitterFactor();
+            if (jitterFactor != -1 && (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1)) {
+                throw new IllegalArgumentException("Retry jitter factor must be -1 or from 0 (inclusive) to 1 "
+                                                           + "(exclusive)");
+            }
+            if (!jitter.equals(Duration.ofSeconds(-1)) && jitterFactor != -1) {
+                throw new IllegalArgumentException("Retry jitter and jitter factor cannot both be configured");
+            }
+            target.maxDelay().ifPresent(maxDelay -> {
+                if (maxDelay.isNegative()) {
+                    throw new IllegalArgumentException("Retry maximum delay must not be negative");
+                }
+            });
+        }
+    }
+
+    static class TimeoutBuilderDecorator implements Prototype.BuilderDecorator<TimeoutConfig.BuilderBase<?, ?>> {
+        @Override
+        public void decorate(TimeoutConfig.BuilderBase<?, ?> target) {
+            if (target.name().isEmpty()) {
+                target.config()
+                        .ifPresent(cfg -> target.name(cfg.name()));
+            }
+        }
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
@@ -64,7 +64,9 @@ final class FtBuilderSupport {
                         .ifPresent(cfg -> target.name(cfg.name()));
             }
             var retryPolicy = target.retryPolicy();
-            if (retryPolicy.isEmpty() || retryPolicy.get() instanceof DerivedRetryPolicy) {
+            if (retryPolicy.isEmpty()
+                    || retryPolicy.get() instanceof Retry.DelayingRetryPolicy delayingPolicy
+                            && delayingPolicy.autoDerived()) {
                 target.retryPolicy(retryPolicy(target));
             }
         }
@@ -93,7 +95,7 @@ final class FtBuilderSupport {
                 delayBuilder.jitterFactor(target.jitterFactor());
             }
             target.maxDelay().ifPresent(delayBuilder::maxDelay);
-            return new DerivedRetryPolicy(delayBuilder);
+            return delayBuilder.autoDerived().build();
         }
 
         private void validate(RetryConfig.BuilderBase<?, ?> target) {
@@ -127,12 +129,6 @@ final class FtBuilderSupport {
                     throw new IllegalArgumentException("Retry maximum delay must not be negative");
                 }
             });
-        }
-    }
-
-    private static final class DerivedRetryPolicy extends Retry.DelayingRetryPolicy {
-        private DerivedRetryPolicy(Retry.DelayingRetryPolicy.Builder builder) {
-            super(builder);
         }
     }
 

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
@@ -17,11 +17,16 @@
 package io.helidon.faulttolerance;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
 
 final class FtBuilderSupport {
     private FtBuilderSupport() {
+    }
+
+    private static void clearRetryPolicy(RetryConfig.BuilderBase<?, ?> target) {
+        target.clearRetryPolicy();
     }
 
     static class AsyncBuilderDecorator implements Prototype.BuilderDecorator<AsyncConfig.BuilderBase<?, ?>> {
@@ -63,10 +68,7 @@ final class FtBuilderSupport {
                 target.config()
                         .ifPresent(cfg -> target.name(cfg.name()));
             }
-            var retryPolicy = target.retryPolicy();
-            if (retryPolicy.isEmpty()
-                    || retryPolicy.get() instanceof Retry.DelayingRetryPolicy delayingPolicy
-                            && delayingPolicy.autoDerived()) {
+            if (target.retryPolicy().isEmpty()) {
                 target.retryPolicy(retryPolicy(target));
             }
         }
@@ -95,7 +97,7 @@ final class FtBuilderSupport {
                 delayBuilder.jitterFactor(target.jitterFactor());
             }
             target.maxDelay().ifPresent(delayBuilder::maxDelay);
-            return delayBuilder.autoDerived().build();
+            return delayBuilder.build();
         }
 
         private void validate(RetryConfig.BuilderBase<?, ?> target) {
@@ -129,6 +131,38 @@ final class FtBuilderSupport {
                     throw new IllegalArgumentException("Retry maximum delay must not be negative");
                 }
             });
+        }
+    }
+
+    static class RetryDoubleOptionDecorator
+            implements Prototype.OptionDecorator<RetryConfig.BuilderBase<?, ?>, Double> {
+        @Override
+        public void decorate(RetryConfig.BuilderBase<?, ?> target, Double ignored) {
+            clearRetryPolicy(target);
+        }
+    }
+
+    static class RetryDurationOptionDecorator
+            implements Prototype.OptionDecorator<RetryConfig.BuilderBase<?, ?>, Duration> {
+        @Override
+        public void decorate(RetryConfig.BuilderBase<?, ?> target, Duration ignored) {
+            clearRetryPolicy(target);
+        }
+    }
+
+    static class RetryIntegerOptionDecorator
+            implements Prototype.OptionDecorator<RetryConfig.BuilderBase<?, ?>, Integer> {
+        @Override
+        public void decorate(RetryConfig.BuilderBase<?, ?> target, Integer ignored) {
+            clearRetryPolicy(target);
+        }
+    }
+
+    static class RetryOptionalDurationOptionDecorator
+            implements Prototype.OptionDecorator<RetryConfig.BuilderBase<?, ?>, Optional<Duration>> {
+        @Override
+        public void decorate(RetryConfig.BuilderBase<?, ?> target, Optional<Duration> ignored) {
+            clearRetryPolicy(target);
         }
     }
 

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtBuilderSupport.java
@@ -63,7 +63,8 @@ final class FtBuilderSupport {
                 target.config()
                         .ifPresent(cfg -> target.name(cfg.name()));
             }
-            if (target.retryPolicy().isEmpty()) {
+            var retryPolicy = target.retryPolicy();
+            if (retryPolicy.isEmpty() || retryPolicy.get() instanceof DerivedRetryPolicy) {
                 target.retryPolicy(retryPolicy(target));
             }
         }
@@ -92,7 +93,7 @@ final class FtBuilderSupport {
                 delayBuilder.jitterFactor(target.jitterFactor());
             }
             target.maxDelay().ifPresent(delayBuilder::maxDelay);
-            return delayBuilder.build();
+            return new DerivedRetryPolicy(delayBuilder);
         }
 
         private void validate(RetryConfig.BuilderBase<?, ?> target) {
@@ -126,6 +127,12 @@ final class FtBuilderSupport {
                     throw new IllegalArgumentException("Retry maximum delay must not be negative");
                 }
             });
+        }
+    }
+
+    private static final class DerivedRetryPolicy extends Retry.DelayingRetryPolicy {
+        private DerivedRetryPolicy(Retry.DelayingRetryPolicy.Builder builder) {
+            super(builder);
         }
     }
 

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -95,8 +95,12 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      * @param <T> type of result
      * @return result obtained from the function
      * @throws RetryException if the invocation does not complete successfully
+     * @throws java.lang.UnsupportedOperationException if you use a custom retry implementation, and it does not
+     *          implement this method
      */
-    <T> T invoke(Function<RetryContext, ? extends T> function);
+    default <T> T invoke(Function<RetryContext, ? extends T> function) {
+        throw new UnsupportedOperationException("This retry does not implement invoked(Function): " + getClass().getName());
+    }
 
     /**
      * Invoke a function with context for each attempt, using a caller-provided strategy to wait between attempts.
@@ -109,8 +113,13 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      * @param <T> type of result
      * @return result obtained from the function
      * @throws RetryException if the invocation does not complete successfully
+     * @throws java.lang.UnsupportedOperationException if you use a custom retry implementation, and it does not
+     *          implement this method
      */
-    <T> T invoke(Function<RetryContext, ? extends T> function, WaitStrategy waitStrategy);
+    default <T> T invoke(Function<RetryContext, ? extends T> function, WaitStrategy waitStrategy) {
+        throw new UnsupportedOperationException("This retry does not implement invoked(Function, WaitStrategy): "
+                                                        + getClass().getName());
+    }
 
     /**
      * Strategy used to wait before another invocation attempt.

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -121,6 +121,80 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                                                         + getClass().getName());
     }
 
+    private static long durationToMillis(Duration duration) {
+        Objects.requireNonNull(duration);
+        try {
+            return Math.max(0, duration.toMillis());
+        } catch (ArithmeticException e) {
+            return duration.isNegative() ? 0 : Long.MAX_VALUE;
+        }
+    }
+
+    private static void validatePolicy(int calls,
+                                       Duration delay,
+                                       Duration jitter,
+                                       double jitterFactor,
+                                       Duration maxDelay) {
+        Objects.requireNonNull(delay);
+        Objects.requireNonNull(jitter);
+        Objects.requireNonNull(maxDelay);
+        if (calls < 1) {
+            throw new IllegalArgumentException("Calls must be at least 1");
+        }
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("Delay must not be negative");
+        }
+        if (jitter.isNegative()) {
+            throw new IllegalArgumentException("Jitter must not be negative");
+        }
+        if (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1) {
+            throw new IllegalArgumentException("Jitter factor must be greater than or equal to 0 and lower than 1");
+        }
+        if (!jitter.isZero() && jitterFactor != 0) {
+            throw new IllegalArgumentException("Jitter and jitter factor cannot both be greater than zero");
+        }
+        if (maxDelay.isNegative()) {
+            throw new IllegalArgumentException("Maximum delay must not be negative");
+        }
+    }
+
+    private static long multiply(long value, double factor) {
+        double result = value * factor;
+        if (Double.isNaN(result) || result <= 0) {
+            return 0;
+        }
+        if (result >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return (long) result;
+    }
+
+    private static long withJitter(SecureRandom random,
+                                   long delay,
+                                   long jitter,
+                                   double jitterFactor,
+                                   long maxDelay) {
+        long result = delay;
+        if (jitterFactor > 0) {
+            jitter = multiply(delay, jitterFactor);
+        }
+        if (jitter > 0) {
+            long randomJitter;
+            if (jitter <= Long.MAX_VALUE / 2) {
+                randomJitter = random.nextLong(-jitter, jitter);
+            } else {
+                long magnitude = random.nextLong(jitter);
+                randomJitter = random.nextBoolean() ? magnitude : -magnitude;
+            }
+            if (randomJitter > 0 && result > Long.MAX_VALUE - randomJitter) {
+                result = Long.MAX_VALUE;
+            } else {
+                result = Math.max(0, result + randomJitter);
+            }
+        }
+        return Math.min(result, maxDelay);
+    }
+
     /**
      * Strategy used to wait before another invocation attempt.
      */
@@ -483,77 +557,4 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
         }
     }
 
-    private static long durationToMillis(Duration duration) {
-        Objects.requireNonNull(duration);
-        try {
-            return Math.max(0, duration.toMillis());
-        } catch (ArithmeticException e) {
-            return duration.isNegative() ? 0 : Long.MAX_VALUE;
-        }
-    }
-
-    private static void validatePolicy(int calls,
-                                       Duration delay,
-                                       Duration jitter,
-                                       double jitterFactor,
-                                       Duration maxDelay) {
-        Objects.requireNonNull(delay);
-        Objects.requireNonNull(jitter);
-        Objects.requireNonNull(maxDelay);
-        if (calls < 1) {
-            throw new IllegalArgumentException("Calls must be at least 1");
-        }
-        if (delay.isNegative()) {
-            throw new IllegalArgumentException("Delay must not be negative");
-        }
-        if (jitter.isNegative()) {
-            throw new IllegalArgumentException("Jitter must not be negative");
-        }
-        if (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1) {
-            throw new IllegalArgumentException("Jitter factor must be greater than or equal to 0 and lower than 1");
-        }
-        if (!jitter.isZero() && jitterFactor != 0) {
-            throw new IllegalArgumentException("Jitter and jitter factor cannot both be greater than zero");
-        }
-        if (maxDelay.isNegative()) {
-            throw new IllegalArgumentException("Maximum delay must not be negative");
-        }
-    }
-
-    private static long multiply(long value, double factor) {
-        double result = value * factor;
-        if (Double.isNaN(result) || result <= 0) {
-            return 0;
-        }
-        if (result >= Long.MAX_VALUE) {
-            return Long.MAX_VALUE;
-        }
-        return (long) result;
-    }
-
-    private static long withJitter(SecureRandom random,
-                                   long delay,
-                                   long jitter,
-                                   double jitterFactor,
-                                   long maxDelay) {
-        long result = delay;
-        if (jitterFactor > 0) {
-            jitter = multiply(delay, jitterFactor);
-        }
-        if (jitter > 0) {
-            long randomJitter;
-            if (jitter <= Long.MAX_VALUE / 2) {
-                randomJitter = random.nextLong(-jitter, jitter);
-            } else {
-                long magnitude = random.nextLong(jitter);
-                randomJitter = random.nextBoolean() ? magnitude : -magnitude;
-            }
-            if (randomJitter > 0 && result > Long.MAX_VALUE - randomJitter) {
-                result = Long.MAX_VALUE;
-            } else {
-                result = Math.max(0, result + randomJitter);
-            }
-        }
-        return Math.min(result, maxDelay);
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -16,10 +16,12 @@
 
 package io.helidon.faulttolerance;
 
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.RuntimeType;
@@ -79,9 +81,54 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      * Number of times a method called has been retried. This is a monotonically
      * increasing counter over the lifetime of the handler.
      *
-     * @return number ot times a method is retried.
+     * @return number of times a method is retried
      */
     long retryCounter();
+
+    /**
+     * Invoke a function with context for each attempt.
+     * <p>
+     * Unlike {@link #invoke(Supplier)}, an invocation that does not complete successfully always throws a
+     * {@link RetryException}. The exception contains the retry outcome, including a termination reason.
+     *
+     * @param function function invoked for each attempt
+     * @param <T> type of result
+     * @return result obtained from the function
+     * @throws RetryException if the invocation does not complete successfully
+     */
+    <T> T invoke(Function<RetryContext, ? extends T> function);
+
+    /**
+     * Invoke a function with context for each attempt, using a caller-provided strategy to wait between attempts.
+     * <p>
+     * The wait strategy can perform work needed to keep a resource alive while waiting, or terminate retries by
+     * returning {@code false}.
+     *
+     * @param function function invoked for each attempt
+     * @param waitStrategy strategy that waits between attempts
+     * @param <T> type of result
+     * @return result obtained from the function
+     * @throws RetryException if the invocation does not complete successfully
+     */
+    <T> T invoke(Function<RetryContext, ? extends T> function, WaitStrategy waitStrategy);
+
+    /**
+     * Strategy used to wait before another invocation attempt.
+     */
+    @FunctionalInterface
+    interface WaitStrategy {
+        /**
+         * Wait before the next attempt.
+         * <p>
+         * An implementation that is interrupted must restore the thread interrupt status before returning or throwing.
+         * The retry invocation then terminates with {@link RetryOutcome.Termination#INTERRUPTED}.
+         *
+         * @param delay proposed delay before the next attempt
+         * @return {@code true} when the requested wait completed and another attempt should be made, {@code false} to
+         *         terminate retries
+         */
+        boolean await(Duration delay);
+    }
 
     /**
      * Retry policy to handle delays between retries.
@@ -94,7 +141,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
          *
          * @param firstCallMillis milliseconds recorded before the first call using {@link System#currentTimeMillis()}
          * @param lastDelay       last delay that was used (0 for the first failed call)
-         * @param call            call index (0 for the first failed call)
+         * @param call            number of completed calls (1 for the first failed invocation)
          * @return how long to wait before trying again, or empty to notify this is the end of retries
          */
         Optional<Long> nextDelayMillis(long firstCallMillis, long lastDelay, int call);
@@ -117,16 +164,30 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      *     <li>Second retry - 200 millis (previous delay * factor)</li>
      *     <li>Third retry - 400 millis (previous delay * factor)</li>
      * </ul>
+     * An optional absolute or relative jitter is applied after multiplying the delay. The final non-negative delay,
+     * including jitter, is capped by the configured maximum delay.
      */
     class DelayingRetryPolicy implements RetryPolicy {
+        private static final SecureRandom RANDOM = new SecureRandom();
+
         private final int calls;
         private final long delayMillis;
         private final double delayFactor;
+        private final long jitterMillis;
+        private final double jitterFactor;
+        private final long maxDelayMillis;
 
         private DelayingRetryPolicy(Builder builder) {
+            validatePolicy(builder.calls, builder.delay, builder.jitter, builder.jitterFactor, builder.maxDelay);
+            if (!Double.isFinite(builder.delayFactor) || builder.delayFactor < 0) {
+                throw new IllegalArgumentException("Delay factor must be a finite, non-negative number");
+            }
             this.calls = builder.calls;
-            this.delayMillis = builder.delay.toMillis();
+            this.delayMillis = durationToMillis(builder.delay);
             this.delayFactor = builder.delayFactor;
+            this.jitterMillis = durationToMillis(builder.jitter);
+            this.jitterFactor = builder.jitterFactor;
+            this.maxDelayMillis = durationToMillis(builder.maxDelay);
         }
 
         /**
@@ -158,11 +219,30 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                 return Optional.empty();
             }
 
-            if (call == 0 || lastDelay == 0) {
-                return Optional.of(delayMillis);
-            }
+            long delay = multiply(delayMillis, Math.pow(delayFactor, Math.max(0, call - 1)));
 
-            return Optional.of((long) (lastDelay * delayFactor));
+            return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof DelayingRetryPolicy other)) {
+                return false;
+            }
+            return calls == other.calls
+                    && delayMillis == other.delayMillis
+                    && Double.compare(delayFactor, other.delayFactor) == 0
+                    && jitterMillis == other.jitterMillis
+                    && Double.compare(jitterFactor, other.jitterFactor) == 0
+                    && maxDelayMillis == other.maxDelayMillis;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(calls, delayMillis, delayFactor, jitterMillis, jitterFactor, maxDelayMillis);
         }
 
         /**
@@ -172,6 +252,9 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             private int calls = 3;
             private double delayFactor = 2;
             private Duration delay = Duration.ofMillis(200);
+            private Duration jitter = Duration.ZERO;
+            private double jitterFactor;
+            private Duration maxDelay = Duration.ofMillis(Long.MAX_VALUE);
 
             private Builder() {
             }
@@ -213,6 +296,43 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                 this.delayFactor = delayFactor;
                 return this;
             }
+
+            /**
+             * Random part of the delay.
+             * A number between {@code [-jitter,+jitter]} is applied after the delay factor is calculated.
+             *
+             * @param jitter jitter duration
+             * @return updated builder instance
+             */
+            public Builder jitter(Duration jitter) {
+                this.jitter = Objects.requireNonNull(jitter);
+                return this;
+            }
+
+            /**
+             * Random jitter relative to the calculated delay, from {@code 0} (inclusive) to {@code 1} (exclusive).
+             * For example, a value of {@code 0.2} applies a random jitter of up to twenty percent in either direction.
+             * Relative and absolute jitter cannot both be greater than zero.
+             *
+             * @param jitterFactor relative jitter factor
+             * @return updated builder instance
+             */
+            public Builder jitterFactor(double jitterFactor) {
+                this.jitterFactor = jitterFactor;
+                return this;
+            }
+
+            /**
+             * Maximum delay between invocation attempts, including jitter. Jitter is applied first and the final
+             * non-negative delay is then capped by this value.
+             *
+             * @param maxDelay maximum delay
+             * @return updated builder instance
+             */
+            public Builder maxDelay(Duration maxDelay) {
+                this.maxDelay = Objects.requireNonNull(maxDelay);
+                return this;
+            }
         }
     }
 
@@ -229,28 +349,26 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      *
      * <ul>
      *     <li>Initial call - always immediate (not handled by retry policy)</li>
-     *     <li>First retry: 50 - 150 millis (delay +- Random.nextInt(jitter)</li>
-     *     <li>Second retry: 50 - 150 millis</li>
-     *     <li>Third retry: 50 - 150 millis</li>
+     *     <li>First retry: 50 (inclusive) - 150 (exclusive) millis</li>
+     *     <li>Second retry: 50 (inclusive) - 150 (exclusive) millis</li>
+     *     <li>Third retry: 50 (inclusive) - 150 (exclusive) millis</li>
      * </ul>
+     * The final non-negative delay, including jitter, is capped by the configured maximum delay.
      */
     class JitterRetryPolicy implements RetryPolicy {
+        private static final SecureRandom RANDOM = new SecureRandom();
+
         private final int calls;
         private final long delayMillis;
-        private final Supplier<Integer> randomJitter;
+        private final long jitterMillis;
+        private final long maxDelayMillis;
 
         private JitterRetryPolicy(Builder builder) {
+            validatePolicy(builder.calls, builder.delay, builder.jitter, 0, builder.maxDelay);
             this.calls = builder.calls;
-            this.delayMillis = builder.delay.toMillis();
-            long jitter = builder.jitter.toMillis();
-            int jitterMillis = (jitter > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) jitter;
-            if (jitterMillis == 0) {
-                randomJitter = () -> 0;
-            } else {
-                Random random = new Random();
-                // need a number [-jitterMillis,+jitterMillis]
-                randomJitter = () -> random.nextInt(jitterMillis * 2) - jitterMillis;
-            }
+            this.delayMillis = durationToMillis(builder.delay);
+            this.jitterMillis = durationToMillis(builder.jitter);
+            this.maxDelayMillis = durationToMillis(builder.maxDelay);
         }
 
         /**
@@ -263,17 +381,31 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
         }
 
         @Override
-        public Optional<Long> nextDelayMillis(long firstCallNanos, long lastDelay, int call) {
+        public Optional<Long> nextDelayMillis(long firstCallMillis, long lastDelay, int call) {
             if (call >= calls) {
                 return Optional.empty();
             }
 
-            long delay = delayMillis;
-            int jitterRandom = randomJitter.get();
-            delay = delay + jitterRandom;
-            delay = Math.max(0, delay);
+            return Optional.of(withJitter(RANDOM, delayMillis, jitterMillis, 0, maxDelayMillis));
+        }
 
-            return Optional.of(delay);
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof JitterRetryPolicy other)) {
+                return false;
+            }
+            return calls == other.calls
+                    && delayMillis == other.delayMillis
+                    && jitterMillis == other.jitterMillis
+                    && maxDelayMillis == other.maxDelayMillis;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(calls, delayMillis, jitterMillis, maxDelayMillis);
         }
 
         /**
@@ -283,6 +415,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             private int calls = 3;
             private Duration delay = Duration.ofMillis(200);
             private Duration jitter = Duration.ofMillis(50);
+            private Duration maxDelay = Duration.ofMillis(Long.MAX_VALUE);
 
             private Builder() {
             }
@@ -323,9 +456,95 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
              * @return updated builder instance
              */
             public Builder jitter(Duration jitter) {
-                this.jitter = jitter;
+                this.jitter = Objects.requireNonNull(jitter);
+                return this;
+            }
+
+            /**
+             * Maximum delay between invocation attempts, including jitter. Jitter is applied first and the final
+             * non-negative delay is then capped by this value.
+             *
+             * @param maxDelay maximum delay
+             * @return updated builder instance
+             */
+            public Builder maxDelay(Duration maxDelay) {
+                this.maxDelay = Objects.requireNonNull(maxDelay);
                 return this;
             }
         }
+    }
+
+    private static long durationToMillis(Duration duration) {
+        Objects.requireNonNull(duration);
+        try {
+            return Math.max(0, duration.toMillis());
+        } catch (ArithmeticException e) {
+            return duration.isNegative() ? 0 : Long.MAX_VALUE;
+        }
+    }
+
+    private static void validatePolicy(int calls,
+                                       Duration delay,
+                                       Duration jitter,
+                                       double jitterFactor,
+                                       Duration maxDelay) {
+        Objects.requireNonNull(delay);
+        Objects.requireNonNull(jitter);
+        Objects.requireNonNull(maxDelay);
+        if (calls < 1) {
+            throw new IllegalArgumentException("Calls must be at least 1");
+        }
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("Delay must not be negative");
+        }
+        if (jitter.isNegative()) {
+            throw new IllegalArgumentException("Jitter must not be negative");
+        }
+        if (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1) {
+            throw new IllegalArgumentException("Jitter factor must be greater than or equal to 0 and lower than 1");
+        }
+        if (!jitter.isZero() && jitterFactor != 0) {
+            throw new IllegalArgumentException("Jitter and jitter factor cannot both be greater than zero");
+        }
+        if (maxDelay.isNegative()) {
+            throw new IllegalArgumentException("Maximum delay must not be negative");
+        }
+    }
+
+    private static long multiply(long value, double factor) {
+        double result = value * factor;
+        if (Double.isNaN(result) || result <= 0) {
+            return 0;
+        }
+        if (result >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return (long) result;
+    }
+
+    private static long withJitter(SecureRandom random,
+                                   long delay,
+                                   long jitter,
+                                   double jitterFactor,
+                                   long maxDelay) {
+        long result = delay;
+        if (jitterFactor > 0) {
+            jitter = multiply(delay, jitterFactor);
+        }
+        if (jitter > 0) {
+            long randomJitter;
+            if (jitter <= Long.MAX_VALUE / 2) {
+                randomJitter = random.nextLong(-jitter, jitter);
+            } else {
+                long magnitude = random.nextLong(jitter);
+                randomJitter = random.nextBoolean() ? magnitude : -magnitude;
+            }
+            if (randomJitter > 0 && result > Long.MAX_VALUE - randomJitter) {
+                result = Long.MAX_VALUE;
+            } else {
+                result = Math.max(0, result + randomJitter);
+            }
+        }
+        return Math.min(result, maxDelay);
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -259,7 +259,6 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
         private final long jitterMillis;
         private final double jitterFactor;
         private final long maxDelayMillis;
-        private final boolean autoDerived;
 
         private DelayingRetryPolicy(Builder builder) {
             validatePolicy(builder.calls, builder.delay, builder.jitter, builder.jitterFactor, builder.maxDelay);
@@ -272,7 +271,6 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             this.jitterMillis = durationToMillis(builder.jitter);
             this.jitterFactor = builder.jitterFactor;
             this.maxDelayMillis = durationToMillis(builder.maxDelay);
-            this.autoDerived = builder.autoDerived;
         }
 
         /**
@@ -309,10 +307,6 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
         }
 
-        boolean autoDerived() {
-            return autoDerived;
-        }
-
         @Override
         public boolean equals(Object object) {
             if (this == object) {
@@ -344,7 +338,6 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             private Duration jitter = Duration.ZERO;
             private double jitterFactor;
             private Duration maxDelay = Duration.ofMillis(Long.MAX_VALUE);
-            private boolean autoDerived;
 
             private Builder() {
             }
@@ -352,11 +345,6 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             @Override
             public DelayingRetryPolicy build() {
                 return new DelayingRetryPolicy(this);
-            }
-
-            Builder autoDerived() {
-                this.autoDerived = true;
-                return this;
             }
 
             /**

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -247,8 +247,9 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
      *     <li>Second retry - 200 millis (previous delay * factor)</li>
      *     <li>Third retry - 400 millis (previous delay * factor)</li>
      * </ul>
-     * An optional absolute or relative jitter is applied after multiplying the delay. The final non-negative delay,
-     * including jitter, is capped by the configured maximum delay.
+     * An optional absolute or relative jitter is applied independently after calculating each delay. A jittered delay
+     * does not affect the calculation of later delays. The final non-negative delay, including jitter, is capped by the
+     * configured maximum delay.
      */
     class DelayingRetryPolicy implements RetryPolicy {
         private static final SecureRandom RANDOM = new SecureRandom();
@@ -302,7 +303,12 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                 return Optional.empty();
             }
 
-            long delay = call == 1 ? delayMillis : multiply(lastDelay, delayFactor);
+            long delay;
+            if (jitterMillis == 0 && jitterFactor == 0) {
+                delay = call == 1 ? delayMillis : multiply(lastDelay, delayFactor);
+            } else {
+                delay = multiply(delayMillis, Math.pow(delayFactor, Math.max(0, call - 1)));
+            }
 
             return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
         }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -259,8 +259,9 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
         private final long jitterMillis;
         private final double jitterFactor;
         private final long maxDelayMillis;
+        private final boolean autoDerived;
 
-        DelayingRetryPolicy(Builder builder) {
+        private DelayingRetryPolicy(Builder builder) {
             validatePolicy(builder.calls, builder.delay, builder.jitter, builder.jitterFactor, builder.maxDelay);
             if (!Double.isFinite(builder.delayFactor) || builder.delayFactor < 0) {
                 throw new IllegalArgumentException("Delay factor must be a finite, non-negative number");
@@ -271,6 +272,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             this.jitterMillis = durationToMillis(builder.jitter);
             this.jitterFactor = builder.jitterFactor;
             this.maxDelayMillis = durationToMillis(builder.maxDelay);
+            this.autoDerived = builder.autoDerived;
         }
 
         /**
@@ -307,6 +309,10 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
         }
 
+        boolean autoDerived() {
+            return autoDerived;
+        }
+
         @Override
         public boolean equals(Object object) {
             if (this == object) {
@@ -338,6 +344,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             private Duration jitter = Duration.ZERO;
             private double jitterFactor;
             private Duration maxDelay = Duration.ofMillis(Long.MAX_VALUE);
+            private boolean autoDerived;
 
             private Builder() {
             }
@@ -345,6 +352,11 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
             @Override
             public DelayingRetryPolicy build() {
                 return new DelayingRetryPolicy(this);
+            }
+
+            Builder autoDerived() {
+                this.autoDerived = true;
+                return this;
             }
 
             /**

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -302,7 +302,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                 return Optional.empty();
             }
 
-            long delay = multiply(delayMillis, Math.pow(delayFactor, Math.max(0, call - 1)));
+            long delay = lastDelay == 0 ? delayMillis : multiply(lastDelay, delayFactor);
 
             return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
         }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -302,7 +302,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
                 return Optional.empty();
             }
 
-            long delay = lastDelay == 0 ? delayMillis : multiply(lastDelay, delayFactor);
+            long delay = call == 1 ? delayMillis : multiply(lastDelay, delayFactor);
 
             return Optional.of(withJitter(RANDOM, delay, jitterMillis, jitterFactor, maxDelayMillis));
         }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -260,7 +260,7 @@ public interface Retry extends FtHandler, RuntimeType.Api<RetryConfig> {
         private final double jitterFactor;
         private final long maxDelayMillis;
 
-        private DelayingRetryPolicy(Builder builder) {
+        DelayingRetryPolicy(Builder builder) {
             validatePolicy(builder.calls, builder.delay, builder.jitter, builder.jitterFactor, builder.maxDelay);
             if (!Double.isFinite(builder.delayFactor) || builder.delayFactor < 0) {
                 throw new IllegalArgumentException("Delay factor must be a finite, non-negative number");

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ import io.helidon.builder.api.Prototype;
 /**
  * {@link Retry} configuration bean.
  */
-@Prototype.Blueprint(decorator = RetryConfigBlueprint.BuilderDecorator.class)
+@Prototype.Blueprint(decorator = FtBuilderSupport.RetryBuilderDecorator.class)
 @Prototype.Configured("fault-tolerance.retries")
+@Prototype.IncludeDefaultMethods({"jitterFactor", "maxDelay"})
 interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     /**
      * Default calls to make.
@@ -106,8 +107,10 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      * @return relative jitter factor
      */
     @Option.Configured
-    @Option.DefaultDouble(-1L)
-    double jitterFactor();
+    @Option.DefaultDouble(-1.0)
+    default double jitterFactor() {
+        return -1.0;
+    }
 
     /**
      * Maximum delay between invocation attempts, including jitter.
@@ -117,7 +120,9 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      * @return maximum delay, if configured
      */
     @Option.Configured
-    Optional<Duration> maxDelay();
+    default Optional<Duration> maxDelay() {
+        return Optional.empty();
+    }
 
     /**
      * Overall timeout of all retries combined.
@@ -165,78 +170,4 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     @Option.Configured
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
-
-    class BuilderDecorator implements Prototype.BuilderDecorator<RetryConfig.BuilderBase<?, ?>> {
-        @Override
-        public void decorate(RetryConfig.BuilderBase<?, ?> target) {
-            validate(target);
-            if (target.name().isEmpty()) {
-                target.config()
-                        .ifPresent(cfg -> target.name(cfg.name()));
-            }
-            if (target.retryPolicy().isEmpty()) {
-                target.retryPolicy(retryPolicy(target));
-            }
-        }
-
-        /**
-         * Retry policy created from this configuration.
-         *
-         * @return retry policy to use
-         */
-        private Retry.RetryPolicy retryPolicy(RetryConfig.BuilderBase<?, ?> target) {
-            boolean jitterConfigured = !target.jitter().equals(Duration.ofSeconds(-1));
-            boolean jitterFactorConfigured = target.jitterFactor() != -1;
-            Retry.DelayingRetryPolicy.Builder delayBuilder = Retry.DelayingRetryPolicy.builder()
-                    .calls(target.calls())
-                    .delay(target.delay());
-
-            if (target.delayFactor() != -1) {
-                delayBuilder.delayFactor(target.delayFactor());
-            } else if (jitterConfigured || jitterFactorConfigured) {
-                delayBuilder.delayFactor(1);
-            }
-            if (jitterConfigured) {
-                delayBuilder.jitter(target.jitter());
-            }
-            if (jitterFactorConfigured) {
-                delayBuilder.jitterFactor(target.jitterFactor());
-            }
-            target.maxDelay().ifPresent(delayBuilder::maxDelay);
-            return delayBuilder.build();
-        }
-
-        private void validate(RetryConfig.BuilderBase<?, ?> target) {
-            if (target.calls() < 1) {
-                throw new IllegalArgumentException("Retry calls must be at least 1");
-            }
-            if (target.delay().isNegative()) {
-                throw new IllegalArgumentException("Retry delay must not be negative");
-            }
-            if (target.overallTimeout().isNegative() || target.overallTimeout().isZero()) {
-                throw new IllegalArgumentException("Retry overall timeout must be positive");
-            }
-            double delayFactor = target.delayFactor();
-            if (delayFactor != -1 && (!Double.isFinite(delayFactor) || delayFactor < 0)) {
-                throw new IllegalArgumentException("Retry delay factor must be -1 or a finite, non-negative number");
-            }
-            Duration jitter = target.jitter();
-            if (jitter.isNegative() && !jitter.equals(Duration.ofSeconds(-1))) {
-                throw new IllegalArgumentException("Retry jitter must be PT-1S or non-negative");
-            }
-            double jitterFactor = target.jitterFactor();
-            if (jitterFactor != -1 && (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1)) {
-                throw new IllegalArgumentException("Retry jitter factor must be -1 or from 0 (inclusive) to 1 "
-                                                           + "(exclusive)");
-            }
-            if (!jitter.equals(Duration.ofSeconds(-1)) && jitterFactor != -1) {
-                throw new IllegalArgumentException("Retry jitter and jitter factor cannot both be configured");
-            }
-            target.maxDelay().ifPresent(maxDelay -> {
-                if (maxDelay.isNegative()) {
-                    throw new IllegalArgumentException("Retry maximum delay must not be negative");
-                }
-            });
-        }
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -72,10 +72,11 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     Duration delay();
 
     /**
-     * Delay retry policy factor. If unspecified (value of {@code -1}), Jitter retry policy would be used, unless
-     * jitter is also unspecified.
+     * Delay retry policy factor. If unspecified (value of {@code -1}), a factor of {@code 2} is used unless jitter is
+     * configured, in which case the delay remains constant.
      * <p>
-     * Default when {@link Retry.DelayingRetryPolicy} is used is {@code 2}.
+     * When both this option and {@link #jitter()} are configured, the delay factor is applied first and jitter is
+     * applied to the resulting delay.
      *
      * @return delay factor for delaying retry policy
      */
@@ -84,15 +85,39 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     double delayFactor();
 
     /**
-     * Jitter for {@link Retry.JitterRetryPolicy}. If unspecified (value of {@code -1}),
-     * delaying retry policy is used. If both this value, and {@link #delayFactor()} are specified, delaying retry policy
-     * would be used.
+     * Random jitter applied to the delay. If unspecified (value of {@code PT-1S}), jitter is not applied.
+     * When both this option and {@link #delayFactor()} are configured, the delay factor is applied first and jitter is
+     * applied to the resulting delay. The final delay is capped by {@link #maxDelay()}, when configured.
      *
      * @return jitter
      */
     @Option.Configured
     @Option.Default("PT-1S")
     Duration jitter();
+
+    /**
+     * Random jitter relative to the calculated delay. The factor must be from {@code 0} (inclusive) to {@code 1}
+     * (exclusive). For example, a value of {@code 0.2} applies a random jitter of up to twenty percent in either
+     * direction.
+     * <p>
+     * This option cannot be combined with an explicitly configured {@link #jitter() absolute jitter}. A value of
+     * {@code -1} means relative jitter is not configured.
+     *
+     * @return relative jitter factor
+     */
+    @Option.Configured
+    @Option.DefaultDouble(-1L)
+    double jitterFactor();
+
+    /**
+     * Maximum delay between invocation attempts, including jitter.
+     * <p>
+     * When not configured, the delay is not capped.
+     *
+     * @return maximum delay, if configured
+     */
+    @Option.Configured
+    Optional<Duration> maxDelay();
 
     /**
      * Overall timeout of all retries combined.
@@ -144,6 +169,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     class BuilderDecorator implements Prototype.BuilderDecorator<RetryConfig.BuilderBase<?, ?>> {
         @Override
         public void decorate(RetryConfig.BuilderBase<?, ?> target) {
+            validate(target);
             if (target.name().isEmpty()) {
                 target.config()
                         .ifPresent(cfg -> target.name(cfg.name()));
@@ -159,28 +185,58 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
          * @return retry policy to use
          */
         private Retry.RetryPolicy retryPolicy(RetryConfig.BuilderBase<?, ?> target) {
-            if (target.jitter().toSeconds() == -1) {
-                Retry.DelayingRetryPolicy.Builder delayBuilder = Retry.DelayingRetryPolicy.builder()
-                        .calls(target.calls())
-                        .delay(target.delay());
-
-                if (target.delayFactor() != -1) {
-                    delayBuilder.delayFactor(target.delayFactor());
-                }
-                return delayBuilder.build();
-            }
-            if (target.delayFactor() != -1) {
-                return Retry.DelayingRetryPolicy.builder()
-                        .calls(target.calls())
-                        .delayFactor(target.delayFactor())
-                        .delay(target.delay())
-                        .build();
-            }
-            return Retry.JitterRetryPolicy.builder()
+            boolean jitterConfigured = !target.jitter().equals(Duration.ofSeconds(-1));
+            boolean jitterFactorConfigured = target.jitterFactor() != -1;
+            Retry.DelayingRetryPolicy.Builder delayBuilder = Retry.DelayingRetryPolicy.builder()
                     .calls(target.calls())
-                    .delay(target.delay())
-                    .jitter(target.jitter())
-                    .build();
+                    .delay(target.delay());
+
+            if (target.delayFactor() != -1) {
+                delayBuilder.delayFactor(target.delayFactor());
+            } else if (jitterConfigured || jitterFactorConfigured) {
+                delayBuilder.delayFactor(1);
+            }
+            if (jitterConfigured) {
+                delayBuilder.jitter(target.jitter());
+            }
+            if (jitterFactorConfigured) {
+                delayBuilder.jitterFactor(target.jitterFactor());
+            }
+            target.maxDelay().ifPresent(delayBuilder::maxDelay);
+            return delayBuilder.build();
+        }
+
+        private void validate(RetryConfig.BuilderBase<?, ?> target) {
+            if (target.calls() < 1) {
+                throw new IllegalArgumentException("Retry calls must be at least 1");
+            }
+            if (target.delay().isNegative()) {
+                throw new IllegalArgumentException("Retry delay must not be negative");
+            }
+            if (target.overallTimeout().isNegative() || target.overallTimeout().isZero()) {
+                throw new IllegalArgumentException("Retry overall timeout must be positive");
+            }
+            double delayFactor = target.delayFactor();
+            if (delayFactor != -1 && (!Double.isFinite(delayFactor) || delayFactor < 0)) {
+                throw new IllegalArgumentException("Retry delay factor must be -1 or a finite, non-negative number");
+            }
+            Duration jitter = target.jitter();
+            if (jitter.isNegative() && !jitter.equals(Duration.ofSeconds(-1))) {
+                throw new IllegalArgumentException("Retry jitter must be PT-1S or non-negative");
+            }
+            double jitterFactor = target.jitterFactor();
+            if (jitterFactor != -1 && (!Double.isFinite(jitterFactor) || jitterFactor < 0 || jitterFactor >= 1)) {
+                throw new IllegalArgumentException("Retry jitter factor must be -1 or from 0 (inclusive) to 1 "
+                                                           + "(exclusive)");
+            }
+            if (!jitter.equals(Duration.ofSeconds(-1)) && jitterFactor != -1) {
+                throw new IllegalArgumentException("Retry jitter and jitter factor cannot both be configured");
+            }
+            target.maxDelay().ifPresent(maxDelay -> {
+                if (maxDelay.isNegative()) {
+                    throw new IllegalArgumentException("Retry maximum delay must not be negative");
+                }
+            });
         }
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -54,7 +54,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     Optional<String> name();
 
     /**
-     * Number of calls (first try + retries).
+     * Number of calls, including the initial call and retries, which must be at least {@code 1}.
      *
      * @return number of desired calls, must be 1 (means no retries) or higher.
      */
@@ -63,8 +63,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     int calls();
 
     /**
-     * Base delay between try and retry.
-     * Defaults to {@code 200 ms}.
+     * Non-negative base delay between the initial call and retries, which defaults to {@code 200 ms}.
      *
      * @return delay between retries (combines with retry policy)
      */
@@ -73,11 +72,8 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     Duration delay();
 
     /**
-     * Delay retry policy factor. If unspecified (value of {@code -1}), a factor of {@code 2} is used unless jitter is
-     * configured, in which case the delay remains constant.
-     * <p>
-     * When both this option and {@link #jitter()} are configured, the delay factor is applied first and jitter is
-     * applied to the resulting delay.
+     * Delay multiplier that must be {@code -1} or finite and non-negative; {@code -1} selects {@code 2} unless either
+     * jitter option is configured, and an explicit multiplier is applied before jitter.
      *
      * @return delay factor for delaying retry policy
      */
@@ -86,9 +82,8 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     double delayFactor();
 
     /**
-     * Random jitter applied to the delay. If unspecified (value of {@code PT-1S}), jitter is not applied.
-     * When both this option and {@link #delayFactor()} are configured, the delay factor is applied first and jitter is
-     * applied to the resulting delay. The final delay is capped by {@link #maxDelay()}, when configured.
+     * Absolute random jitter that must be {@code PT-1S} (disabled) or non-negative; it cannot be combined with
+     * {@code jitter-factor}, is applied after {@code delay-factor}, and is capped by {@code max-delay} when present.
      *
      * @return jitter
      */
@@ -97,12 +92,10 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     Duration jitter();
 
     /**
-     * Random jitter relative to the calculated delay. The factor must be from {@code 0} (inclusive) to {@code 1}
-     * (exclusive). For example, a value of {@code 0.2} applies a random jitter of up to twenty percent in either
-     * direction.
-     * <p>
-     * This option cannot be combined with an explicitly configured {@link #jitter() absolute jitter}. A value of
-     * {@code -1} means relative jitter is not configured.
+     * Relative random jitter that must be {@code -1} (disabled) or from {@code 0} (inclusive) to {@code 1} (exclusive);
+     * it cannot be combined with {@code jitter}, is applied after {@code delay-factor}, and is capped by
+     * {@code max-delay} when present.
+     * A value of {@code 0.2} applies a random jitter of up to twenty percent in either direction.
      *
      * @return relative jitter factor
      */
@@ -113,9 +106,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     }
 
     /**
-     * Maximum delay between invocation attempts, including jitter.
-     * <p>
-     * When not configured, the delay is not capped.
+     * Optional non-negative maximum delay applied after jitter; when absent, the delay is not capped.
      *
      * @return maximum delay, if configured
      */
@@ -125,7 +116,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
     }
 
     /**
-     * Overall timeout of all retries combined.
+     * Positive overall timeout used to bound the complete retry sequence.
      *
      * @return overall timeout
      */

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -58,6 +58,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return number of desired calls, must be 1 (means no retries) or higher.
      */
+    @Option.Decorator(FtBuilderSupport.RetryIntegerOptionDecorator.class)
     @Option.Configured
     @Option.DefaultInt(DEFAULT_CALLS)
     int calls();
@@ -67,6 +68,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return delay between retries (combines with retry policy)
      */
+    @Option.Decorator(FtBuilderSupport.RetryDurationOptionDecorator.class)
     @Option.Configured
     @Option.Default("PT0.2S")
     Duration delay();
@@ -77,6 +79,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return delay factor for delaying retry policy
      */
+    @Option.Decorator(FtBuilderSupport.RetryDoubleOptionDecorator.class)
     @Option.Configured
     @Option.DefaultDouble(-1L)
     double delayFactor();
@@ -87,6 +90,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return jitter
      */
+    @Option.Decorator(FtBuilderSupport.RetryDurationOptionDecorator.class)
     @Option.Configured
     @Option.Default("PT-1S")
     Duration jitter();
@@ -99,6 +103,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return relative jitter factor
      */
+    @Option.Decorator(FtBuilderSupport.RetryDoubleOptionDecorator.class)
     @Option.Configured
     @Option.DefaultDouble(-1.0)
     default double jitterFactor() {
@@ -110,6 +115,7 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
      *
      * @return maximum delay, if configured
      */
+    @Option.Decorator(FtBuilderSupport.RetryOptionalDurationOptionDecorator.class)
     @Option.Configured
     default Optional<Duration> maxDelay() {
         return Optional.empty();
@@ -144,6 +150,8 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
 
     /**
      * Explicitly configured retry policy.
+     * The most recently configured policy-related option takes precedence. Configuring calls, delay, delay factor,
+     * jitter, jitter factor, or maximum delay after this option clears it so a new policy is derived from those settings.
      *
      * @return retry policy
      */

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryConfigBlueprint.java
@@ -86,7 +86,8 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
 
     /**
      * Absolute random jitter that must be {@code PT-1S} (disabled) or non-negative; it cannot be combined with
-     * {@code jitter-factor}, is applied after {@code delay-factor}, and is capped by {@code max-delay} when present.
+     * {@code jitter-factor}, is applied independently after {@code delay-factor}, does not affect later base-delay
+     * calculations, and is capped by {@code max-delay} when present.
      *
      * @return jitter
      */
@@ -97,8 +98,8 @@ interface RetryConfigBlueprint extends Prototype.Factory<Retry> {
 
     /**
      * Relative random jitter that must be {@code -1} (disabled) or from {@code 0} (inclusive) to {@code 1} (exclusive);
-     * it cannot be combined with {@code jitter}, is applied after {@code delay-factor}, and is capped by
-     * {@code max-delay} when present.
+     * it cannot be combined with {@code jitter}, is applied independently after {@code delay-factor}, does not affect
+     * later base-delay calculations, and is capped by {@code max-delay} when present.
      * A value of {@code 0.2} applies a random jitter of up to twenty percent in either direction.
      *
      * @return relative jitter factor

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContext.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContext.java
@@ -17,7 +17,6 @@
 package io.helidon.faulttolerance;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -27,36 +26,20 @@ import java.util.Optional;
  * throwable. Each subsequent attempt provides the delay preceding that attempt and the throwable from the previous
  * attempt. The context is created immediately before invoking the function for an attempt.
  */
-public final class RetryContext {
-    private final int attempt;
-    private final Duration elapsedTime;
-    private final Duration previousDelay;
-    private final Throwable previousThrowable;
-
-    RetryContext(int attempt, Duration elapsedTime, Duration previousDelay, Throwable previousThrowable) {
-        this.attempt = attempt;
-        this.elapsedTime = Objects.requireNonNull(elapsedTime);
-        this.previousDelay = Objects.requireNonNull(previousDelay);
-        this.previousThrowable = previousThrowable;
-    }
-
+public interface RetryContext {
     /**
      * Number of the current invocation attempt.
      *
      * @return 1-based invocation attempt number
      */
-    public int attempt() {
-        return attempt;
-    }
+    int attempt();
 
     /**
      * Time elapsed since the retry invocation started when this attempt began.
      *
      * @return elapsed time
      */
-    public Duration elapsedTime() {
-        return elapsedTime;
-    }
+    Duration elapsedTime();
 
     /**
      * Requested delay preceding this attempt.
@@ -65,16 +48,12 @@ public final class RetryContext {
      *
      * @return requested delay preceding this attempt
      */
-    public Duration previousDelay() {
-        return previousDelay;
-    }
+    Duration previousDelay();
 
     /**
      * Throwable from the preceding attempt.
      *
      * @return preceding throwable, or empty for the initial attempt
      */
-    public Optional<Throwable> previousThrowable() {
-        return Optional.ofNullable(previousThrowable);
-    }
+    Optional<Throwable> previousThrowable();
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContext.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContext.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Context of an invocation attempt handled by {@link Retry}.
+ * <p>
+ * The first attempt has an attempt number of {@code 1}, a previous delay of {@link Duration#ZERO}, and no previous
+ * throwable. Each subsequent attempt provides the delay preceding that attempt and the throwable from the previous
+ * attempt. The context is created immediately before invoking the function for an attempt.
+ */
+public final class RetryContext {
+    private final int attempt;
+    private final Duration elapsedTime;
+    private final Duration previousDelay;
+    private final Throwable previousThrowable;
+
+    RetryContext(int attempt, Duration elapsedTime, Duration previousDelay, Throwable previousThrowable) {
+        this.attempt = attempt;
+        this.elapsedTime = Objects.requireNonNull(elapsedTime);
+        this.previousDelay = Objects.requireNonNull(previousDelay);
+        this.previousThrowable = previousThrowable;
+    }
+
+    /**
+     * Number of the current invocation attempt.
+     *
+     * @return 1-based invocation attempt number
+     */
+    public int attempt() {
+        return attempt;
+    }
+
+    /**
+     * Time elapsed since the retry invocation started when this attempt began.
+     *
+     * @return elapsed time
+     */
+    public Duration elapsedTime() {
+        return elapsedTime;
+    }
+
+    /**
+     * Requested delay preceding this attempt.
+     * <p>
+     * The value is {@link Duration#ZERO} for the initial attempt.
+     *
+     * @return requested delay preceding this attempt
+     */
+    public Duration previousDelay() {
+        return previousDelay;
+    }
+
+    /**
+     * Throwable from the preceding attempt.
+     *
+     * @return preceding throwable, or empty for the initial attempt
+     */
+    public Optional<Throwable> previousThrowable() {
+        return Optional.ofNullable(previousThrowable);
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContextImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContextImpl.java
@@ -17,7 +17,6 @@
 package io.helidon.faulttolerance;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Optional;
 
 record RetryContextImpl(int attempt,

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContextImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryContextImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+record RetryContextImpl(int attempt,
+                        Duration elapsedTime,
+                        Duration previousDelay,
+                        Throwable previousThrowableValue) implements RetryContext {
+
+    @Override
+    public Optional<Throwable> previousThrowable() {
+        return Optional.ofNullable(previousThrowableValue);
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryException.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.util.Objects;
+
+/**
+ * Exception thrown by contextual {@link Retry} invocations.
+ */
+public final class RetryException extends FaultToleranceException {
+    private static final long serialVersionUID = -4170677285736327133L;
+
+    /**
+     * Retry outcome.
+     */
+    private final RetryOutcome outcome;
+
+    /**
+     * Create a retry exception.
+     *
+     * @param message error message
+     * @param outcome retry outcome
+     * @param cause exception that caused the retry invocation to terminate
+     */
+    RetryException(String message, RetryOutcome outcome, Throwable cause) {
+        super(message, cause);
+        this.outcome = Objects.requireNonNull(outcome);
+    }
+
+    /**
+     * Reason the retry invocation terminated.
+     *
+     * @return termination reason
+     */
+    public RetryOutcome.Termination termination() {
+        return outcome.termination();
+    }
+
+    /**
+     * Retry outcome.
+     *
+     * @return retry outcome
+     */
+    public RetryOutcome outcome() {
+        return outcome;
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryException.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryException.java
@@ -30,13 +30,24 @@ public final class RetryException extends FaultToleranceException {
     private final RetryOutcome outcome;
 
     /**
+     * Create a retry exception without a cause.
+     *
+     * @param message error message
+     * @param outcome retry outcome
+     */
+    public RetryException(String message, RetryOutcome outcome) {
+        super(message);
+        this.outcome = Objects.requireNonNull(outcome);
+    }
+
+    /**
      * Create a retry exception.
      *
      * @param message error message
      * @param outcome retry outcome
      * @param cause exception that caused the retry invocation to terminate
      */
-    RetryException(String message, RetryOutcome outcome, Throwable cause) {
+    public RetryException(String message, RetryOutcome outcome, Throwable cause) {
         super(message, cause);
         this.outcome = Objects.requireNonNull(outcome);
     }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -35,15 +35,7 @@ import io.helidon.service.registry.ServiceRegistry;
 
 class RetryImpl implements Retry {
     private static final int MAX_RETAINED_FAILURES = 16;
-    private static final WaitStrategy DEFAULT_WAIT_STRATEGY = delay -> {
-        try {
-            Thread.sleep(delay);
-            return true;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new WaitInterruptedException(e);
-        }
-    };
+    private static final WaitStrategy DEFAULT_WAIT_STRATEGY = new DefaultWaitStrategy();
 
     private final ErrorChecker errorChecker;
     private final long maxTimeNanos;
@@ -356,7 +348,7 @@ class RetryImpl implements Retry {
         private int attempt = 1;
         private long previousDelayMillis;
         private Throwable lastFailure;
-        private RetryContext context = new RetryContext(1, Duration.ZERO, Duration.ZERO, null);
+        private RetryContext context = new RetryContextImpl(1, Duration.ZERO, Duration.ZERO, null);
 
         private RetryContext context() {
             return context;
@@ -367,11 +359,11 @@ class RetryImpl implements Retry {
         }
 
         private RetryOutcome outcome(RetryOutcome.Termination termination, long now) {
-            return new RetryOutcome(termination,
-                                    attempt,
-                                    Duration.ofNanos(elapsedNanos(startedNanos, now)),
-                                    Duration.ofMillis(previousDelayMillis),
-                                    lastFailure);
+            return new RetryOutcomeImpl(termination,
+                                        attempt,
+                                        Duration.ofNanos(elapsedNanos(startedNanos, now)),
+                                        Duration.ofMillis(previousDelayMillis),
+                                        lastFailure);
         }
 
         private void failure(Throwable failure) {
@@ -387,10 +379,10 @@ class RetryImpl implements Retry {
             if (attempt < Integer.MAX_VALUE) {
                 attempt++;
             }
-            context = new RetryContext(attempt,
-                                       Duration.ofNanos(elapsedNanos(startedNanos, now)),
-                                       Duration.ofMillis(previousDelayMillis),
-                                       lastFailure);
+            context = new RetryContextImpl(attempt,
+                                           Duration.ofNanos(elapsedNanos(startedNanos, now)),
+                                           Duration.ofMillis(previousDelayMillis),
+                                           lastFailure);
         }
 
         private <T> T throwLegacy() {
@@ -412,6 +404,19 @@ class RetryImpl implements Retry {
 
         private WaitInterruptedException(InterruptedException cause) {
             super(cause);
+        }
+    }
+
+    private static final class DefaultWaitStrategy implements WaitStrategy {
+        @Override
+        public boolean await(Duration delay) {
+            try {
+                Thread.sleep(delay);
+                return true;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new WaitInterruptedException(e);
+            }
         }
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -107,6 +107,63 @@ class RetryImpl implements Retry {
         return invoke(function, waitStrategy, false);
     }
 
+    @Override
+    public long retryCounter() {
+        return retryCounter.get();
+    }
+
+    private static long durationToNanos(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
+        }
+    }
+
+    private static long millisToNanos(long millis) {
+        if (millis > Long.MAX_VALUE / 1_000_000) {
+            return Long.MAX_VALUE;
+        }
+        return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+
+    private static long elapsedNanos(long startedNanos, long now) {
+        return Math.max(0, now - startedNanos);
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        Throwable unwrapped = SupplierHelper.unwrapThrowable(throwable);
+        if (unwrapped instanceof ExecutionException) {
+            unwrapped = unwrapped.getCause();
+        }
+        return unwrapped == null ? throwable : unwrapped;
+    }
+
+    private static Throwable interrupted(Throwable throwable) {
+        Throwable current = throwable;
+        for (int i = 0; current != null && i < 64; i++) {
+            if (current instanceof InterruptedException) {
+                return current;
+            }
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                return null;
+            }
+            current = cause;
+        }
+        return null;
+    }
+
+    private static <T> T throwLegacy(Throwable throwable) {
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new SupplierException(throwable);
+    }
+
     private <T> T invoke(Function<RetryContext, ? extends T> function,
                          WaitStrategy waitStrategy,
                          boolean legacy) {
@@ -208,11 +265,6 @@ class RetryImpl implements Retry {
         }
     }
 
-    @Override
-    public long retryCounter() {
-        return retryCounter.get();
-    }
-
     private <T> T terminateAfterInvocation(boolean legacy,
                                            RetryOutcome.Termination termination,
                                            InvocationState state,
@@ -287,58 +339,6 @@ class RetryImpl implements Retry {
                 + " ms, must be lower than overallTimeout duration of: "
                 + overallTimeout
                 + ".";
-    }
-
-    private static long durationToNanos(Duration duration) {
-        try {
-            return duration.toNanos();
-        } catch (ArithmeticException e) {
-            return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
-        }
-    }
-
-    private static long millisToNanos(long millis) {
-        if (millis > Long.MAX_VALUE / 1_000_000) {
-            return Long.MAX_VALUE;
-        }
-        return TimeUnit.MILLISECONDS.toNanos(millis);
-    }
-
-    private static long elapsedNanos(long startedNanos, long now) {
-        return Math.max(0, now - startedNanos);
-    }
-
-    private static Throwable unwrap(Throwable throwable) {
-        Throwable unwrapped = SupplierHelper.unwrapThrowable(throwable);
-        if (unwrapped instanceof ExecutionException) {
-            unwrapped = unwrapped.getCause();
-        }
-        return unwrapped == null ? throwable : unwrapped;
-    }
-
-    private static Throwable interrupted(Throwable throwable) {
-        Throwable current = throwable;
-        for (int i = 0; current != null && i < 64; i++) {
-            if (current instanceof InterruptedException) {
-                return current;
-            }
-            Throwable cause = current.getCause();
-            if (cause == current) {
-                return null;
-            }
-            current = cause;
-        }
-        return null;
-    }
-
-    private static <T> T throwLegacy(Throwable throwable) {
-        if (throwable instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
-        if (throwable instanceof Error error) {
-            throw error;
-        }
-        throw new SupplierException(throwable);
     }
 
     private static final class InvocationState {

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -17,13 +17,14 @@
 package io.helidon.faulttolerance;
 
 import java.time.Duration;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.metrics.api.Counter;
@@ -33,8 +34,20 @@ import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 
 class RetryImpl implements Retry {
+    private static final int MAX_RETAINED_FAILURES = 16;
+    private static final WaitStrategy DEFAULT_WAIT_STRATEGY = delay -> {
+        try {
+            Thread.sleep(delay);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new WaitInterruptedException(e);
+        }
+    };
+
     private final ErrorChecker errorChecker;
     private final long maxTimeNanos;
+    private final Duration overallTimeout;
     private final RetryPolicy retryPolicy;
     private final RetryConfig retryConfig;
     private final AtomicLong retryCounter = new AtomicLong(0L);
@@ -61,7 +74,8 @@ class RetryImpl implements Retry {
                       boolean metricsDefaultEnabled) {
         this.name = retryConfig.name().orElseGet(() -> "retry-" + System.identityHashCode(retryConfig));
         this.errorChecker = ErrorChecker.create(retryConfig.skipOn(), retryConfig.applyOn());
-        this.maxTimeNanos = retryConfig.overallTimeout().toNanos();
+        this.overallTimeout = retryConfig.overallTimeout();
+        this.maxTimeNanos = durationToNanos(overallTimeout);
         this.retryPolicy = retryConfig.retryPolicy().orElseThrow();
         this.retryConfig = retryConfig;
 
@@ -87,54 +101,118 @@ class RetryImpl implements Retry {
 
     @Override
     public <T> T invoke(Supplier<? extends T> supplier) {
-        RetryContext<? extends T> context = new RetryContext<>();
+        Objects.requireNonNull(supplier);
+        return invoke(context -> supplier.get(), DEFAULT_WAIT_STRATEGY, true);
+    }
+
+    @Override
+    public <T> T invoke(Function<RetryContext, ? extends T> function) {
+        return invoke(function, DEFAULT_WAIT_STRATEGY, false);
+    }
+
+    @Override
+    public <T> T invoke(Function<RetryContext, ? extends T> function, WaitStrategy waitStrategy) {
+        return invoke(function, waitStrategy, false);
+    }
+
+    private <T> T invoke(Function<RetryContext, ? extends T> function,
+                         WaitStrategy waitStrategy,
+                         boolean legacy) {
+        Objects.requireNonNull(function);
+        Objects.requireNonNull(waitStrategy);
+        InvocationState state = new InvocationState();
         while (true) {
             try {
                 if (metricsEnabled) {
                     callsCounterMetric.increment();
                 }
-                return supplier.get();
+                return function.apply(state.context());
             } catch (Throwable t) {
-                Throwable throwable = SupplierHelper.unwrapThrowable(t);
-                // if an ExecutionException, extract real cause
-                if (throwable instanceof ExecutionException) {
-                    throwable = throwable.getCause();
+                Throwable throwable = unwrap(t);
+                state.failure(throwable);
+                Throwable interrupted = throwable instanceof Error ? null : interrupted(t);
+                if (interrupted != null) {
+                    Thread.currentThread().interrupt();
+                    return terminateAfterInvocation(legacy,
+                                                    RetryOutcome.Termination.INTERRUPTED,
+                                                    state,
+                                                    interrupted);
                 }
-                context.thrown.add(throwable);
-                if (errorChecker.shouldSkip(throwable)
-                        || throwable instanceof InterruptedException) {     // no retry on interrupt
-                    return context.throwIt();
+                if (errorChecker.shouldSkip(throwable)) {
+                    return terminateAfterInvocation(legacy,
+                                                    RetryOutcome.Termination.NOT_RETRYABLE,
+                                                    state,
+                                                    throwable);
                 }
             }
-            // now retry
-            int currentCallIndex = context.count.incrementAndGet();
-            Optional<Long> maybeDelay = computeDelay(context, currentCallIndex);
+
+            Optional<Long> maybeDelay;
+            try {
+                maybeDelay = Objects.requireNonNull(retryPolicy.nextDelayMillis(state.startedMillis,
+                                                                                state.previousDelayMillis,
+                                                                                state.attempt),
+                                                    "Retry policy returned null");
+            } catch (RuntimeException t) {
+                return terminatePolicyFailure(legacy, state, t);
+            }
             if (maybeDelay.isEmpty()) {
-                return context.throwIt();
+                return terminateAfterInvocation(legacy,
+                                                RetryOutcome.Termination.RETRIES_EXHAUSTED,
+                                                state,
+                                                state.lastFailure);
             }
 
             long delayMillis = maybeDelay.get();
+            if (delayMillis < 0) {
+                return terminatePolicyFailure(legacy,
+                                              state,
+                                              new IllegalArgumentException("Retry policy returned a negative delay: "
+                                                                                   + delayMillis + " ms"));
+            }
 
-            // check timeout before sleep (if execution took too long)
             long now = System.nanoTime();
-            checkTimeout(context, now);
-            // check timeout after sleep
-            checkTimeout(context, now + TimeUnit.MILLISECONDS.toNanos(delayMillis));
+            if (isTimedOut(state, now, delayMillis)) {
+                return terminateTimeout(legacy, state, now);
+            }
 
-            // now we are retrying for sure
+            boolean continueRetries;
+            try {
+                continueRetries = waitStrategy.await(Duration.ofMillis(delayMillis));
+            } catch (RuntimeException t) {
+                Throwable interrupted = interrupted(t);
+                if (interrupted != null) {
+                    Thread.currentThread().interrupt();
+                    return terminateWait(legacy,
+                                         RetryOutcome.Termination.INTERRUPTED,
+                                         state,
+                                         interrupted);
+                }
+                return terminateWait(legacy, RetryOutcome.Termination.WAIT_FAILED, state, t);
+            }
+
+            if (Thread.currentThread().isInterrupted()) {
+                return terminateWait(legacy,
+                                     RetryOutcome.Termination.INTERRUPTED,
+                                     state,
+                                     new InterruptedException("Retry wait interrupted"));
+            }
+            if (!continueRetries) {
+                return terminateWait(legacy,
+                                     RetryOutcome.Termination.CANCELLED,
+                                     state,
+                                     state.lastFailure);
+            }
+
+            now = System.nanoTime();
+            if (isTimedOut(state, now, 0)) {
+                return terminateTimeout(legacy, state, now);
+            }
+
             retryCounter.getAndIncrement();
             if (metricsEnabled) {
                 retryCounterMetric.increment();
             }
-
-            // just block current thread, we are expected to run in Virtual threads with Loom
-            try {
-                Thread.sleep(Duration.ofMillis(delayMillis));
-            } catch (InterruptedException e) {
-                e.addSuppressed(context.throwable());
-                throw new RuntimeException("Retries interrupted", e);
-            }
-            context.lastDelay.set(delayMillis);
+            state.nextAttempt(delayMillis, now);
         }
     }
 
@@ -143,63 +221,197 @@ class RetryImpl implements Retry {
         return retryCounter.get();
     }
 
-    void checkTimeout(RetryContext<?> context, long nanoTime) {
-        if ((nanoTime - context.startedNanos) > maxTimeNanos) {
-            RetryTimeoutException te = new RetryTimeoutException("Execution took too long. Already executing for: "
-                                                                         + TimeUnit.NANOSECONDS.toMillis(
-                    nanoTime - context.startedNanos)
-                                                                         + " ms, must be lower than overallTimeout duration of: "
-                                                                         + TimeUnit.NANOSECONDS.toMillis(maxTimeNanos)
-                                                                         + " ms.",
-                                                                 context.throwable());
-            throw te;
+    private <T> T terminateAfterInvocation(boolean legacy,
+                                           RetryOutcome.Termination termination,
+                                           InvocationState state,
+                                           Throwable cause) {
+        if (legacy) {
+            return state.throwLegacy();
+        }
+        throw retryException(termination, state, cause);
+    }
+
+    private <T> T terminatePolicyFailure(boolean legacy, InvocationState state, Throwable cause) {
+        if (legacy) {
+            return throwLegacy(cause);
+        }
+        throw retryException(RetryOutcome.Termination.RETRY_POLICY_FAILED, state, cause);
+    }
+
+    private <T> T terminateWait(boolean legacy,
+                                RetryOutcome.Termination termination,
+                                InvocationState state,
+                                Throwable cause) {
+        if (legacy) {
+            if (termination == RetryOutcome.Termination.INTERRUPTED) {
+                Throwable lastFailure = state.legacyThrowable();
+                if (cause != lastFailure) {
+                    cause.addSuppressed(lastFailure);
+                }
+                throw new RuntimeException("Retries interrupted", cause);
+            }
+            return throwLegacy(cause);
+        }
+        throw retryException(termination, state, cause);
+    }
+
+    private <T> T terminateTimeout(boolean legacy, InvocationState state, long now) {
+        String message = timeoutMessage(state, now);
+        if (legacy) {
+            throw new RetryTimeoutException(message, state.legacyThrowable());
+        }
+        throw new RetryException(message,
+                                 state.outcome(RetryOutcome.Termination.TIMED_OUT, now),
+                                 state.lastFailure);
+    }
+
+    private RetryException retryException(RetryOutcome.Termination termination,
+                                          InvocationState state,
+                                          Throwable cause) {
+        String message = switch (termination) {
+        case RETRIES_EXHAUSTED -> "Retries exhausted";
+        case NOT_RETRYABLE -> "Invocation failed with a non-retriable throwable";
+        case TIMED_OUT -> "Retry invocation timed out";
+        case INTERRUPTED -> "Retry invocation interrupted";
+        case CANCELLED -> "Retry invocation cancelled by the wait strategy";
+        case WAIT_FAILED -> "Retry wait strategy failed";
+        case RETRY_POLICY_FAILED -> "Retry policy failed";
+        };
+        return new RetryException(message, state.outcome(termination), cause);
+    }
+
+    private boolean isTimedOut(InvocationState state, long now, long additionalDelayMillis) {
+        long elapsedNanos = elapsedNanos(state.startedNanos, now);
+        if (elapsedNanos > maxTimeNanos) {
+            return true;
+        }
+        long delayNanos = millisToNanos(additionalDelayMillis);
+        return delayNanos > maxTimeNanos - elapsedNanos;
+    }
+
+    private String timeoutMessage(InvocationState state, long now) {
+        return "Execution took too long. Already executing for: "
+                + TimeUnit.NANOSECONDS.toMillis(elapsedNanos(state.startedNanos, now))
+                + " ms, must be lower than overallTimeout duration of: "
+                + overallTimeout
+                + ".";
+    }
+
+    private static long durationToNanos(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException e) {
+            return duration.isNegative() ? Long.MIN_VALUE : Long.MAX_VALUE;
         }
     }
 
-    private Optional<Long> computeDelay(RetryContext<?> context, int currentCallIndex) {
-        return retryPolicy.nextDelayMillis(context.startedMillis,
-                                           context.lastDelay.get(),
-                                           currentCallIndex);
+    private static long millisToNanos(long millis) {
+        if (millis > Long.MAX_VALUE / 1_000_000) {
+            return Long.MAX_VALUE;
+        }
+        return TimeUnit.MILLISECONDS.toNanos(millis);
     }
 
-    private static class RetryContext<U> {
-        // retry runtime
+    private static long elapsedNanos(long startedNanos, long now) {
+        return Math.max(0, now - startedNanos);
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        Throwable unwrapped = SupplierHelper.unwrapThrowable(throwable);
+        if (unwrapped instanceof ExecutionException) {
+            unwrapped = unwrapped.getCause();
+        }
+        return unwrapped == null ? throwable : unwrapped;
+    }
+
+    private static Throwable interrupted(Throwable throwable) {
+        Throwable current = throwable;
+        for (int i = 0; current != null && i < 64; i++) {
+            if (current instanceof InterruptedException) {
+                return current;
+            }
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                return null;
+            }
+            current = cause;
+        }
+        return null;
+    }
+
+    private static <T> T throwLegacy(Throwable throwable) {
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        throw new SupplierException(throwable);
+    }
+
+    private static final class InvocationState {
         private final long startedMillis = System.currentTimeMillis();
         private final long startedNanos = System.nanoTime();
-        private final AtomicInteger count = new AtomicInteger();
-        private final List<Throwable> thrown = new LinkedList<>();
-        private final AtomicLong lastDelay = new AtomicLong();
+        private final Deque<Throwable> failures = new ArrayDeque<>(MAX_RETAINED_FAILURES);
+        private int attempt = 1;
+        private long previousDelayMillis;
+        private Throwable lastFailure;
+        private RetryContext context = new RetryContext(1, Duration.ZERO, Duration.ZERO, null);
 
-        RetryContext() {
+        private RetryContext context() {
+            return context;
         }
 
-        public U throwIt() {
-            Throwable t = throwable();
-            if (t instanceof RuntimeException r) {
-                throw r;
-            }
-            if (t instanceof Error e) {
-                throw e;
-            }
-            throw new SupplierException(t);
+        private RetryOutcome outcome(RetryOutcome.Termination termination) {
+            return outcome(termination, System.nanoTime());
         }
 
-        boolean hasThrowable() {
-            return !thrown.isEmpty();
+        private RetryOutcome outcome(RetryOutcome.Termination termination, long now) {
+            return new RetryOutcome(termination,
+                                    attempt,
+                                    Duration.ofNanos(elapsedNanos(startedNanos, now)),
+                                    Duration.ofMillis(previousDelayMillis),
+                                    lastFailure);
         }
 
-        Throwable throwable() {
-            if (thrown.isEmpty()) {
-                return new IllegalStateException("Exception list is empty");
+        private void failure(Throwable failure) {
+            lastFailure = failure;
+            if (failures.size() == MAX_RETAINED_FAILURES) {
+                failures.removeFirst();
             }
-            Throwable last = thrown.get(thrown.size() - 1);
-            for (int i = 0; i < thrown.size() - 1; i++) {
-                Throwable throwable = thrown.get(i);
-                if (throwable != last) {
-                    last.addSuppressed(throwable);
+            failures.addLast(failure);
+        }
+
+        private void nextAttempt(long delayMillis, long now) {
+            previousDelayMillis = delayMillis;
+            if (attempt < Integer.MAX_VALUE) {
+                attempt++;
+            }
+            context = new RetryContext(attempt,
+                                       Duration.ofNanos(elapsedNanos(startedNanos, now)),
+                                       Duration.ofMillis(previousDelayMillis),
+                                       lastFailure);
+        }
+
+        private <T> T throwLegacy() {
+            return RetryImpl.throwLegacy(legacyThrowable());
+        }
+
+        private Throwable legacyThrowable() {
+            for (Throwable failure : failures) {
+                if (failure != lastFailure) {
+                    lastFailure.addSuppressed(failure);
                 }
             }
-            return last;
+            return lastFailure;
+        }
+    }
+
+    private static final class WaitInterruptedException extends RuntimeException {
+        private static final long serialVersionUID = 2858492180285840898L;
+
+        private WaitInterruptedException(InterruptedException cause) {
+            super(cause);
         }
     }
 }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -180,12 +180,17 @@ class RetryImpl implements Retry {
                 Throwable throwable = unwrap(t);
                 state.failure(throwable);
                 Throwable interrupted = throwable instanceof Error ? null : interrupted(t);
-                if (interrupted != null) {
-                    Thread.currentThread().interrupt();
+                if (interrupted != null && Thread.currentThread().isInterrupted()) {
                     return terminateAfterInvocation(legacy,
                                                     RetryOutcome.Termination.INTERRUPTED,
                                                     state,
                                                     interrupted);
+                }
+                if (throwable instanceof InterruptedException) {
+                    return terminateAfterInvocation(legacy,
+                                                    RetryOutcome.Termination.NOT_RETRYABLE,
+                                                    state,
+                                                    throwable);
                 }
                 if (errorChecker.shouldSkip(throwable)) {
                     return terminateAfterInvocation(legacy,
@@ -229,8 +234,7 @@ class RetryImpl implements Retry {
                 continueRetries = waitStrategy.await(Duration.ofMillis(delayMillis));
             } catch (RuntimeException t) {
                 Throwable interrupted = interrupted(t);
-                if (interrupted != null || Thread.currentThread().isInterrupted()) {
-                    Thread.currentThread().interrupt();
+                if (Thread.currentThread().isInterrupted()) {
                     return terminateWait(legacy,
                                          RetryOutcome.Termination.INTERRUPTED,
                                          state,

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -172,12 +172,12 @@ class RetryImpl implements Retry {
                 continueRetries = waitStrategy.await(Duration.ofMillis(delayMillis));
             } catch (RuntimeException t) {
                 Throwable interrupted = interrupted(t);
-                if (interrupted != null) {
+                if (interrupted != null || Thread.currentThread().isInterrupted()) {
                     Thread.currentThread().interrupt();
                     return terminateWait(legacy,
                                          RetryOutcome.Termination.INTERRUPTED,
                                          state,
-                                         interrupted);
+                                         interrupted == null ? t : interrupted);
                 }
                 return terminateWait(legacy, RetryOutcome.Termination.WAIT_FAILED, state, t);
             }

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcome.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcome.java
@@ -17,57 +17,32 @@
 package io.helidon.faulttolerance;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Outcome of an unsuccessful contextual {@link Retry} invocation.
  */
-public final class RetryOutcome {
-    private final Termination termination;
-    private final int attempts;
-    private final Duration elapsedTime;
-    private final Duration lastDelay;
-    private final Throwable lastThrowable;
-
-    RetryOutcome(Termination termination,
-                 int attempts,
-                 Duration elapsedTime,
-                 Duration lastDelay,
-                 Throwable lastThrowable) {
-        this.termination = Objects.requireNonNull(termination);
-        this.attempts = attempts;
-        this.elapsedTime = Objects.requireNonNull(elapsedTime);
-        this.lastDelay = Objects.requireNonNull(lastDelay);
-        this.lastThrowable = lastThrowable;
-    }
-
+public interface RetryOutcome {
     /**
      * Reason the retry invocation terminated.
      *
      * @return termination reason
      */
-    public Termination termination() {
-        return termination;
-    }
+    Termination termination();
 
     /**
      * Number of completed invocation attempts.
      *
      * @return number of completed attempts
      */
-    public int attempts() {
-        return attempts;
-    }
+    int attempts();
 
     /**
      * Time elapsed since the retry invocation started.
      *
      * @return elapsed time
      */
-    public Duration elapsedTime() {
-        return elapsedTime;
-    }
+    Duration elapsedTime();
 
     /**
      * Delay preceding the last completed invocation attempt.
@@ -76,23 +51,19 @@ public final class RetryOutcome {
      *
      * @return delay preceding the last completed attempt
      */
-    public Duration lastDelay() {
-        return lastDelay;
-    }
+    Duration lastDelay();
 
     /**
      * Throwable from the last completed invocation attempt.
      *
      * @return last invocation throwable
      */
-    public Optional<Throwable> lastThrowable() {
-        return Optional.ofNullable(lastThrowable);
-    }
+    Optional<Throwable> lastThrowable();
 
     /**
      * Reason a contextual retry invocation terminated.
      */
-    public enum Termination {
+    enum Termination {
         /**
          * The retry policy did not permit another retry.
          */

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcome.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcome.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Outcome of an unsuccessful contextual {@link Retry} invocation.
+ */
+public final class RetryOutcome {
+    private final Termination termination;
+    private final int attempts;
+    private final Duration elapsedTime;
+    private final Duration lastDelay;
+    private final Throwable lastThrowable;
+
+    RetryOutcome(Termination termination,
+                 int attempts,
+                 Duration elapsedTime,
+                 Duration lastDelay,
+                 Throwable lastThrowable) {
+        this.termination = Objects.requireNonNull(termination);
+        this.attempts = attempts;
+        this.elapsedTime = Objects.requireNonNull(elapsedTime);
+        this.lastDelay = Objects.requireNonNull(lastDelay);
+        this.lastThrowable = lastThrowable;
+    }
+
+    /**
+     * Reason the retry invocation terminated.
+     *
+     * @return termination reason
+     */
+    public Termination termination() {
+        return termination;
+    }
+
+    /**
+     * Number of completed invocation attempts.
+     *
+     * @return number of completed attempts
+     */
+    public int attempts() {
+        return attempts;
+    }
+
+    /**
+     * Time elapsed since the retry invocation started.
+     *
+     * @return elapsed time
+     */
+    public Duration elapsedTime() {
+        return elapsedTime;
+    }
+
+    /**
+     * Delay preceding the last completed invocation attempt.
+     * <p>
+     * The value is {@link Duration#ZERO} if only the initial attempt completed.
+     *
+     * @return delay preceding the last completed attempt
+     */
+    public Duration lastDelay() {
+        return lastDelay;
+    }
+
+    /**
+     * Throwable from the last completed invocation attempt.
+     *
+     * @return last invocation throwable
+     */
+    public Optional<Throwable> lastThrowable() {
+        return Optional.ofNullable(lastThrowable);
+    }
+
+    /**
+     * Reason a contextual retry invocation terminated.
+     */
+    public enum Termination {
+        /**
+         * The retry policy did not permit another retry.
+         */
+        RETRIES_EXHAUSTED,
+
+        /**
+         * The invocation threw a throwable that is not retriable.
+         */
+        NOT_RETRYABLE,
+
+        /**
+         * The configured overall timeout was reached.
+         */
+        TIMED_OUT,
+
+        /**
+         * The invoking thread was interrupted.
+         */
+        INTERRUPTED,
+
+        /**
+         * The wait strategy declined another attempt.
+         */
+        CANCELLED,
+
+        /**
+         * The wait strategy failed.
+         */
+        WAIT_FAILED,
+
+        /**
+         * The retry policy failed or returned an invalid result.
+         */
+        RETRY_POLICY_FAILED
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcomeImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryOutcomeImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.Optional;
+
+record RetryOutcomeImpl(Termination termination,
+                        int attempts,
+                        Duration elapsedTime,
+                        Duration lastDelay,
+                        Throwable lastThrowableValue) implements RetryOutcome {
+
+    @Override
+    public Optional<Throwable> lastThrowable() {
+        return Optional.ofNullable(lastThrowableValue);
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/SupplierHelper.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/SupplierHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ public class SupplierHelper {
     }
 
     /**
-     * Maps a supplier returning a {@code CompletionStage<T>} to a supplier returning {@code T}
-     * by waiting on the stage to produce a value.
+     * Maps a supplier returning a {@code CompletionStage<T>} to a supplier returning {@code T} by waiting on the stage,
+     * restoring the calling thread's interrupt status before propagating an interruption as {@link SupplierException}.
      *
      * @param supplier the async supplier
      * @param timeout time to wait
@@ -45,6 +45,9 @@ public class SupplierHelper {
             try {
                 CompletionStage<T> result = supplier.get();
                 return result.toCompletableFuture().get(timeout, unit);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw toRuntimeException(e);
             } catch (Throwable t) {
                 Throwable throwable = unwrapThrowable(t);
                 throw toRuntimeException(throwable);

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/SupplierHelper.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/SupplierHelper.java
@@ -30,8 +30,10 @@ public class SupplierHelper {
     }
 
     /**
-     * Maps a supplier returning a {@code CompletionStage<T>} to a supplier returning {@code T} by waiting on the stage,
-     * restoring the calling thread's interrupt status before propagating an interruption as {@link SupplierException}.
+     * Maps a supplier returning a {@code CompletionStage<T>} to a supplier returning {@code T} by waiting on the stage;
+     * interruption of the calling thread during that wait restores its interrupt status before propagation as
+     * {@link SupplierException}, while an {@link InterruptedException} reported by the stage does not modify the calling
+     * thread's interrupt status.
      *
      * @param supplier the async supplier
      * @param timeout time to wait

--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.builder.api.Prototype;
 /**
  * {@link Timeout} configuration bean.
  */
-@Prototype.Blueprint(decorator = TimeoutConfigBlueprint.BuilderDecorator.class)
+@Prototype.Blueprint(decorator = FtBuilderSupport.TimeoutBuilderDecorator.class)
 @Prototype.Configured("fault-tolerance.timeouts")
 interface TimeoutConfigBlueprint extends Prototype.Factory<Timeout> {
     /**
@@ -76,13 +76,4 @@ interface TimeoutConfigBlueprint extends Prototype.Factory<Timeout> {
     @Option.DefaultBoolean(false)
     boolean enableMetrics();
 
-    class BuilderDecorator implements Prototype.BuilderDecorator<TimeoutConfig.BuilderBase<?, ?>> {
-        @Override
-        public void decorate(TimeoutConfig.BuilderBase<?, ?> target) {
-            if (target.name().isEmpty()) {
-                target.config()
-                        .ifPresent(cfg -> target.name(cfg.name()));
-            }
-        }
-    }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,13 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
 import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DelayRetryPolicyTest {
     @Test
@@ -37,11 +43,9 @@ class DelayRetryPolicyTest {
 
         long firstCall = System.nanoTime();
 
-        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
         assertThat(aLong, optionalValue(is(100L)));
-        aLong = policy.nextDelayMillis(firstCall, 100, 1);
-        assertThat(aLong, optionalValue(is(300L)));
-        aLong = policy.nextDelayMillis(firstCall, 100, 2); // should just apply factor on last delay
+        aLong = policy.nextDelayMillis(firstCall, 100, 2);
         assertThat(aLong, optionalValue(is(300L)));
         aLong = policy.nextDelayMillis(firstCall, 100, 3); // limit of calls
         assertThat(aLong, is(optionalEmpty()));
@@ -57,13 +61,195 @@ class DelayRetryPolicyTest {
 
         long firstCall = System.nanoTime();
 
-        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
         assertThat(aLong, optionalValue(is(0L)));
-        aLong = policy.nextDelayMillis(firstCall, 0, 1);
-        assertThat(aLong, optionalValue(is(0L)));
-        aLong = policy.nextDelayMillis(firstCall, 0, 2); // should just apply factor on last delay
+        aLong = policy.nextDelayMillis(firstCall, 0, 2);
         assertThat(aLong, optionalValue(is(0L)));
         aLong = policy.nextDelayMillis(firstCall, 100, 3); // limit of calls
         assertThat(aLong, is(optionalEmpty()));
+    }
+
+    @Test
+    void testMaximumDelay() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(100))
+                .calls(4)
+                .delayFactor(3)
+                .maxDelay(Duration.ofMillis(250))
+                .build();
+
+        long firstCall = System.currentTimeMillis();
+
+        assertThat(policy.nextDelayMillis(firstCall, 0, 1), optionalValue(is(100L)));
+        assertThat(policy.nextDelayMillis(firstCall, 100, 2), optionalValue(is(250L)));
+        assertThat(policy.nextDelayMillis(firstCall, 250, 3), optionalValue(is(250L)));
+    }
+
+    @Test
+    void testDelayFactorAndJitterAreCombined() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(100))
+                .calls(3)
+                .delayFactor(2)
+                .jitter(Duration.ofMillis(10))
+                .build();
+        boolean observedJitter = false;
+
+        for (int i = 0; i < 1_000; i++) {
+            Optional<Long> delay = policy.nextDelayMillis(System.currentTimeMillis(), 100, 2);
+            assertThat(delay, optionalValue(both(greaterThanOrEqualTo(190L))
+                                                     .and(lessThanOrEqualTo(210L))));
+            if (delay.orElseThrow() != 200) {
+                observedJitter = true;
+            }
+        }
+
+        assertThat("Configured jitter must be applied after the delay factor", observedJitter, is(true));
+    }
+
+    @Test
+    void testDelayFactorAndRelativeJitterAreCombined() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(100))
+                .calls(3)
+                .delayFactor(2)
+                .jitterFactor(0.25)
+                .build();
+        boolean observedJitter = false;
+
+        for (int i = 0; i < 1_000; i++) {
+            Optional<Long> delay = policy.nextDelayMillis(System.currentTimeMillis(), 100, 2);
+            assertThat(delay, optionalValue(both(greaterThanOrEqualTo(150L))
+                                                     .and(lessThanOrEqualTo(250L))));
+            if (delay.orElseThrow() != 200) {
+                observedJitter = true;
+            }
+        }
+
+        assertThat("Configured relative jitter must be applied after the delay factor", observedJitter, is(true));
+    }
+
+    @Test
+    void testHugeDelayDoesNotOverflow() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(Long.MAX_VALUE))
+                .calls(3)
+                .delayFactor(Double.MAX_VALUE)
+                .build();
+
+        assertThat(policy.nextDelayMillis(System.currentTimeMillis(), 0, 1),
+                   optionalValue(is(Long.MAX_VALUE)));
+        assertThat(policy.nextDelayMillis(System.currentTimeMillis(), Long.MAX_VALUE, 2),
+                   optionalValue(is(Long.MAX_VALUE)));
+    }
+
+    @Test
+    void testConfigurationCombinesDelayFactorJitterAndMaximumDelay() {
+        RetryConfig config = RetryConfig.builder()
+                .calls(3)
+                .delay(Duration.ofMillis(100))
+                .delayFactor(2)
+                .jitter(Duration.ofMillis(10))
+                .maxDelay(Duration.ofMillis(205))
+                .buildPrototype();
+
+        assertThat(config.maxDelay(), optionalValue(is(Duration.ofMillis(205))));
+        Retry.RetryPolicy policy = config.retryPolicy().orElseThrow();
+        assertThat(policy, instanceOf(Retry.DelayingRetryPolicy.class));
+
+        Optional<Long> delay = policy.nextDelayMillis(System.currentTimeMillis(), 100, 2);
+        assertThat(delay, optionalValue(both(greaterThanOrEqualTo(190L))
+                                                 .and(lessThanOrEqualTo(205L))));
+    }
+
+    @Test
+    void testEquivalentPoliciesAndConfigurationsAreEqual() {
+        Retry.DelayingRetryPolicy firstPolicy = Retry.DelayingRetryPolicy.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .delayFactor(2)
+                .jitterFactor(0.25)
+                .maxDelay(Duration.ofSeconds(2))
+                .build();
+        Retry.DelayingRetryPolicy secondPolicy = Retry.DelayingRetryPolicy.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .delayFactor(2)
+                .jitterFactor(0.25)
+                .maxDelay(Duration.ofSeconds(2))
+                .build();
+        RetryConfig firstConfig = RetryConfig.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .delayFactor(2)
+                .jitterFactor(0.25)
+                .maxDelay(Duration.ofSeconds(2))
+                .buildPrototype();
+        RetryConfig secondConfig = RetryConfig.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .delayFactor(2)
+                .jitterFactor(0.25)
+                .maxDelay(Duration.ofSeconds(2))
+                .buildPrototype();
+
+        assertThat(firstPolicy, is(secondPolicy));
+        assertThat(firstPolicy.hashCode(), is(secondPolicy.hashCode()));
+        assertThat(firstConfig, is(secondConfig));
+        assertThat(firstConfig.hashCode(), is(secondConfig.hashCode()));
+    }
+
+    @Test
+    void testInvalidConfigurationIsRejected() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().calls(0).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().delay(Duration.ofMillis(-1)).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().overallTimeout(Duration.ZERO).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().delayFactor(Double.POSITIVE_INFINITY).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().jitter(Duration.ofMillis(-1)).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().jitterFactor(-0.5).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().jitterFactor(1.5).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().jitterFactor(1).buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder()
+                                           .jitter(Duration.ofMillis(10))
+                                           .jitterFactor(0.25)
+                                           .buildPrototype()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> RetryConfig.builder().maxDelay(Duration.ofMillis(-1)).buildPrototype()));
+    }
+
+    @Test
+    void testInvalidPolicyIsRejected() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder().calls(0).build()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder()
+                                           .delay(Duration.ofMillis(-1))
+                                           .build()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder()
+                                           .delayFactor(Double.POSITIVE_INFINITY)
+                                           .build()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder().jitterFactor(1).build()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder()
+                                           .jitter(Duration.ofMillis(10))
+                                           .jitterFactor(0.25)
+                                           .build()),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> Retry.DelayingRetryPolicy.builder()
+                                           .maxDelay(Duration.ofMillis(-1))
+                                           .build()));
     }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -175,6 +176,32 @@ class DelayRetryPolicyTest {
         Optional<Long> delay = policy.nextDelayMillis(System.currentTimeMillis(), 100, 2);
         assertThat(delay, optionalValue(both(greaterThanOrEqualTo(190L))
                                                  .and(lessThanOrEqualTo(205L))));
+    }
+
+    @Test
+    void testCopiedConfigurationRebuildsDerivedRetryPolicy() {
+        RetryConfig original = RetryConfig.builder()
+                .delay(Duration.ofMillis(100))
+                .buildPrototype();
+        RetryConfig changed = RetryConfig.builder(original)
+                .maxDelay(Duration.ofMillis(50))
+                .buildPrototype();
+
+        assertThat(changed.maxDelay(), optionalValue(is(Duration.ofMillis(50))));
+        assertThat(changed.retryPolicy().orElseThrow().nextDelayMillis(0, 100, 2), optionalValue(is(50L)));
+    }
+
+    @Test
+    void testCopiedConfigurationPreservesExplicitRetryPolicy() {
+        Retry.RetryPolicy customPolicy = (_, _, _) -> Optional.of(123L);
+        RetryConfig original = RetryConfig.builder()
+                .retryPolicy(customPolicy)
+                .buildPrototype();
+        RetryConfig changed = RetryConfig.builder(original)
+                .maxDelay(Duration.ofMillis(50))
+                .buildPrototype();
+
+        assertThat(changed.retryPolicy().orElseThrow(), sameInstance(customPolicy));
     }
 
     @Test

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -68,6 +68,21 @@ class DelayRetryPolicyTest {
     }
 
     @Test
+    void testZeroFactorDoesNotResetToBaseDelay() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(100))
+                .calls(4)
+                .delayFactor(0)
+                .build();
+
+        long firstCall = System.currentTimeMillis();
+
+        assertThat(policy.nextDelayMillis(firstCall, 0, 1), optionalValue(is(100L)));
+        assertThat(policy.nextDelayMillis(firstCall, 100, 2), optionalValue(is(0L)));
+        assertThat(policy.nextDelayMillis(firstCall, 0, 3), optionalValue(is(0L)));
+    }
+
+    @Test
     void testNoDelay() {
         Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
                 .delay(Duration.ZERO)

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -207,16 +207,48 @@ class DelayRetryPolicyTest {
     }
 
     @Test
-    void testCopiedConfigurationPreservesExplicitRetryPolicy() {
-        Retry.RetryPolicy customPolicy = (_, _, _) -> Optional.of(123L);
+    void testClearedMaximumDelayConfiguredLastWins() {
         RetryConfig original = RetryConfig.builder()
-                .retryPolicy(customPolicy)
+                .delay(Duration.ofMillis(100))
+                .maxDelay(Duration.ofMillis(150))
                 .buildPrototype();
         RetryConfig changed = RetryConfig.builder(original)
-                .maxDelay(Duration.ofMillis(50))
+                .clearMaxDelay()
                 .buildPrototype();
 
-        assertThat(changed.retryPolicy().orElseThrow(), sameInstance(customPolicy));
+        assertThat(changed.maxDelay(), is(optionalEmpty()));
+        assertThat(changed.retryPolicy().orElseThrow().nextDelayMillis(0, 100, 2), optionalValue(is(200L)));
+    }
+
+    @Test
+    void testExplicitPolicyConfiguredLastWins() {
+        Retry.RetryPolicy reusedPolicy = RetryConfig.builder()
+                .delay(Duration.ofMillis(100))
+                .buildPrototype()
+                .retryPolicy()
+                .orElseThrow();
+        RetryConfig changed = RetryConfig.builder()
+                .delay(Duration.ofSeconds(5))
+                .retryPolicy(reusedPolicy)
+                .buildPrototype();
+
+        assertThat(changed.retryPolicy().orElseThrow(), sameInstance(reusedPolicy));
+        assertThat(changed.retryPolicy().orElseThrow().nextDelayMillis(0, 0, 1), optionalValue(is(100L)));
+    }
+
+    @Test
+    void testDelayConfiguredLastWins() {
+        Retry.RetryPolicy reusedPolicy = RetryConfig.builder()
+                .delay(Duration.ofMillis(100))
+                .buildPrototype()
+                .retryPolicy()
+                .orElseThrow();
+        RetryConfig changed = RetryConfig.builder()
+                .retryPolicy(reusedPolicy)
+                .delay(Duration.ofSeconds(5))
+                .buildPrototype();
+
+        assertThat(changed.retryPolicy().orElseThrow().nextDelayMillis(0, 0, 1), optionalValue(is(5_000L)));
     }
 
     @Test

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -161,6 +161,26 @@ class DelayRetryPolicyTest {
     }
 
     @Test
+    void testRelativeJitterDoesNotCompoundAcrossRetries() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(100))
+                .calls(3)
+                .delayFactor(1)
+                .jitterFactor(0.25)
+                .build();
+
+        for (int i = 0; i < 1_000; i++) {
+            long firstDelay = policy.nextDelayMillis(0, 0, 1).orElseThrow();
+            Optional<Long> secondDelay = policy.nextDelayMillis(0, firstDelay, 2);
+
+            assertThat("Relative jitter must remain within 25% of the configured delay",
+                       secondDelay,
+                       optionalValue(both(greaterThanOrEqualTo(75L))
+                                             .and(lessThanOrEqualTo(125L))));
+        }
+    }
+
+    @Test
     void testHugeDelayDoesNotOverflow() {
         Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
                 .delay(Duration.ofMillis(Long.MAX_VALUE))

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/DelayRetryPolicyTest.java
@@ -52,6 +52,21 @@ class DelayRetryPolicyTest {
     }
 
     @Test
+    void testFractionalDelayIsAppliedToPreviousDelay() {
+        Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
+                .delay(Duration.ofMillis(1))
+                .calls(4)
+                .delayFactor(1.5)
+                .build();
+
+        long firstCall = System.currentTimeMillis();
+
+        assertThat(policy.nextDelayMillis(firstCall, 0, 1), optionalValue(is(1L)));
+        assertThat(policy.nextDelayMillis(firstCall, 1, 2), optionalValue(is(1L)));
+        assertThat(policy.nextDelayMillis(firstCall, 1, 3), optionalValue(is(1L)));
+    }
+
+    @Test
     void testNoDelay() {
         Retry.DelayingRetryPolicy policy = Retry.DelayingRetryPolicy.builder()
                 .delay(Duration.ZERO)

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/JitterRetryPolicyTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/JitterRetryPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ class JitterRetryPolicyTest {
                 .build();
 
         long firstCall = System.nanoTime();
-        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
         assertThat(aLong, optionalValue(is(100L)));
-        aLong = policy.nextDelayMillis(firstCall, aLong.get(), 1);
+        aLong = policy.nextDelayMillis(firstCall, aLong.get(), 2);
         assertThat(aLong, optionalValue(is(100L)));
     }
 
@@ -78,10 +78,10 @@ class JitterRetryPolicyTest {
         boolean hadNegative = false;
         boolean hadPositive = false;
         for (int i = 0; i < 10000; i++) {
-            Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+            Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
             assertThat(aLong, optionalPresent());
             long value = aLong.get();
-            assertThat(value, is(both(greaterThan(49L)).and(lessThan(151L))));
+            assertThat(value, is(both(greaterThan(49L)).and(lessThan(150L))));
             if (value < 100) {
                 hadNegative = true;
             } else if (value > 100) {
@@ -106,7 +106,7 @@ class JitterRetryPolicyTest {
         boolean hadPositive = false;
         boolean hadZero = false;
         for (int i = 0; i < 10000; i++) {
-            Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+            Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
             assertThat(aLong, optionalPresent());
             long value = aLong.get();
             assertThat(value, is(both(greaterThan(-1L)).and(lessThan(50L))));
@@ -131,13 +131,42 @@ class JitterRetryPolicyTest {
 
         long firstCall = System.nanoTime();
 
-        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 0);
+        Optional<Long> aLong = policy.nextDelayMillis(firstCall, 0, 1);
         assertThat(aLong, optionalValue(is(0L)));
-        aLong = policy.nextDelayMillis(firstCall, 0, 1);
-        assertThat(aLong, optionalValue(is(0L)));
-        aLong = policy.nextDelayMillis(firstCall, 0, 2); // should just apply factor on last delay
+        aLong = policy.nextDelayMillis(firstCall, 0, 2);
         assertThat(aLong, optionalValue(is(0L)));
         aLong = policy.nextDelayMillis(firstCall, 100, 3); // limit of calls
         assertThat(aLong, is(optionalEmpty()));
+    }
+
+    @Test
+    void testMaximumDelay() {
+        Retry.JitterRetryPolicy policy = Retry.JitterRetryPolicy.builder()
+                .jitter(Duration.ZERO)
+                .delay(Duration.ofMillis(100))
+                .maxDelay(Duration.ofMillis(75))
+                .calls(3)
+                .build();
+
+        assertThat(policy.nextDelayMillis(System.currentTimeMillis(), 0, 1), optionalValue(is(75L)));
+    }
+
+    @Test
+    void testEquivalentPoliciesAreEqual() {
+        Retry.JitterRetryPolicy first = Retry.JitterRetryPolicy.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .jitter(Duration.ofMillis(25))
+                .maxDelay(Duration.ofSeconds(2))
+                .build();
+        Retry.JitterRetryPolicy second = Retry.JitterRetryPolicy.builder()
+                .calls(5)
+                .delay(Duration.ofMillis(100))
+                .jitter(Duration.ofMillis(25))
+                .maxDelay(Duration.ofSeconds(2))
+                .build();
+
+        assertThat(first, is(second));
+        assertThat(first.hashCode(), is(second.hashCode()));
     }
 }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
@@ -211,6 +211,31 @@ class RetryContextTest {
     }
 
     @Test
+    void testCustomWaitFailureWithRestoredInterruptFlag() {
+        TerminalFailure waitFailure = new TerminalFailure();
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        try {
+            RetryException exception = assertThrows(RetryException.class,
+                                                    () -> retry.invoke(context -> {
+                                                        throw new TestFailure("invocation");
+                                                    }, delay -> {
+                                                        Thread.currentThread().interrupt();
+                                                        throw waitFailure;
+                                                    }));
+
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.INTERRUPTED));
+            assertThat(exception.getCause(), sameInstance(waitFailure));
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     void testRetryPolicyFailure() {
         TestFailure invocationFailure = new TestFailure("invocation");
         TerminalFailure policyFailure = new TerminalFailure();

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -211,6 +213,33 @@ class RetryContextTest {
     }
 
     @Test
+    void testTransportedWaitInterruptionDoesNotInterruptInvokingThread() {
+        RuntimeException waitFailure = new RuntimeException(new InterruptedException("worker interrupted"));
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        try {
+            assertThat(Thread.currentThread().isInterrupted(), is(false));
+            RetryException exception = assertThrows(RetryException.class,
+                                                    () -> retry.invoke(context -> {
+                                                        throw new TestFailure("invocation");
+                                                    }, delay -> {
+                                                        throw waitFailure;
+                                                    }));
+
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.WAIT_FAILED));
+            assertThat(exception.getCause(), sameInstance(waitFailure));
+            assertThat("An interruption reported by another thread must not interrupt the caller",
+                       Thread.currentThread().isInterrupted(),
+                       is(false));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     void testCustomWaitFailureWithRestoredInterruptFlag() {
         TerminalFailure waitFailure = new TerminalFailure();
         Retry retry = Retry.builder()
@@ -283,25 +312,51 @@ class RetryContextTest {
     }
 
     @Test
-    void testWrappedInterruptedInvocationRestoresInterruptFlag() {
-        InterruptedException interrupted = new InterruptedException("interrupted invocation");
-        RuntimeException failure = new RuntimeException(interrupted);
+    void testCallerInterruptionRestoresInterruptFlag() {
+        CompletableFuture<Integer> pending = new CompletableFuture<>();
+        var syncSupplier = SupplierHelper.toSyncSupplier(() -> pending, 1, TimeUnit.SECONDS);
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.noDelay(3))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        Thread.currentThread().interrupt();
+        try {
+            RetryException exception = assertThrows(RetryException.class,
+                                                    () -> retry.invoke(context -> syncSupplier.get()));
+
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.INTERRUPTED));
+            assertThat(exception.outcome().attempts(), is(1));
+            assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+            assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(exception.getCause())));
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testWorkerInterruptionDoesNotInterruptInvokingThread() {
+        InterruptedException interrupted = new InterruptedException("worker interrupted");
+        CompletableFuture<Integer> failedWorker = CompletableFuture.failedFuture(interrupted);
+        var syncSupplier = SupplierHelper.toSyncSupplier(() -> failedWorker, 1, TimeUnit.SECONDS);
         Retry retry = Retry.builder()
                 .retryPolicy(Retry.DelayingRetryPolicy.noDelay(3))
                 .overallTimeout(Duration.ofSeconds(10))
                 .build();
 
         try {
+            assertThat(Thread.currentThread().isInterrupted(), is(false));
             RetryException exception = assertThrows(RetryException.class,
-                                                    () -> retry.invoke(context -> {
-                                                        throw failure;
-                                                    }));
+                                                    () -> retry.invoke(context -> syncSupplier.get()));
 
-            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.INTERRUPTED));
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.NOT_RETRYABLE));
             assertThat(exception.outcome().attempts(), is(1));
-            assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+            assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(interrupted)));
             assertThat(exception.getCause(), sameInstance(interrupted));
-            assertThat(Thread.currentThread().isInterrupted(), is(true));
+            assertThat("An interruption reported by another thread must not interrupt the caller",
+                       Thread.currentThread().isInterrupted(),
+                       is(false));
         } finally {
             Thread.interrupted();
         }

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryContextTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.faulttolerance;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalEmpty;
+import static io.helidon.common.testing.junit5.OptionalMatcher.optionalValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RetryContextTest {
+    @Test
+    void testAttemptContext() {
+        List<RetryContext> contexts = new ArrayList<>();
+        TestFailure first = new TestFailure("first");
+        TestFailure second = new TestFailure("second");
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.noDelay(3))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        int result = retry.invoke(context -> {
+            contexts.add(context);
+            if (context.attempt() == 1) {
+                throw first;
+            }
+            if (context.attempt() == 2) {
+                throw second;
+            }
+            return context.attempt();
+        });
+
+        assertThat(result, is(3));
+        assertThat(contexts.size(), is(3));
+        assertThat(contexts.get(0).attempt(), is(1));
+        assertThat(contexts.get(0).elapsedTime(), greaterThanOrEqualTo(Duration.ZERO));
+        assertThat(contexts.get(0).previousDelay(), is(Duration.ZERO));
+        assertThat(contexts.get(0).previousThrowable(), optionalEmpty());
+        assertThat(contexts.get(1).attempt(), is(2));
+        assertThat(contexts.get(1).previousDelay(), is(Duration.ZERO));
+        assertThat(contexts.get(1).previousThrowable(), optionalValue(sameInstance(first)));
+        assertThat(contexts.get(2).attempt(), is(3));
+        assertThat(contexts.get(2).previousDelay(), is(Duration.ZERO));
+        assertThat(contexts.get(2).previousThrowable(), optionalValue(sameInstance(second)));
+    }
+
+    @Test
+    void testCallsExhausted() {
+        AtomicInteger calls = new AtomicInteger();
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.builder()
+                                     .calls(2)
+                                     .delay(Duration.ofMillis(17))
+                                     .delayFactor(1)
+                                     .build())
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    calls.incrementAndGet();
+                                                    throw new TestFailure("failure-" + context.attempt());
+                                                }, RetryContextTest::await));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.RETRIES_EXHAUSTED));
+        assertThat(exception.outcome().attempts(), is(2));
+        assertThat(exception.outcome().elapsedTime(), greaterThanOrEqualTo(Duration.ZERO));
+        assertThat(exception.outcome().lastDelay(), is(Duration.ofMillis(17)));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(exception.getCause())));
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    void testNotRetryable() {
+        TerminalFailure failure = new TerminalFailure();
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.noDelay(3))
+                .overallTimeout(Duration.ofSeconds(10))
+                .addApplyOn(TestFailure.class)
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw failure;
+                                                }));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.NOT_RETRYABLE));
+        assertThat(exception.outcome().attempts(), is(1));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+        assertThat(exception.getCause(), sameInstance(failure));
+    }
+
+    @Test
+    void testTimedOutBeforeWait() {
+        TestFailure failure = new TestFailure("timed-out");
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1_000L))
+                .overallTimeout(Duration.ofMillis(1))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw failure;
+                                                }));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.TIMED_OUT));
+        assertThat(exception.outcome().attempts(), is(1));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+        assertThat(exception.getCause(), sameInstance(failure));
+    }
+
+    @Test
+    void testCustomWaitAndCancellation() {
+        TestFailure failure = new TestFailure("cancelled");
+        AtomicReference<Duration> delay = new AtomicReference<>();
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(17L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw failure;
+                                                }, proposedDelay -> {
+                                                    delay.set(proposedDelay);
+                                                    return false;
+                                                }));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.CANCELLED));
+        assertThat(exception.outcome().attempts(), is(1));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+        assertThat(exception.getCause(), sameInstance(failure));
+        assertThat(delay.get(), is(Duration.ofMillis(17)));
+    }
+
+    @Test
+    void testCustomWaitContinues() {
+        TestFailure failure = new TestFailure("retry");
+        AtomicReference<RetryContext> secondInvocationContext = new AtomicReference<>();
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(17L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        int result = retry.invoke(context -> {
+            if (context.attempt() == 1) {
+                throw failure;
+            }
+            assertThat(context.previousDelay(), is(Duration.ofMillis(17)));
+            assertThat(context.previousThrowable(), optionalValue(sameInstance(failure)));
+            secondInvocationContext.set(context);
+            return context.attempt();
+        }, delay -> {
+            assertThat(delay, is(Duration.ofMillis(17)));
+            return await(delay);
+        });
+
+        assertThat(result, is(2));
+        assertThat(secondInvocationContext.get().attempt(), is(2));
+        assertThat(secondInvocationContext.get().previousThrowable(), optionalValue(sameInstance(failure)));
+    }
+
+    @Test
+    void testCustomWaitFailure() {
+        TestFailure invocationFailure = new TestFailure("invocation");
+        TerminalFailure waitFailure = new TerminalFailure();
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw invocationFailure;
+                                                }, delay -> {
+                                                    throw waitFailure;
+                                                }));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.WAIT_FAILED));
+        assertThat(exception.outcome().attempts(), is(1));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(invocationFailure)));
+        assertThat(exception.getCause(), sameInstance(waitFailure));
+    }
+
+    @Test
+    void testRetryPolicyFailure() {
+        TestFailure invocationFailure = new TestFailure("invocation");
+        TerminalFailure policyFailure = new TerminalFailure();
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> {
+                    throw policyFailure;
+                })
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw invocationFailure;
+                                                }));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.RETRY_POLICY_FAILED));
+        assertThat(exception.outcome().attempts(), is(1));
+        assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(invocationFailure)));
+        assertThat(exception.getCause(), sameInstance(policyFailure));
+    }
+
+    @Test
+    void testInterruptedWaitRestoresInterruptFlag() {
+        TestFailure failure = new TestFailure("interrupted");
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1_000L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        Thread.currentThread().interrupt();
+        try {
+            RetryException exception = assertThrows(RetryException.class,
+                                                    () -> retry.invoke(context -> {
+                                                        throw failure;
+                                                    }));
+
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.INTERRUPTED));
+            assertThat(exception.outcome().attempts(), is(1));
+            assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+            assertThat(exception.getCause() instanceof InterruptedException, is(true));
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testWrappedInterruptedInvocationRestoresInterruptFlag() {
+        InterruptedException interrupted = new InterruptedException("interrupted invocation");
+        RuntimeException failure = new RuntimeException(interrupted);
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.noDelay(3))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        try {
+            RetryException exception = assertThrows(RetryException.class,
+                                                    () -> retry.invoke(context -> {
+                                                        throw failure;
+                                                    }));
+
+            assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.INTERRUPTED));
+            assertThat(exception.outcome().attempts(), is(1));
+            assertThat(exception.outcome().lastThrowable(), optionalValue(sameInstance(failure)));
+            assertThat(exception.getCause(), sameInstance(interrupted));
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testLegacyFailuresAreBounded() {
+        int calls = 100;
+        Retry retry = Retry.builder()
+                .retryPolicy(Retry.DelayingRetryPolicy.noDelay(calls))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+        AtomicInteger invocation = new AtomicInteger();
+
+        TestFailure exception = assertThrows(TestFailure.class,
+                                             () -> retry.invoke(() -> {
+                                                 throw new TestFailure("failure-" + invocation.incrementAndGet());
+                                             }));
+
+        assertThat(invocation.get(), is(calls));
+        assertThat(exception.getSuppressed().length, lessThanOrEqualTo(15));
+    }
+
+    @Test
+    void testLegacyTimeoutExceptionIsPreserved() {
+        TestFailure failure = new TestFailure("legacy timeout");
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1_000L))
+                .overallTimeout(Duration.ofMillis(1))
+                .build();
+
+        RetryTimeoutException exception = assertThrows(RetryTimeoutException.class,
+                                                       () -> retry.invoke(() -> {
+                                                           throw failure;
+                                                       }));
+
+        assertThat(exception.lastRetryException(), sameInstance(failure));
+        assertThat(exception.getCause(), sameInstance(failure));
+    }
+
+    @Test
+    void testLegacyInterruptedExceptionTypeIsPreserved() {
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1_000L))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        Thread.currentThread().interrupt();
+        try {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                                                       () -> retry.invoke(() -> {
+                                                           throw new TestFailure("interrupted");
+                                                       }));
+
+            assertThat(exception, not(instanceOf(RetryException.class)));
+            assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+            assertThat(Thread.currentThread().isInterrupted(), is(true));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testLargeTimeoutDoesNotOverflow() {
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(1L))
+                .overallTimeout(Duration.ofSeconds(Long.MAX_VALUE))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw new TestFailure("large duration");
+                                                }, delay -> false));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.CANCELLED));
+    }
+
+    @Test
+    void testLargeDelayDoesNotOverflow() {
+        Retry retry = Retry.builder()
+                .retryPolicy((firstCallMillis, lastDelay, call) -> Optional.of(Long.MAX_VALUE))
+                .overallTimeout(Duration.ofSeconds(10))
+                .build();
+
+        RetryException exception = assertThrows(RetryException.class,
+                                                () -> retry.invoke(context -> {
+                                                    throw new TestFailure("large delay");
+                                                }, delay -> false));
+
+        assertThat(exception.outcome().termination(), is(RetryOutcome.Termination.TIMED_OUT));
+    }
+
+    private static boolean await(Duration delay) {
+        try {
+            Thread.sleep(delay);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    private static final class TestFailure extends RuntimeException {
+        private TestFailure(String message) {
+            super(message);
+        }
+    }
+
+    private static final class TerminalFailure extends RuntimeException {
+    }
+}

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/RetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,11 @@ class RetryTest {
     @Test
     public void testLastDelay() {
         List<Long> lastDelayCalls = new ArrayList<>();
+        List<Integer> callIndices = new ArrayList<>();
         Retry retry = Retry.builder()
                 .retryPolicy((firstCallMillis, lastDelay, call) -> {
                     lastDelayCalls.add(lastDelay);
+                    callIndices.add(call);
                     return Optional.of(lastDelay + 1);
                 })
                 .build();
@@ -46,6 +48,7 @@ class RetryTest {
         assertThat(req.call.get(), is(4));
 
         assertThat("Last delay should increase", lastDelayCalls, contains(0L, 1L, 2L));
+        assertThat("Call is the number of completed attempts", callIndices, contains(1, 2, 3));
     }
 
     @Test


### PR DESCRIPTION
Add contextual retry invocation to the core fault-tolerance API so callers such as messaging connectors can share the existing retry implementation.

- Expose per-attempt `RetryContext` and terminal `RetryOutcome` through `RetryException`.
- Allow caller-controlled waits while preserving `FtHandler` chaining and the existing `Supplier` contract.
- Add exponential delay with absolute or relative jitter and an optional maximum delay, including declarative and configuration parity.
- Preserve caller interruption provenance and bound retained failures.
- Move blueprint decorators into package-private fault-tolerance support.
