### PR TITLE
Annotate JSON APIs with API stability

### DIFF
--- a/http/media/json-binding/pom.xml
+++ b/http/media/json-binding/pom.xml
@@ -133,6 +133,55 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.builder</groupId>
+                                    <artifactId>helidon-builder-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.json</groupId>
+                                    <artifactId>helidon-json-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.service</groupId>
+                                    <artifactId>helidon-service-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.config.metadata</groupId>
+                                    <artifactId>helidon-config-metadata-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -167,6 +216,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingMediaSupportProvider.java
+++ b/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingMediaSupportProvider.java
@@ -28,12 +28,12 @@ import io.helidon.http.media.spi.MediaSupportProvider;
  * This provider creates instances of {@link JsonBindingSupport} for handling
  * JSON serialization and deserialization in HTTP requests and responses.
  */
+@Api.Internal
 public class JsonBindingMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Api.Internal
     public JsonBindingMediaSupportProvider() {
     }
 

--- a/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingSupport.java
+++ b/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingSupport.java
@@ -19,6 +19,7 @@ package io.helidon.http.media.json.binding;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 import io.helidon.config.Config;
 import io.helidon.http.Headers;
@@ -39,6 +40,7 @@ import io.helidon.json.binding.JsonBinding;
  * character encoding detection, and integrates with the Helidon media support
  * framework.
  */
+@Api.Preview
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class JsonBindingSupport
         extends MediaSupportBase<JsonBindingSupportConfig>

--- a/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingSupportConfigBlueprint.java
+++ b/http/media/json-binding/src/main/java/io/helidon/http/media/json/binding/JsonBindingSupportConfigBlueprint.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.media.MediaSupportConfig;
@@ -33,6 +34,7 @@ import io.helidon.json.binding.JsonBinding;
  * which provides JSON serialization and deserialization capabilities for HTTP requests
  * and responses.
  */
+@Api.Preview
 @Prototype.Configured(value = JsonBindingSupport.ID, root = false)
 @Prototype.Provides(MediaSupportProvider.class)
 @Prototype.Blueprint(decorator = JsonBindingConfigSupport.Decorator.class)

--- a/http/media/json/pom.xml
+++ b/http/media/json/pom.xml
@@ -133,6 +133,55 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.builder</groupId>
+                                    <artifactId>helidon-builder-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.json</groupId>
+                                    <artifactId>helidon-json-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.service</groupId>
+                                    <artifactId>helidon-service-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.config.metadata</groupId>
+                                    <artifactId>helidon-config-metadata-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -167,6 +216,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonMediaSupportProvider.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonMediaSupportProvider.java
@@ -27,11 +27,11 @@ import io.helidon.http.media.spi.MediaSupportProvider;
  * This provider creates instances of {@link JsonSupport} for handling
  * JSON serialization and deserialization in HTTP requests and responses.
  */
+@Api.Internal
 public class JsonMediaSupportProvider implements MediaSupportProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Api.Internal
     public JsonMediaSupportProvider() {
     }
 

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupport.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupport.java
@@ -19,6 +19,7 @@ package io.helidon.http.media.json;
 import java.util.function.Consumer;
 
 import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 import io.helidon.http.Headers;
 import io.helidon.http.WritableHeaders;
@@ -33,6 +34,7 @@ import io.helidon.json.JsonValue;
  * <p>
  * This media support adds serialization and deserialization for {@link io.helidon.json.JsonValue}.
  */
