### PR TITLE
Reject negative LruCache capacity

### DIFF
--- a/common/common/src/main/java/io/helidon/common/LruCache.java
+++ b/common/common/src/main/java/io/helidon/common/LruCache.java
@@ -53,6 +53,7 @@ public interface LruCache<K, V> {
      * @param <K>      key type
      * @param <V>      value type
      * @return a new cache instance
+     * @throws IllegalArgumentException if {@code capacity} is negative
      */
     static <K, V> LruCache<K, V> create(int capacity) {
         return new LruCacheImpl<>(capacity);

--- a/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
+++ b/common/common/src/main/java/io/helidon/common/LruCacheImpl.java
@@ -41,6 +41,9 @@ final class LruCacheImpl<K, V> implements LruCache<K, V> {
     private final int capacity;
 
     LruCacheImpl(int capacity) {
+        if (capacity < 0) {
+            throw new IllegalArgumentException("Capacity must not be negative");
+        }
         this.capacity = capacity;
     }
 

--- a/common/common/src/test/java/io/helidon/common/LruCacheTest.java
+++ b/common/common/src/test/java/io/helidon/common/LruCacheTest.java
@@ -101,6 +101,11 @@ class LruCacheTest {
     }
 
     @Test
+    void testNegativeCapacity() {
+        assertThrows(IllegalArgumentException.class, () -> LruCache.create(-1));
+    }
+
+    @Test
     void testMaxCapacity() {
         LruCache<Integer, Integer> theCache = LruCache.create(10);
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Resolves #12461

Reject negative `LruCache` capacities during construction, document the public factory contract, and add regression coverage for fail-fast validation.
