### PR TITLE
Settle Async result futures on cancellation

### DIFF
--- a/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncImpl.java
+++ b/fault-tolerance/fault-tolerance/src/main/java/io/helidon/faulttolerance/AsyncImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -62,6 +63,7 @@ class AsyncImpl implements Async {
 
     @Override
     public <T> CompletableFuture<T> invoke(Supplier<T> supplier) {
+        AtomicBoolean terminalClaimed = new AtomicBoolean();
         AtomicReference<Future<?>> ourFuture = new AtomicReference<>();
         CompletableFuture<T> result = new CompletableFuture<>() {
             @Override
@@ -73,7 +75,9 @@ class AsyncImpl implements Async {
                     LOGGER.log(System.Logger.Level.WARNING, "Failed to cancel future, it is not yet available.");
                     return false;
                 } else {
-                    return toCancel.cancel(mayInterruptIfRunning);
+                    terminalClaimed.set(true);
+                    toCancel.cancel(mayInterruptIfRunning);
+                    return super.cancel(mayInterruptIfRunning);
                 }
             }
         };
@@ -85,10 +89,14 @@ class AsyncImpl implements Async {
             }
             try {
                 T t = supplier.get();
-                result.complete(t);
+                if (terminalClaimed.compareAndSet(false, true)) {
+                    result.complete(t);
+                }
             } catch (Throwable t) {
-                Throwable throwable = SupplierHelper.unwrapThrowable(t);
-                result.completeExceptionally(throwable);
+                if (terminalClaimed.compareAndSet(false, true)) {
+                    Throwable throwable = SupplierHelper.unwrapThrowable(t);
+                    result.completeExceptionally(throwable);
+                }
             }
         });
         ourFuture.set(future);

--- a/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/AsyncTest.java
+++ b/fault-tolerance/fault-tolerance/src/test/java/io/helidon/faulttolerance/AsyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,11 @@
 package io.helidon.faulttolerance;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
@@ -80,6 +84,82 @@ class AsyncTest {
             }
         });
         assertThat(cf.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(context));
+    }
+
+    @Test
+    void testCancelSettlesResult() throws Exception {
+        CountDownLatch executorOccupied = new CountDownLatch(1);
+        CountDownLatch releaseExecutor = new CountDownLatch(1);
+        AtomicBoolean supplierInvoked = new AtomicBoolean();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            executor.execute(() -> {
+                executorOccupied.countDown();
+                try {
+                    releaseExecutor.await();
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertThat(executorOccupied.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+
+            Async async = AsyncConfig.builder()
+                    .executor(executor)
+                    .build();
+            CompletableFuture<String> result = async.invoke(() -> {
+                supplierInvoked.set(true);
+                return "result";
+            });
+            CountDownLatch resultCompleted = new CountDownLatch(1);
+            result.whenComplete((_, _) -> resultCompleted.countDown());
+
+            assertThat(result.cancel(false), is(true));
+            assertThat(result.isDone(), is(true));
+            assertThat(result.isCancelled(), is(true));
+            assertThat(resultCompleted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+        } finally {
+            releaseExecutor.countDown();
+            executor.close();
+        }
+        assertThat(supplierInvoked.get(), is(false));
+    }
+
+    @Test
+    void testCancelInterruptsBeforeCompletionCallbacks() throws Exception {
+        CountDownLatch supplierStarted = new CountDownLatch(1);
+        CountDownLatch supplierInterrupted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Async async = AsyncConfig.builder()
+                    .executor(executor)
+                    .build();
+            CompletableFuture<Void> result = async.invoke(() -> {
+                supplierStarted.countDown();
+                try {
+                    new CountDownLatch(1).await();
+                } catch (InterruptedException _) {
+                    supplierInterrupted.countDown();
+                    Thread.currentThread().interrupt();
+                }
+                return null;
+            });
+            assertThat(supplierStarted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            result.whenComplete((_, _) -> {
+                try {
+                    supplierInterrupted.await();
+                } catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            CompletableFuture<Boolean> cancellation = CompletableFuture.supplyAsync(() -> result.cancel(true));
+            assertThat(supplierInterrupted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(cancellation.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS), is(true));
+            assertThat(result.isCancelled(), is(true));
+        } finally {
+            executor.shutdownNow();
+            executor.close();
+        }
     }
 
     private Thread testAsync(Async async) {


### PR DESCRIPTION
Resolves #12463

Coordinate supplier completion with cancellation, cancel the executor task before settling the returned future, and prevent completion callbacks from blocking interrupt delivery. Add regression coverage for queued and running suppliers, public-future settlement, and dependent completion callbacks.
