### PR TITLE
Restore default-port CORS origin matching (4.x)

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
@@ -17,6 +17,7 @@
 package io.helidon.webserver.cors;
 
 import java.lang.System.Logger.Level;
+import java.net.URI;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
@@ -234,12 +235,15 @@ class CorsPathValidator {
 
     private static String normalizeDefaultPort(String origin) {
         int authorityOffset;
+        int defaultPort;
         int portLength;
         if (origin.startsWith("http://") && origin.endsWith(":80")) {
             authorityOffset = "http://".length();
+            defaultPort = 80;
             portLength = 3;
         } else if (origin.startsWith("https://") && origin.endsWith(":443")) {
             authorityOffset = "https://".length();
+            defaultPort = 443;
             portLength = 4;
         } else {
             return origin;
@@ -249,6 +253,14 @@ class CorsPathValidator {
                 || origin.indexOf('/', authorityOffset) != -1
                 || origin.indexOf('?', authorityOffset) != -1
                 || origin.indexOf('#', authorityOffset) != -1) {
+            return origin;
+        }
+        try {
+            URI uri = URI.create(origin);
+            if (uri.getHost() == null || uri.getUserInfo() != null || uri.getPort() != defaultPort) {
+                return origin;
+            }
+        } catch (IllegalArgumentException ignored) {
             return origin;
         }
         return origin.substring(0, portOffset);
@@ -274,7 +286,7 @@ class CorsPathValidator {
             log(req, Level.TRACE, "CORS allowing all origins; actual origin: %s", origin);
             return false;
         }
-        if (allowedOriginsExact.contains(origin)) {
+        if (allowedOriginsExact.contains(normalizeDefaultPort(origin))) {
             log(req, Level.TRACE, "CORS allowing origin; actual origin: %s, allowedOrigins: %s", origin, allowedOriginsExact);
             return false;
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
@@ -17,7 +17,6 @@
 package io.helidon.webserver.cors;
 
 import java.lang.System.Logger.Level;
-import java.net.URI;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +24,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import io.helidon.common.uri.UriValidationException;
+import io.helidon.common.uri.UriValidator;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
@@ -79,6 +80,7 @@ class CorsPathValidator {
                     // this is a pattern
                     originPatterns.add(Pattern.compile(origin, Pattern.CASE_INSENSITIVE));
                 } else {
+                    exactMatchOrigins.add(origin);
                     exactMatchOrigins.add(normalizeDefaultPort(origin));
                 }
             }
@@ -235,15 +237,12 @@ class CorsPathValidator {
 
     private static String normalizeDefaultPort(String origin) {
         int authorityOffset;
-        int defaultPort;
         int portLength;
         if (origin.startsWith("http://") && origin.endsWith(":80")) {
             authorityOffset = "http://".length();
-            defaultPort = 80;
             portLength = 3;
         } else if (origin.startsWith("https://") && origin.endsWith(":443")) {
             authorityOffset = "https://".length();
-            defaultPort = 443;
             portLength = 4;
         } else {
             return origin;
@@ -256,11 +255,8 @@ class CorsPathValidator {
             return origin;
         }
         try {
-            URI uri = URI.create(origin);
-            if (uri.getHost() == null || uri.getUserInfo() != null || uri.getPort() != defaultPort) {
-                return origin;
-            }
-        } catch (IllegalArgumentException ignored) {
+            UriValidator.validateHost(origin.substring(authorityOffset, portOffset));
+        } catch (UriValidationException ignored) {
             return origin;
         }
         return origin.substring(0, portOffset);
@@ -286,7 +282,7 @@ class CorsPathValidator {
             log(req, Level.TRACE, "CORS allowing all origins; actual origin: %s", origin);
             return false;
         }
-        if (allowedOriginsExact.contains(normalizeDefaultPort(origin))) {
+        if (allowedOriginsExact.contains(origin)) {
             log(req, Level.TRACE, "CORS allowing origin; actual origin: %s, allowedOrigins: %s", origin, allowedOriginsExact);
             return false;
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
@@ -78,7 +78,7 @@ class CorsPathValidator {
                     // this is a pattern
                     originPatterns.add(Pattern.compile(origin, Pattern.CASE_INSENSITIVE));
                 } else {
-                    exactMatchOrigins.add(origin);
+                    exactMatchOrigins.add(normalizeDefaultPort(origin));
                 }
             }
 
@@ -230,6 +230,28 @@ class CorsPathValidator {
             }
         }
         return Result.ALLOWED;
+    }
+
+    private static String normalizeDefaultPort(String origin) {
+        int authorityOffset;
+        int portLength;
+        if (origin.startsWith("http://") && origin.endsWith(":80")) {
+            authorityOffset = "http://".length();
+            portLength = 3;
+        } else if (origin.startsWith("https://") && origin.endsWith(":443")) {
+            authorityOffset = "https://".length();
+            portLength = 4;
+        } else {
+            return origin;
+        }
+        int portOffset = origin.length() - portLength;
+        if (portOffset == authorityOffset
+                || origin.indexOf('/', authorityOffset) != -1
+                || origin.indexOf('?', authorityOffset) != -1
+                || origin.indexOf('#', authorityOffset) != -1) {
+            return origin;
+        }
+        return origin.substring(0, portOffset);
     }
 
     private boolean invalidHeaders(ServerRequest req, ServerResponse res, List<String> headers) {

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
@@ -167,6 +167,35 @@ public class CorsPathValidatorTest {
     }
 
     @Test
+    public void testPreFlightConfiguredDefaultPortOrigins() {
+        assertDefaultPortOriginAllowed("http://example.com:80", "http://example.com");
+        assertDefaultPortOriginAllowed("https://example.com:443", "https://example.com");
+    }
+
+    @Test
+    public void testPreFlightNonDefaultPortOriginForbidden() {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of("https://example.com:444"))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, "https://example.com");
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var statusCaptor = ArgumentCaptor.forClass(Status.class);
+        var response = response(ServerResponseHeaders.create());
+        when(response.status(statusCaptor.capture())).thenReturn(response);
+
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders), response);
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(false));
+        assertThat(statusCaptor.getValue(), is(Status.FORBIDDEN_403));
+        verify(response, times(1)).send();
+    }
+
+    @Test
     public void testPreFlightCustomPattern() {
         CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
                                                                        .pathPattern("/greet")
@@ -509,6 +538,25 @@ public class CorsPathValidatorTest {
 
         assertThat("There should be 1 configured response header", responseHeaders.size(), is(1));
         assertThat(responseHeaders, hasHeaderValue(ACCESS_CONTROL_ALLOW_ORIGIN, is(Cors.ALLOW_ALL)));
+    }
+
+    private static void assertDefaultPortOriginAllowed(String allowedOrigin, String origin) {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of(allowedOrigin))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, origin);
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var responseHeaders = ServerResponseHeaders.create();
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders),
+                                                              response(responseHeaders));
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(true));
+        assertThat(responseHeaders, hasHeaderValue(ACCESS_CONTROL_ALLOW_ORIGIN, is(origin)));
     }
 
     private static ServerRequest request(String path, Headers headers) {

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
@@ -169,7 +169,9 @@ public class CorsPathValidatorTest {
     @Test
     public void testPreFlightConfiguredDefaultPortOrigins() {
         assertDefaultPortOriginAllowed("http://example.com:80", "http://example.com");
+        assertDefaultPortOriginAllowed("http://example.com:80", "http://example.com:80");
         assertDefaultPortOriginAllowed("https://example.com:443", "https://example.com");
+        assertDefaultPortOriginAllowed("https://example.com:443", "https://example.com:443");
     }
 
     @Test
@@ -181,6 +183,29 @@ public class CorsPathValidatorTest {
 
         var requestHeaders = WritableHeaders.create();
         requestHeaders.set(HeaderNames.ORIGIN, "https://example.com");
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var statusCaptor = ArgumentCaptor.forClass(Status.class);
+        var response = response(ServerResponseHeaders.create());
+        when(response.status(statusCaptor.capture())).thenReturn(response);
+
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders), response);
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(false));
+        assertThat(statusCaptor.getValue(), is(Status.FORBIDDEN_403));
+        verify(response, times(1)).send();
+    }
+
+    @Test
+    public void testPreFlightMalformedDefaultPortOriginForbidden() {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of("https://example.com:8443:443"))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, "https://example.com:8443");
         requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
 
         var statusCaptor = ArgumentCaptor.forClass(Status.class);


### PR DESCRIPTION
Resolves #12190

Normalize explicit HTTP and HTTPS default ports in configured exact CORS origins so they match browser-serialized `Origin` headers.