+@Api.Preview
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class JsonSupport extends MediaSupportBase<JsonSupportConfig> implements RuntimeType.Api<JsonSupportConfig> {
     /**

--- a/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupportConfigBlueprint.java
+++ b/http/media/json/src/main/java/io/helidon/http/media/json/JsonSupportConfigBlueprint.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.http.HttpMediaType;
 import io.helidon.http.media.MediaSupportConfig;
@@ -28,6 +29,7 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 /**
  * Configuration of Helidon JSON media support.
  */
+@Api.Preview
 @Prototype.Configured(value = JsonSupport.ID, root = false)
 @Prototype.Provides(MediaSupportProvider.class)
 @Prototype.Blueprint

--- a/http/media/smile/pom.xml
+++ b/http/media/smile/pom.xml
@@ -140,6 +140,55 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.builder</groupId>
+                                    <artifactId>helidon-builder-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.json</groupId>
+                                    <artifactId>helidon-json-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.service</groupId>
+                                    <artifactId>helidon-service-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.config.metadata</groupId>
+                                    <artifactId>helidon-config-metadata-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -174,6 +223,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/http/media/smile/src/main/java/io/helidon/http/media/json/smile/SmileMediaSupportProvider.java
+++ b/http/media/smile/src/main/java/io/helidon/http/media/json/smile/SmileMediaSupportProvider.java
@@ -25,11 +25,11 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 /**
  * Media support provider for Smile media support.
  */
+@Api.Internal
 public class SmileMediaSupportProvider implements MediaSupportProvider, Weighted {
     /**
      * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
      */
-    @Api.Internal
     public SmileMediaSupportProvider() {
     }
 

--- a/json/binding/pom.xml
+++ b/json/binding/pom.xml
@@ -114,6 +114,50 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.config.metadata</groupId>
+                                    <artifactId>helidon-config-metadata-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.builder</groupId>
+                                    <artifactId>helidon-builder-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.service</groupId>
+                                    <artifactId>helidon-service-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -143,6 +187,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/json/json/pom.xml
+++ b/json/json/pom.xml
@@ -78,6 +78,30 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.common.features</groupId>
+                                    <artifactId>helidon-common-features-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -87,6 +111,11 @@
                     <dependency>
                         <groupId>io.helidon.common.features</groupId>
                         <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/json/json/src/main/java/io/helidon/json/JsonException.java
+++ b/json/json/src/main/java/io/helidon/json/JsonException.java
@@ -16,6 +16,8 @@
 
 package io.helidon.json;
 
+import io.helidon.common.Api;
+
 /**
  * Exception thrown during JSON processing operations.
  * <p>
@@ -23,6 +25,7 @@ package io.helidon.json;
  * serialization, or other JSON-related operations.
  * </p>
  */
+@Api.Preview
 public class JsonException extends RuntimeException {
 
     /**

--- a/json/json/src/main/java/io/helidon/json/JsonGeneratorBase.java
+++ b/json/json/src/main/java/io/helidon/json/JsonGeneratorBase.java
@@ -19,11 +19,13 @@ package io.helidon.json;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import io.helidon.common.Api;
 import io.helidon.common.buffers.Bytes;
 
 /**
  * Base implementation of {@link JsonGenerator} with shared structure and state handling.
  */
+@Api.Preview
 public abstract class JsonGeneratorBase implements JsonGenerator {
 
     static final int MAX_DEPTH = 64;

--- a/json/json/src/main/java/io/helidon/json/JsonKey.java
+++ b/json/json/src/main/java/io/helidon/json/JsonKey.java
@@ -19,6 +19,8 @@ package io.helidon.json;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+import io.helidon.common.Api;
+
 /**
  * A precomputed JSON object key.
  * <p>
@@ -26,6 +28,7 @@ import java.util.Objects;
  * re-encoding the property name on each serialization call.
  * </p>
  */
+@Api.Preview
 public final class JsonKey {
 
     private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();

--- a/json/json/src/main/java/io/helidon/json/JsonParserBase.java
+++ b/json/json/src/main/java/io/helidon/json/JsonParserBase.java
@@ -20,9 +20,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import io.helidon.common.Api;
+
 /**
  * Base implementation of {@link JsonParser}.
  */
+@Api.Preview
 public abstract class JsonParserBase implements JsonParser {
 
     private int nestingDepth;

--- a/json/json/src/main/java/io/helidon/json/Parsers.java
+++ b/json/json/src/main/java/io/helidon/json/Parsers.java
@@ -22,9 +22,12 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import io.helidon.common.Api;
+
 /**
  * Utility methods shared by JSON parser implementations.
  */
+@Api.Internal
 public final class Parsers {
 
     //Lookup table for converting hexadecimal characters to their numeric values

--- a/json/smile/pom.xml
+++ b/json/smile/pom.xml
@@ -100,6 +100,40 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-apt</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.builder</groupId>
+                                    <artifactId>helidon-builder-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.config.metadata</groupId>
+                                    <artifactId>helidon-config-metadata-codegen</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -119,6 +153,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
Related to #11500

Classifies the remaining public types across Helidon JSON, JSON Binding, JSON Smile, and their HTTP media support modules. Enables compile-time API stability enforcement in all six modules while preserving their existing annotation processors.
