### PR TITLE
Support RFC 10008 QUERY method (27.x)

### DIFF
--- a/declarative/codegen-model/src/main/java/io/helidon/declarative/codegen/model/http/HttpMethod.java
+++ b/declarative/codegen-model/src/main/java/io/helidon/declarative/codegen/model/http/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package io.helidon.declarative.codegen.model.http;
  * HTTP Method definition.
  *
  * @param name    method name (such as {@code GET, POST, LIST})
- * @param builtIn whether this is a recognized method we have constants and methods for in Helidon, or a custom method
+ * @param builtIn whether this is a recognized method with a predefined Helidon HTTP method constant, or a custom method
  */
 public record HttpMethod(String name, boolean builtIn) {
 }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/RestExtensionBase.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/RestExtensionBase.java
@@ -66,7 +66,8 @@ public abstract class RestExtensionBase {
                                                                 + element.elementName(),
                                                         element.originatingElementValue()));
         return switch (method) {
-            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "TRACE" -> new HttpMethod(method, true);
+            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "QUERY", "TRACE" ->
+                new HttpMethod(method, true);
             default -> new HttpMethod(method, false);
         };
     }

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/restclient/RestClientExtension.java
@@ -69,6 +69,7 @@ import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_ENTITY_ANNOTATI
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_FORM_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_NAMES;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_HEADER_PARAM_ANNOTATION;
+import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_METHOD_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PATH_PARAM_ANNOTATION;
 import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_PRODUCES_ANNOTATION;
@@ -107,6 +108,16 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         for (ClientEndpoint endpoint : endpoints) {
             process(roundContext, endpoint);
         }
+    }
+
+    private static boolean hasClientShortcut(RestMethod restMethod) {
+        if (!restMethod.httpMethod().builtIn()) {
+            return false;
+        }
+        return switch (restMethod.httpMethod().name()) {
+            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "TRACE" -> true;
+            default -> false;
+        };
     }
 
     private ClientEndpoint toEndpoint(TypeInfo typeInfo) {
@@ -437,9 +448,15 @@ class RestClientExtension extends RestExtensionBase implements RegistryCodegenEx
         }
 
         it.addContent("var declarative__builder = client.");
-        if (method.httpMethod().builtIn()) {
+        if (hasClientShortcut(method)) {
             it.addContent(method.httpMethod().name().toLowerCase(Locale.ROOT))
                     .addContentLine("(declarative__uri);");
+        } else if (method.httpMethod().builtIn()) {
+            it.addContent("method(")
+                    .addContent(HTTP_METHOD)
+                    .addContent(".")
+                    .addContent(method.httpMethod().name())
+                    .addContentLine(").uri(declarative__uri);");
         } else {
             it.addContent("method(")
                     .addContent(HttpFields.ensureHttpMethodConstant(fieldHandler, method.httpMethod().name()))

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/RestServerExtension.java
@@ -142,6 +142,16 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
                 .addContentLine("\", this::routing);"));
     }
 
+    private static boolean hasServerShortcut(HttpMethod httpMethod) {
+        if (!httpMethod.builtIn()) {
+            return false;
+        }
+        return switch (httpMethod.name()) {
+            case "GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS", "PATCH", "TRACE" -> true;
+            default -> false;
+        };
+    }
+
     private Constructor.Builder constructor(TypeName endpoint,
                                             boolean singleton) {
         var constructor = Constructor.builder();
@@ -633,9 +643,15 @@ class RestServerExtension extends RestExtensionBase implements RegistryCodegenEx
         routing.addContent("rules.");
 
         HttpMethod httpMethod = restMethod.httpMethod();
-        if (httpMethod.builtIn()) {
+        if (hasServerShortcut(httpMethod)) {
             routing.addContent(httpMethod.name().toLowerCase(Locale.ROOT))
                     .addContent("(");
+        } else if (httpMethod.builtIn()) {
+            routing.addContent("route(")
+                    .addContent(HTTP_METHOD)
+                    .addContent(".")
+                    .addContent(httpMethod.name())
+                    .addContent(", ");
         } else {
             routing.addContent("route(" + HttpFields.ensureHttpMethodConstant(fieldHandler, httpMethod.name()) + ", ");
         }

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/QueryMethodCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/restclient/QueryMethodCodegenTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.restclient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Generated;
+import io.helidon.common.types.TypeName;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webclient.api.RestClient;
+import io.helidon.webclient.api.WebClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class QueryMethodCodegenTest {
+    private static final List<Class<?>> CLASSPATH = List.of(
+            Generated.class,
+            TypeName.class,
+            Config.class,
+            Http.class,
+            Service.class,
+            RestClient.class,
+            WebClient.class
+    );
+
+    @Test
+    void generatedQueryClientUsesGenericMethodApi() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .procOnly()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/rest-client-query-method"))
+                .addSource("QueryClient.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.webclient.api.RestClient;
+
+                        @RestClient.Endpoint("http://localhost:8080")
+                        interface QueryClient {
+                            @Http.QUERY
+                            String query(@Http.Entity String query);
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedClient = result.sourceOutput().resolve("com/example/QueryClient__DeclarativeClient.java");
+        assertThat(diagnostics, Files.exists(generatedClient), is(true));
+
+        String generated = Files.readString(generatedClient, StandardCharsets.UTF_8);
+        assertThat(generated, containsString("client.method(Method.QUERY).uri(declarative__uri);"));
+        assertThat(generated, not(containsString("client.query(")));
+    }
+}

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryMethodCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/http/webserver/QueryMethodCodegenTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.declarative.codegen.http.webserver;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Default;
+import io.helidon.common.Generated;
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.Mappers;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.types.Annotation;
+import io.helidon.common.uri.UriQuery;
+import io.helidon.config.Config;
+import io.helidon.http.Http;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.service.registry.Dependency;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceDescriptor;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.HttpEntryPoint;
+import io.helidon.webserver.http.HttpFeature;
+import io.helidon.webserver.http.HttpRoute;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.RestServer;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class QueryMethodCodegenTest {
+    private static final List<Class<?>> CLASSPATH = List.of(
+            Annotation.class,
+            Config.class,
+            Default.class,
+            Dependency.class,
+            Generated.class,
+            GenericType.class,
+            Handler.class,
+            Http.class,
+            HttpEntryPoint.class,
+            HttpFeature.class,
+            HttpRoute.class,
+            HttpRouting.class,
+            HttpRules.class,
+            Mappers.class,
+            Parameters.class,
+            Prototype.class,
+            ReadableEntity.class,
+            RestServer.class,
+            ServerRequest.class,
+            ServerResponse.class,
+            Service.class,
+            ServiceDescriptor.class,
+            UriQuery.class
+    );
+
+    @Test
+    void generatedQueryEndpointUsesGenericRouteApi() throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(CLASSPATH)
+                .addProcessor(AptProcessor::new)
+                .workDir(Path.of("target/test-compiler/http-query-method"))
+                .addSource("QueryEndpoint.java", """
+                        package com.example;
+
+                        import io.helidon.http.Http;
+                        import io.helidon.service.registry.Service;
+                        import io.helidon.webserver.http.RestServer;
+
+                        @RestServer.Listener("@default")
+                        @RestServer.Endpoint
+                        @Service.Singleton
+                        @Http.Path("/query")
+                        class QueryEndpoint {
+                            @Http.QUERY
+                            String query() {
+                                return "result";
+                            }
+                        }
+                        """)
+                .addSource("Main.java", """
+                        package com.example;
+
+                        import io.helidon.service.registry.Service;
+
+                        @Service.GenerateBinding
+                        class Main {
+                        }
+                        """)
+                .build()
+                .compile();
+
+        String diagnostics = String.join("\n", result.diagnostics());
+        assertThat(diagnostics, result.success(), is(true));
+
+        var generatedEndpoint = result.sourceOutput().resolve("com/example/QueryEndpoint__HttpFeature.java");
+        assertThat(diagnostics, Files.exists(generatedEndpoint), is(true));
+
+        String generated = Files.readString(generatedEndpoint, StandardCharsets.UTF_8);
+        assertThat(generated, containsString("rules.route(Method.QUERY, \"/\", handler_query);"));
+        assertThat(generated, not(containsString("rules.query(")));
+    }
+}

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetService.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetService.java
@@ -44,6 +44,12 @@ interface GreetService {
     @Http.Path("/all")
     List<GreetingDto> greetings();
 
+    @Http.QUERY
+    @Http.Path("/query")
+    @Http.Consumes(MediaTypes.TEXT_PLAIN_VALUE)
+    @Http.Produces(MediaTypes.TEXT_PLAIN_VALUE)
+    String query(@Http.Entity String query);
+
     @Http.GET
     @Http.Path("/ft/retry")
     String retriable();

--- a/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
+++ b/declarative/tests/http/src/main/java/io/helidon/declarative/tests/http/GreetServiceEndpoint.java
@@ -166,6 +166,11 @@ class GreetServiceEndpoint implements GreetService {
         return List.of(new GreetingDto(this.greeting.get()), new GreetingDto("Hello"));
     }
 
+    @Override
+    public String query(@Http.Entity String query) {
+        return "Result: " + query;
+    }
+
     @Ft.Fallback(value = "fallback", applyOn = IllegalStateException.class)
     @Override
     public String failingFallback(@Http.HeaderParam(HeaderNames.HOST_NAME) String host) {

--- a/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
+++ b/declarative/tests/http/src/test/java/io/helidon/declarative/tests/http/DeclarativeHttpTest.java
@@ -91,6 +91,16 @@ class DeclarativeHttpTest {
     }
 
     @Test
+    void testQuery() {
+        GreetServiceClient typedClient = registry.get(Lookup.builder()
+                                                              .addContract(GreetServiceClient.class)
+                                                              .addQualifier(Qualifier.create(RestClient.Client.class))
+                                                              .build());
+
+        assertThat(typedClient.query("name = 'Ada'"), is("Result: name = 'Ada'"));
+    }
+
+    @Test
     void testInheritedClientRetry() {
         InheritedFtClient typedClient = registry.get(Lookup.builder()
                                                               .addContract(InheritedFtClient.class)

--- a/docs/modules/injection/declarative.md
+++ b/docs/modules/injection/declarative.md
@@ -181,8 +181,9 @@ Annotations on endpoint methods:
   to return (if a custom one is required)
 - [`io.helidon.http.Http.Path`][io-helidon-http] - path (context) this method
   will be available on (subpath of the endpoint path)
-- [`io.helidon.http.Http.GET`][io-helidon-http-2] (and other methods) -
-  definition of HTTP method this method will serve
+- [`io.helidon.http.Http.GET`][io-helidon-http-2] (and other methods, including
+  `io.helidon.http.Http.QUERY`) - definition of HTTP method this method will
+  serve
 - [`io.helidon.http.Http.HttpMethod`][io-helidon-http-3] - for custom HTTP
   method names (mutually exclusive with above)
 - [`io.helidon.http.Http.Produces`][io-helidon-http-4] - what media type this
@@ -191,6 +192,10 @@ Annotations on endpoint methods:
 - [`io.helidon.http.Http.Consumes`][io-helidon-http-5] - what media type this
   method accepts (request entity content type), replacing the endpoint default;
   an empty array clears it
+
+For a QUERY endpoint, use `@Http.QUERY` with `@Http.Entity` for the query
+content and `@Http.Consumes` for its required media type. The application still
+defines the query format and validates that the content matches that media type.
 
 Annotations on method parameters:
 
@@ -323,8 +328,9 @@ Annotations on endpoint methods:
   header to compute and include in every request to the server
 - [`io.helidon.http.Http.Path`][io-helidon-http] - path (context) the server
   serves this endpoint method on
-- [`io.helidon.http.Http.GET`][io-helidon-http-2] (and other methods) -
-  definition of HTTP method this method will invoke
+- [`io.helidon.http.Http.GET`][io-helidon-http-2] (and other methods, including
+  `io.helidon.http.Http.QUERY`) - definition of HTTP method this method will
+  invoke
 - [`io.helidon.http.Http.HttpMethod`][io-helidon-http-3] - for custom HTTP
   method names (mutually exclusive with above)
 - [`io.helidon.http.Http.Produces`][io-helidon-http-4] - what media type this
@@ -333,6 +339,9 @@ Annotations on endpoint methods:
 - [`io.helidon.http.Http.Consumes`][io-helidon-http-5] - what media type this
   method accepts (request entity content type), replacing the client type
   default; an empty array clears it
+
+For a QUERY client method, use `@Http.QUERY`, annotate its query content with
+`@Http.Entity`, and declare the content media type using `@Http.Consumes`.
 
 Annotations on method parameters:
 

--- a/docs/modules/metrics/metrics.md
+++ b/docs/modules/metrics/metrics.md
@@ -783,10 +783,10 @@ requests Helidon measures; use the `methods` setting in a `paths` entry for that
 purpose.
 
 By default, Helidon records `CONNECT`, `DELETE`, `GET`, `HEAD`, `LIST`,
-`OPTIONS`, `PATCH`, `POST`, `PUT`, and `TRACE` as their canonical method names.
-Helidon records any other method as `_OTHER`. Method names in the configuration
-are canonicalized using Helidon's HTTP method model; for example, `propfind`
-becomes `PROPFIND`.
+`OPTIONS`, `PATCH`, `POST`, `PUT`, `QUERY`, and `TRACE` as their canonical
+method names. Helidon records any other method as `_OTHER`. Method names in the
+configuration are canonicalized using Helidon's HTTP method model; for example,
+`propfind` becomes `PROPFIND`.
 
 Assigning `known-methods` replaces the entire default list. Include every
 default method you want to retain.

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -131,6 +131,21 @@ These methods will create a new instance of
 [HttpClientRequest][httpclientreques] which can then be configured to add
 optional settings that will customize the behavior of the request.
 
+Use the generic method API for a QUERY request and submit the query as request
+content with its media type:
+
+```java
+var response = client.method(Method.QUERY)
+        .uri("http://example.com/search")
+        .contentType(MediaTypes.APPLICATION_JSON)
+        .submit(query);
+```
+
+When redirects are enabled, WebClient preserves the QUERY method and its
+content for `301`, `302`, `307`, and `308` responses. A `303` response changes
+the redirected request to GET without the original query content, as required
+by [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html#section-2.5).
+
 ### Customizing the Request
 
 Configuration can be set for every request type before it is sent.

--- a/docs/modules/webserver/webserver.md
+++ b/docs/modules/webserver/webserver.md
@@ -443,10 +443,41 @@ example:
 | **DELETE**         | `.delete(handler)`                                                 |
 | **TRACE**          | `.trace(handler)`                                                  |
 | **OPTIONS**        | `.options(handler)`                                                |
+| **QUERY**          | `.route(Method.QUERY, handler)`                                    |
 | *any method*       | `.any(handler)`                                                    |
 | *multiple methods* | `.route(Method.predicate(Method.GET, Method.POST), path, handler)` |
 | *custom method*    | `.route(Method.create("CUSTOM"), handler)`                         |
 <!--@mdc :: -->
+
+#### QUERY Requests
+
+The [QUERY method](https://www.rfc-editor.org/rfc/rfc10008.html) is safe and
+idempotent. Its request content and `Content-Type` together define the query,
+so a QUERY request must include a `Content-Type`. Helidon transports the method,
+content, and metadata and routes the request. The application remains
+responsible for ensuring the operation is actually safe and idempotent, checking
+that the content is consistent with its declared type, and selecting responses
+such as `415 Unsupported Media Type`, `422 Unprocessable Content`, or
+`406 Not Acceptable` when appropriate.
+
+An application can advertise the query formats supported by a resource using
+`res.headers().addAcceptQueries(...)`. A WebClient can read the advertised media
+types using `response.headers().acceptQueries()`. `Accept-Query` is an
+[RFC 9651 Structured Field](https://www.rfc-editor.org/rfc/rfc9651.html) List,
+not an `Accept`-style field. Each list member is a Token or String containing a
+media range without parameters; media type parameters are Structured Field
+parameters with Token or String values. Those two parameter value forms have
+the same semantics. Only `*/*` and `type/*` wildcards are supported, member
+order is insignificant, and the advertised value applies to the resource path
+regardless of the URI query component. Applications which parse or produce the
+field must use RFC 9651's strict syntax.
+
+QUERY responses are cacheable, but a cache which reuses them for later QUERY
+requests must include the request content and related metadata in its cache key.
+Cache normalization must preserve the resource's query semantics. Helidon does
+not construct that application-specific key. Browser clients use a CORS
+preflight for QUERY because it is not a CORS-safelisted method, so applications
+must allow QUERY explicitly when cross-origin access is intended.
 
 ### Path Matcher Routing
 

--- a/http/http/src/main/java/io/helidon/http/AcceptQuery.java
+++ b/http/http/src/main/java/io/helidon/http/AcceptQuery.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+
+final class AcceptQuery {
+    private AcceptQuery() {
+    }
+
+    static List<HttpMediaType> parse(String value) {
+        Objects.requireNonNull(value, "Accept-Query value must not be null");
+        return new Parser(value).parse();
+    }
+
+    static String serialize(MediaType... mediaTypes) {
+        Objects.requireNonNull(mediaTypes, "Accept-Query media types must not be null");
+
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < mediaTypes.length; i++) {
+            MediaType mediaType = Objects.requireNonNull(mediaTypes[i], "Accept-Query media type must not be null");
+            if (i > 0) {
+                result.append(", ");
+            }
+
+            appendStringOrToken(result, mediaRange(mediaType));
+            if (mediaType instanceof HttpMediaType httpMediaType) {
+                for (Map.Entry<String, String> entry : httpMediaType.parameters().entrySet()) {
+                    String key = entry.getKey().toLowerCase(Locale.ROOT);
+                    validateKey(key);
+                    result.append(';')
+                            .append(key)
+                            .append('=');
+                    appendStringOrToken(result,
+                                        Objects.requireNonNull(entry.getValue(),
+                                                               "Accept-Query parameter value must not be null"));
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    private static HttpMediaType createMediaType(String mediaRange, Map<String, String> parameters) {
+        int slash = mediaRange.indexOf('/');
+        if (slash < 1 || slash != mediaRange.lastIndexOf('/') || slash == mediaRange.length() - 1) {
+            throw invalid("Invalid media range");
+        }
+
+        String type = mediaRange.substring(0, slash);
+        String subtype = mediaRange.substring(slash + 1);
+        validateMediaRange(type, subtype);
+        return HttpMediaType.builder()
+                .mediaType(MediaTypes.create(type, subtype))
+                .parameters(parameters)
+                .build();
+    }
+
+    private static String mediaRange(MediaType mediaType) {
+        String type = Objects.requireNonNull(mediaType.type(), "Accept-Query media type must not be null");
+        String subtype = Objects.requireNonNull(mediaType.subtype(), "Accept-Query media subtype must not be null");
+        validateMediaRange(type, subtype);
+        return type + "/" + subtype;
+    }
+
+    private static void validateMediaRange(String type, String subtype) {
+        if (!HttpToken.isValid(type) || !HttpToken.isValid(subtype)) {
+            throw invalid("Invalid media range");
+        }
+        if (type.indexOf('*') >= 0 && !("*".equals(type) && "*".equals(subtype))) {
+            throw invalid("Unsupported wildcard media range");
+        }
+        if (subtype.indexOf('*') >= 0 && !"*".equals(subtype)) {
+            throw invalid("Unsupported wildcard media range");
+        }
+    }
+
+    private static void appendStringOrToken(StringBuilder result, String value) {
+        if (isToken(value)) {
+            result.append(value);
+            return;
+        }
+
+        result.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch < 0x20 || ch >= 0x7f) {
+                throw invalid("Value cannot be represented as a Structured Field String");
+            }
+            if (ch == '"' || ch == '\\') {
+                result.append('\\');
+            }
+            result.append(ch);
+        }
+        result.append('"');
+    }
+
+    private static void validateKey(String key) {
+        if (key.isEmpty() || !isKeyFirst(key.charAt(0))) {
+            throw invalid("Invalid parameter name");
+        }
+        for (int i = 1; i < key.length(); i++) {
+            if (!isKeyCharacter(key.charAt(i))) {
+                throw invalid("Invalid parameter name");
+            }
+        }
+    }
+
+    private static boolean isToken(String value) {
+        if (value.isEmpty() || !isTokenFirst(value.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < value.length(); i++) {
+            if (!isTokenCharacter(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isTokenFirst(char ch) {
+        return isAlpha(ch) || ch == '*';
+    }
+
+    private static boolean isTokenCharacter(char ch) {
+        return isAlpha(ch)
+                || ch >= '0' && ch <= '9'
+                || switch (ch) {
+                    case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~', ':', '/' -> true;
+                    default -> false;
+                };
+    }
+
+    private static boolean isKeyFirst(char ch) {
+        return isLowerAlpha(ch) || ch == '*';
+    }
+
+    private static boolean isKeyCharacter(char ch) {
+        return isLowerAlpha(ch)
+                || ch >= '0' && ch <= '9'
+                || ch == '_'
+                || ch == '-'
+                || ch == '.'
+                || ch == '*';
+    }
+
+    private static boolean isAlpha(char ch) {
+        return ch >= 'A' && ch <= 'Z' || isLowerAlpha(ch);
+    }
+
+    private static boolean isLowerAlpha(char ch) {
+        return ch >= 'a' && ch <= 'z';
+    }
+
+    private static IllegalArgumentException invalid(String message) {
+        return new IllegalArgumentException("Invalid Accept-Query header: " + message);
+    }
+
+    private static final class Parser {
+        private final String value;
+        private int index;
+
+        private Parser(String value) {
+            this.value = value;
+        }
+
+        private List<HttpMediaType> parse() {
+            skipSpaces();
+            if (atEnd()) {
+                return List.of();
+            }
+
+            List<HttpMediaType> result = new ArrayList<>();
+            while (true) {
+                result.add(parseMediaType());
+                skipOptionalWhitespace();
+                if (atEnd()) {
+                    return List.copyOf(result);
+                }
+                require(',');
+                skipOptionalWhitespace();
+                if (atEnd()) {
+                    throw invalid("Trailing comma");
+                }
+            }
+        }
+
+        private HttpMediaType parseMediaType() {
+            String mediaRange = parseStringOrToken();
+            Map<String, String> parameters = new LinkedHashMap<>();
+            while (!atEnd() && current() == ';') {
+                index++;
+                skipSpaces();
+                String key = parseKey();
+                if (atEnd() || current() != '=') {
+                    throw invalid("Accept-Query parameters must have String or Token values");
+                }
+                index++;
+                parameters.put(key, parseStringOrToken());
+            }
+            return createMediaType(mediaRange, parameters);
+        }
+
+        private String parseStringOrToken() {
+            if (atEnd()) {
+                throw invalid("Expected a String or Token");
+            }
+            return current() == '"' ? parseString() : parseToken();
+        }
+
+        private String parseString() {
+            index++;
+            StringBuilder result = new StringBuilder();
+            while (!atEnd()) {
+                char ch = current();
+                index++;
+                if (ch == '\\') {
+                    if (atEnd()) {
+                        throw invalid("Incomplete String escape");
+                    }
+                    ch = current();
+                    index++;
+                    if (ch != '"' && ch != '\\') {
+                        throw invalid("Invalid String escape");
+                    }
+                } else if (ch == '"') {
+                    return result.toString();
+                } else if (ch < 0x20 || ch >= 0x7f) {
+                    throw invalid("Invalid String character");
+                }
+                result.append(ch);
+            }
+            throw invalid("Unterminated String");
+        }
+
+        private String parseToken() {
+            if (!isTokenFirst(current())) {
+                throw invalid("Expected a String or Token");
+            }
+            int start = index++;
+            while (!atEnd() && isTokenCharacter(current())) {
+                index++;
+            }
+            return value.substring(start, index);
+        }
+
+        private String parseKey() {
+            if (atEnd() || !isKeyFirst(current())) {
+                throw invalid("Invalid parameter name");
+            }
+            int start = index++;
+            while (!atEnd() && isKeyCharacter(current())) {
+                index++;
+            }
+            return value.substring(start, index);
+        }
+
+        private void skipSpaces() {
+            while (!atEnd() && current() == ' ') {
+                index++;
+            }
+        }
+
+        private void skipOptionalWhitespace() {
+            while (!atEnd() && (current() == ' ' || current() == '\t')) {
+                index++;
+            }
+        }
+
+        private void require(char expected) {
+            if (atEnd() || current() != expected) {
+                throw invalid("Expected '" + expected + "'");
+            }
+            index++;
+        }
+
+        private boolean atEnd() {
+            return index == value.length();
+        }
+
+        private char current() {
+            return value.charAt(index);
+        }
+    }
+}

--- a/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ClientResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Optional;
 import io.helidon.common.media.type.ParserMode;
 
 import static io.helidon.http.HeaderNames.ACCEPT_PATCH;
+import static io.helidon.http.HeaderNames.ACCEPT_QUERY;
 import static io.helidon.http.HeaderNames.EXPIRES;
 import static io.helidon.http.HeaderNames.LAST_MODIFIED;
 import static io.helidon.http.HeaderNames.LOCATION;
@@ -67,6 +68,24 @@ public interface ClientResponseHeaders extends Headers {
             mediaTypes.add(HttpMediaType.create(value));
         }
         return mediaTypes;
+    }
+
+    /**
+     * Media types supported by the resource for {@link Method#QUERY} request content.
+     *
+     * @return list of accepted QUERY media types, or an empty list if the header is absent or invalid
+     */
+    default List<HttpMediaType> acceptQueries() {
+        Optional<String> value = value(ACCEPT_QUERY);
+        if (value.isEmpty()) {
+            return List.of();
+        }
+        try {
+            return AcceptQuery.parse(value.get());
+        } catch (IllegalArgumentException _) {
+            // RFC 9651 requires the entire field to be ignored if parsing fails.
+            return List.of();
+        }
     }
 
     /**

--- a/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNameEnum.java
@@ -192,6 +192,7 @@ enum HeaderNameEnum implements HeaderName {
         static final String USER_AGENT_NAME = "User-Agent";
         static final String VIA_NAME = "Via";
         static final String ACCEPT_PATCH_NAME = "Accept-Patch";
+        static final String ACCEPT_QUERY_NAME = "Accept-Query";
         static final String ACCEPT_RANGES_NAME = "Accept-Ranges";
         static final String AGE_NAME = "Age";
         static final String ALLOW_NAME = "Allow";

--- a/http/http/src/main/java/io/helidon/http/HeaderNames.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderNames.java
@@ -397,6 +397,18 @@ public final class HeaderNames {
     public static final HeaderName ACCEPT_PATCH = HeaderNameEnum.ACCEPT_PATCH;
     /**
      * The {@value} header name.
+     * Specifies the media types this resource supports for {@link Method#QUERY} request content.
+     */
+    public static final String ACCEPT_QUERY_NAME = Strings.ACCEPT_QUERY_NAME;
+    /**
+     * The {@value #ACCEPT_QUERY_NAME} header name.
+     * Specifies the media types this resource supports for {@link Method#QUERY} request content.
+     * <p>
+     * This specialized response header is not part of the indexed known-header set.
+     */
+    public static final HeaderName ACCEPT_QUERY = createNonIndexed(ACCEPT_QUERY_NAME);
+    /**
+     * The {@value} header name.
      * What partial content range types this server supports via byte serving.
      */
     public static final String ACCEPT_RANGES_NAME = Strings.ACCEPT_RANGES_NAME;

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -299,6 +299,15 @@ public final class Http {
     }
 
     /**
+     * QUERY method of an HTTP endpoint.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Documented
+    @HttpMethod(Method.QUERY_NAME)
+    public @interface QUERY {
+    }
+
+    /**
      * PUT method of an HTTP endpoint.
      */
     @Retention(RetentionPolicy.CLASS)

--- a/http/http/src/main/java/io/helidon/http/Method.java
+++ b/http/http/src/main/java/io/helidon/http/Method.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,10 @@ public final class Method {
     /**
      * {@value} method name.
      */
+    public static final String QUERY_NAME = "QUERY";
+    /**
+     * {@value} method name.
+     */
     public static final String PUT_NAME = "PUT";
     /**
      * {@value} method name.
@@ -85,6 +89,10 @@ public final class Method {
      * to a database.
      */
     public static final Method POST = new Method(POST_NAME, true);
+    /**
+     * The QUERY method requests that the target resource process the enclosed content in a safe and idempotent manner.
+     */
+    public static final Method QUERY = new Method(QUERY_NAME, true);
     /**
      * The PUT method requests that the enclosed entity be stored under the supplied Request-URI. If the Request-URI refers
      * to an already existing resource, the enclosed entity SHOULD be considered as a modified version of the one residing

--- a/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
+++ b/http/http/src/main/java/io/helidon/http/ServerResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,22 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
         }
         return add(HeaderValues.create(HeaderNames.ACCEPT_PATCH,
                                        values));
+    }
+
+    /**
+     * Adds one or more media types supported by this resource for {@link Method#QUERY} request content
+     * (header {@link HeaderNames#ACCEPT_QUERY}).
+     * {@link HttpMediaType} may be used to add media type parameters.
+     *
+     * @param acceptableMediaTypes media types to add
+     * @return this instance
+     */
+    default ServerResponseHeaders addAcceptQueries(MediaType... acceptableMediaTypes) {
+        String value = AcceptQuery.serialize(acceptableMediaTypes);
+        if (value.isEmpty()) {
+            return this;
+        }
+        return add(HeaderValues.create(HeaderNames.ACCEPT_QUERY, value));
     }
 
     /**

--- a/http/http/src/test/java/io/helidon/http/AcceptQueryTest.java
+++ b/http/http/src/test/java/io/helidon/http/AcceptQueryTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http;
+
+import java.util.List;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AcceptQueryTest {
+    @Test
+    void parsesRfcExample() {
+        List<HttpMediaType> result = AcceptQuery.parse(
+                "\"application/jsonpath\", application/sql;charset=\"UTF-8\"");
+
+        assertAll(
+                () -> assertThat(result.size(), is(2)),
+                () -> assertThat(result.get(0).mediaType(), equalTo(MediaTypes.create("application/jsonpath"))),
+                () -> assertThat(result.get(0).parameters().isEmpty(), is(true)),
+                () -> assertThat(result.get(1).mediaType(), equalTo(MediaTypes.create("application/sql"))),
+                () -> assertThat(result.get(1).parameters().get("charset"), is("UTF-8"))
+        );
+    }
+
+    @Test
+    void parsesAllowedWildcardsAndLeadingDigitType() {
+        List<HttpMediaType> result = AcceptQuery.parse("*/*, application/*, \"1example/query\"");
+
+        assertAll(
+                () -> assertThat(result.get(0).mediaType(), equalTo(MediaTypes.WILDCARD)),
+                () -> assertThat(result.get(1).text(), is("application/*")),
+                () -> assertThat(result.get(2).text(), is("1example/query"))
+        );
+    }
+
+    @Test
+    void treatsStringAndTokenItemsTheSame() {
+        List<HttpMediaType> result = AcceptQuery.parse("\"application/json\", application/json");
+
+        assertThat(result.get(0), equalTo(result.get(1)));
+    }
+
+    @Test
+    void usesLastDuplicateParameterValue() {
+        List<HttpMediaType> result = AcceptQuery.parse(
+                "application/sql;charset=UTF-8;charset=\"utf-16\"");
+
+        assertThat(result.get(0).parameters().get("charset"), is("utf-16"));
+    }
+
+    @Test
+    void parsesAllowedWhitespaceAndStringParameterValues() {
+        List<HttpMediaType> result = AcceptQuery.parse(
+                " application/json; profile=\"a,b;c\" \t,\t application/sql; note=\"\" \t");
+
+        assertAll(
+                () -> assertThat(result.get(0).parameters().get("profile"), is("a,b;c")),
+                () -> assertThat(result.get(1).parameters().get("note"), is(""))
+        );
+    }
+
+    @Test
+    void combinesSeparateHeaderFieldsBeforeParsing() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.create(HeaderNames.ACCEPT_QUERY, "application/json"));
+        headers.add(HeaderValues.create(HeaderNames.ACCEPT_QUERY, "application/sql;charset=UTF-8"));
+
+        List<HttpMediaType> result = ClientResponseHeaders.create(headers).acceptQueries();
+
+        assertAll(
+                () -> assertThat(result.size(), is(2)),
+                () -> assertThat(result.get(0).text(), is("application/json")),
+                () -> assertThat(result.get(1).parameters().get("charset"), is("UTF-8"))
+        );
+    }
+
+    @Test
+    void ignoresAnInvalidWholeField() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.create(HeaderNames.ACCEPT_QUERY, "application/json"));
+        headers.add(HeaderValues.create(HeaderNames.ACCEPT_QUERY, "application/sql,"));
+
+        assertThat(ClientResponseHeaders.create(headers).acceptQueries().isEmpty(), is(true));
+    }
+
+    @Test
+    void handlesAbsentAndEmptyFields() {
+        WritableHeaders<?> emptyHeaders = WritableHeaders.create();
+        WritableHeaders<?> emptyField = WritableHeaders.create();
+        emptyField.set(HeaderValues.create(HeaderNames.ACCEPT_QUERY, ""));
+
+        assertAll(
+                () -> assertThat(ClientResponseHeaders.create(emptyHeaders).acceptQueries().isEmpty(), is(true)),
+                () -> assertThat(ClientResponseHeaders.create(emptyField).acceptQueries().isEmpty(), is(true)),
+                () -> assertThat(AcceptQuery.parse("   ").isEmpty(), is(true))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application/json,",
+            "application/json,,application/sql",
+            "(\"application/json\")",
+            "42",
+            "application/json;q",
+            "application/json;q=?0",
+            "application/json;q=1",
+            "application/json;q=:YWJj:",
+            "application/json;q=@1",
+            "application/json;q=%\"value\"",
+            "application/json;Charset=UTF-8",
+            "application/json ;q=UTF-8",
+            "application/json; \tq=UTF-8",
+            "\tapplication/json",
+            "\"application\\/json\"",
+            "\"application/json",
+            "application/*+json",
+            "*/json",
+            "application/json;note=\"non-ASCII-\u00e9\""
+    })
+    void rejectsInvalidStructuredFields(String value) {
+        assertThrows(IllegalArgumentException.class, () -> AcceptQuery.parse(value));
+    }
+
+    @Test
+    void serializesMediaTypesAndParameters() {
+        HttpMediaType sql = HttpMediaType.builder()
+                .mediaType(MediaTypes.create("application/sql"))
+                .charset("UTF-8")
+                .build();
+
+        String result = AcceptQuery.serialize(MediaTypes.APPLICATION_JSON,
+                                                     MediaTypes.create("1example", "query"),
+                                                     sql);
+
+        assertThat(result, is("application/json, \"1example/query\", application/sql;charset=UTF-8"));
+        assertThat(AcceptQuery.parse(result).size(), is(3));
+    }
+
+    @Test
+    void escapesStructuredFieldStrings() {
+        HttpMediaType mediaType = HttpMediaType.builder()
+                .mediaType(MediaTypes.APPLICATION_JSON)
+                .addParameter("profile", "a\"b\\c")
+                .build();
+
+        String result = AcceptQuery.serialize(mediaType);
+
+        assertAll(
+                () -> assertThat(result, is("application/json;profile=\"a\\\"b\\\\c\"")),
+                () -> assertThat(AcceptQuery.parse(result).get(0).parameters().get("profile"), is("a\"b\\c"))
+        );
+    }
+
+    @Test
+    void addsAcceptedQueriesToServerResponseHeaders() {
+        ServerResponseHeaders headers = ServerResponseHeaders.create();
+        HttpMediaType sql = HttpMediaType.builder()
+                .mediaType(MediaTypes.create("application/sql"))
+                .charset("UTF-8")
+                .build();
+
+        assertThat(headers.addAcceptQueries(), sameInstance(headers));
+        assertThat(headers.contains(HeaderNames.ACCEPT_QUERY), is(false));
+
+        headers.addAcceptQueries(MediaTypes.APPLICATION_JSON, sql);
+
+        assertAll(
+                () -> assertThat(headers.get(HeaderNames.ACCEPT_QUERY).get(),
+                                 is("application/json, application/sql;charset=UTF-8")),
+                () -> assertThat(headers.acceptQueries().size(), is(2))
+        );
+    }
+
+    @Test
+    void rejectsValuesThatCannotBeSerialized() {
+        HttpMediaType invalidParameterName = HttpMediaType.builder()
+                .mediaType(MediaTypes.APPLICATION_JSON)
+                .addParameter("1parameter", "value")
+                .build();
+        HttpMediaType invalidParameterValue = HttpMediaType.builder()
+                .mediaType(MediaTypes.APPLICATION_JSON)
+                .addParameter("parameter", "non-ASCII-\u00e9")
+                .build();
+
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> AcceptQuery.serialize(MediaTypes.create("*", "json"))),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> AcceptQuery.serialize(MediaTypes.create("application", "*+json"))),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> AcceptQuery.serialize(invalidParameterName)),
+                () -> assertThrows(IllegalArgumentException.class,
+                                   () -> AcceptQuery.serialize(invalidParameterValue)),
+                () -> assertThrows(NullPointerException.class,
+                                   () -> AcceptQuery.serialize((MediaType[]) null)),
+                () -> assertThrows(NullPointerException.class,
+                                   () -> AcceptQuery.serialize(MediaTypes.APPLICATION_JSON, null))
+        );
+    }
+}

--- a/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderNamesTest.java
@@ -42,6 +42,7 @@ class HeaderNamesTest {
     private static final Class<HeaderNames> clazz = HeaderNames.class;
     @SuppressWarnings("removal")
     private static final List<HeaderName> NON_INDEXED_HEADERS = List.of(HeaderNames.ACCEPT_CHARSET,
+                                                                        HeaderNames.ACCEPT_QUERY,
                                                                         HeaderNames.ALT_USED,
                                                                         HeaderNames.PUBLIC_KEY_PINS,
                                                                         HeaderNames.SET_COOKIE2,
@@ -171,6 +172,19 @@ class HeaderNamesTest {
                 () -> assertThat(contentLocation.defaultCase(), is("Content-Location")),
                 () -> assertThat(contentLocation.lowerCase(), is("content-location")),
                 () -> assertThat(HeaderNames.create("Content-Location"), equalTo(contentLocation))
+        );
+    }
+
+    @Test
+    void testAcceptQueryHeaderName() {
+        HeaderName acceptQuery = HeaderNames.ACCEPT_QUERY;
+
+        assertAll(
+                () -> assertThat(HeaderNames.ACCEPT_QUERY_NAME, is("Accept-Query")),
+                () -> assertThat(acceptQuery.defaultCase(), is("Accept-Query")),
+                () -> assertThat(acceptQuery.lowerCase(), is("accept-query")),
+                () -> assertThat(acceptQuery.index(), is(-1)),
+                () -> assertThat(HeaderNames.create("ACCEPT-QUERY"), equalTo(acceptQuery))
         );
     }
 

--- a/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -47,6 +48,18 @@ class HttpMethodTest {
             .filter(it -> it.getType().equals(String.class))
             .map(Field::getName)
             .collect(Collectors.toSet());
+
+    @Test
+    void testQueryMethod() {
+        MethodPredicate predicate = Method.predicate(Method.QUERY);
+
+        assertAll(
+                () -> assertThat(Method.create("QUERY"), sameInstance(Method.QUERY)),
+                () -> assertThat(Method.create("query"), sameInstance(Method.QUERY)),
+                () -> assertThat(predicate.test(Method.QUERY), is(true)),
+                () -> assertThat(predicate.test(Method.POST), is(false))
+        );
+    }
 
     @Test
     void testAllMethodConstantsAreValid() throws NoSuchFieldException, IllegalAccessException {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
@@ -63,14 +63,47 @@ public class HttpRedirectJmhBenchmark {
         invokeRedirectOutputStream(state.http2Client, blackhole);
     }
 
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1QueryEntityRedirect(NetworkState state, Blackhole blackhole) {
+        invokeQueryRedirect(state.http1Client, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2QueryEntityRedirect(NetworkState state, Blackhole blackhole) {
+        invokeQueryRedirect(state.http2Client, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1QueryOutputStreamRedirect(NetworkState state, Blackhole blackhole) {
+        invokeQueryRedirectOutputStream(state.http1Client, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2QueryOutputStreamRedirect(NetworkState state, Blackhole blackhole) {
+        invokeQueryRedirectOutputStream(state.http2Client, blackhole);
+    }
+
     private static void configureRouting(HttpRouting.Builder routing) {
         routing.put(REDIRECT_PATH, HttpRedirectJmhBenchmark::redirect)
-                .put(TARGET_PATH, HttpRedirectJmhBenchmark::handle);
+                .put(TARGET_PATH, HttpRedirectJmhBenchmark::handle)
+                .route(Method.QUERY, REDIRECT_PATH, HttpRedirectJmhBenchmark::queryRedirect)
+                .route(Method.QUERY, TARGET_PATH, HttpRedirectJmhBenchmark::handle);
     }
 
     private static void redirect(ServerRequest request, ServerResponse response) {
         request.content().as(byte[].class);
         response.status(Status.TEMPORARY_REDIRECT_307)
+                .header(HeaderNames.LOCATION, TARGET_PATH)
+                .send();
+    }
+
+    private static void queryRedirect(ServerRequest request, ServerResponse response) {
+        request.content().as(byte[].class);
+        response.status(Status.FOUND_302)
                 .header(HeaderNames.LOCATION, TARGET_PATH)
                 .send();
     }
@@ -83,6 +116,33 @@ public class HttpRedirectJmhBenchmark {
     private static void invokeRedirectOutputStream(HttpClient<?> client, Blackhole blackhole) {
         for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
             ClientRequest<?> request = client.method(Method.PUT)
+                    .uri(REDIRECT_PATH)
+                    .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
+                    .followRedirects(true);
+            try (HttpClientResponse response = request.outputStream(output -> {
+                output.write(REQUEST_ENTITY);
+                output.close();
+            })) {
+                consume(response, blackhole);
+            }
+        }
+    }
+
+    private static void invokeQueryRedirect(HttpClient<?> client, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            try (HttpClientResponse response = client.method(Method.QUERY)
+                    .uri(REDIRECT_PATH)
+                    .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
+                    .followRedirects(true)
+                    .submit(REQUEST_ENTITY)) {
+                consume(response, blackhole);
+            }
+        }
+    }
+
+    private static void invokeQueryRedirectOutputStream(HttpClient<?> client, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            ClientRequest<?> request = client.method(Method.QUERY)
                     .uri(REDIRECT_PATH)
                     .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
                     .followRedirects(true);

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
@@ -30,7 +30,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
 class HttpRedirectJmhRunnerTest {
-    private static final String METHODS = "(http1PutOutputStreamRedirect|http2PutOutputStreamRedirect)";
+    private static final String METHODS = "(http1PutOutputStreamRedirect|http2PutOutputStreamRedirect"
+            + "|http1QueryEntityRedirect|http2QueryEntityRedirect"
+            + "|http1QueryOutputStreamRedirect|http2QueryOutputStreamRedirect)";
 
     @Test
     void runExactBenchmarks() throws RunnerException {
@@ -43,8 +45,8 @@ class HttpRedirectJmhRunnerTest {
                 .include(include)
                 .threads(1)
                 .forks(Integer.getInteger("http.redirect.jmh.forks", 3))
-                .warmupIterations(Integer.getInteger("http.redirect.jmh.warmupIterations", 3))
-                .measurementIterations(Integer.getInteger("http.redirect.jmh.measurementIterations", 5))
+                .warmupIterations(Integer.getInteger("http.redirect.jmh.warmupIterations", 5))
+                .measurementIterations(Integer.getInteger("http.redirect.jmh.measurementIterations", 30))
                 .mode(Mode.SingleShotTime)
                 .timeUnit(TimeUnit.MICROSECONDS)
                 .addProfiler(GCProfiler.class)

--- a/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/ClientRequestBase.java
@@ -434,6 +434,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     @Api.Internal
     protected final R requestWithoutRouteCleanup() {
         additionalHeaders();
+        validateQueryContentType();
         return validateAndSubmit(BufferData.EMPTY_BYTES);
     }
 
@@ -444,6 +445,9 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
                 rejectHeadWithEntity();
             }
             additionalHeaders();
+            if (entity instanceof byte[]) {
+                validateQueryContentType();
+            }
             return validateAndSubmit(entity);
         } finally {
             clearSelectedProxyRoute();
@@ -455,6 +459,7 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
         try {
             rejectHeadWithEntity();
             additionalHeaders();
+            validateQueryContentType();
             validateRequest();
             return doOutputStream(outputStreamConsumer);
         } finally {
@@ -841,6 +846,12 @@ public abstract class ClientRequestBase<T extends ClientRequest<T>, R extends Ht
     private void rejectHeadWithEntity() {
         if (Method.HEAD.equals(this.method)) {
             throw new IllegalArgumentException("Payload in method '" + Method.HEAD + "' has no defined semantics");
+        }
+    }
+
+    private void validateQueryContentType() {
+        if (Method.QUERY.equals(this.method) && !headers.contains(HeaderNames.CONTENT_TYPE)) {
+            throw new IllegalArgumentException("Content-Type header is required for method '" + Method.QUERY + "'");
         }
     }
 

--- a/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/HttpClientConfigBlueprint.java
@@ -168,7 +168,8 @@ interface HttpClientConfigBlueprint extends HttpConfigBaseBlueprint {
     /**
      * Whether redirects that preserve request method and entity may be followed across origins.
      * <p>
-     * When disabled, {@code 307} and {@code 308} redirects to a different origin fail instead of replaying the request
+     * When disabled, {@code 307} and {@code 308} redirects, and {@code 301} and {@code 302} redirects of a
+     * {@link io.helidon.http.Method#QUERY QUERY} request, to a different origin fail instead of replaying the request
      * entity to the redirect target.
      *
      * @return whether cross-origin redirects may replay request entities

--- a/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
+++ b/webclient/api/src/test/java/io/helidon/webclient/api/ClientRequestBaseTest.java
@@ -93,6 +93,70 @@ class ClientRequestBaseTest {
         assertThat(request.endpointCount(), is(0));
     }
 
+    @Test
+    void rejectsQueriesKnownToLackContentTypeBeforeServices() {
+        AtomicInteger serviceCount = new AtomicInteger();
+        HttpClientConfig config = HttpClientConfig.builder()
+                .addService((chain, request) -> {
+                    serviceCount.incrementAndGet();
+                    return chain.proceed(request);
+                })
+                .build();
+        TestRequest request = new TestRequest(config, Method.QUERY, "http://service.example");
+        TestRequest byteRequest = new TestRequest(config, Method.QUERY, "http://service.example");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           request::request);
+        IllegalArgumentException byteException = assertThrows(IllegalArgumentException.class,
+                                                               () -> byteRequest.submit(new byte[] {1}));
+
+        assertThat(exception.getMessage(), containsString("Content-Type header is required"));
+        assertThat(byteException.getMessage(), containsString("Content-Type header is required"));
+        assertThat(serviceCount.get(), is(0));
+        assertThat(request.endpointCount(), is(0));
+        assertThat(byteRequest.endpointCount(), is(0));
+    }
+
+    @Test
+    void rejectsQueryOutputStreamWithoutContentTypeBeforeServices() {
+        AtomicInteger serviceCount = new AtomicInteger();
+        AtomicInteger handlerCount = new AtomicInteger();
+        HttpClientConfig config = HttpClientConfig.builder()
+                .addService((chain, request) -> {
+                    serviceCount.incrementAndGet();
+                    return chain.proceed(request);
+                })
+                .build();
+        TestRequest request = new TestRequest(config, Method.QUERY, "http://service.example");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> request.outputStream(_ ->
+                                                                   handlerCount.incrementAndGet()));
+
+        assertThat(exception.getMessage(), containsString("Content-Type header is required"));
+        assertThat(handlerCount.get(), is(0));
+        assertThat(serviceCount.get(), is(0));
+        assertThat(request.endpointCount(), is(0));
+    }
+
+    @Test
+    void acceptsQueryContentTypeForEntityApis() {
+        TestRequest submitRequest = new TestRequest(Method.QUERY, "http://service.example");
+        submitRequest.header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN).submit("query");
+        assertThat(submitRequest.endpointCount(), is(1));
+
+        TestRequest streamRequest = new TestRequest(Method.QUERY, "http://service.example");
+        streamRequest.header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN).outputStream(_ -> { });
+        assertThat(streamRequest.endpointCount(), is(1));
+    }
+
+    @Test
+    void customMethodEntityDoesNotRequireContentType() {
+        TestRequest request = new TestRequest(Method.create("CUSTOM"), "http://service.example");
+        request.submit("entity");
+        assertThat(request.endpointCount(), is(1));
+    }
+
     /**
      * Verify that query parameters are preserved when resolving URI templates (cf. issue #8566).
      * Make sure to test both absolute and relative URIs as they are handled differently when resolving.

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -122,10 +122,10 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(responseStatus);
+            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(cos.lastRequest.method(), responseStatus);
             ClientRequest.OutputStreamHandler handler = osHandler;
             if (sendEntity && !cos.lastRequest.canReplayEntityTo(redirectUri)) {
-                // Replaying a 307/308 output-stream body to a new origin can leak credentials or form data.
+                // Replaying a method-preserving output-stream body to a new origin can leak credentials or form data.
                 if (cos.hasEntity()) {
                     connection.closeResource();
                     throw new IllegalStateException("Cross-origin redirect with request entity is disabled.");
@@ -514,7 +514,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (RedirectionProcessor.keepsMethodAndEntity(lastStatus)) {
+            if (RedirectionProcessor.keepsMethodAndEntity(lastRequest.method(), lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -568,7 +568,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     boolean closeRedirectProbeConnection = sendEntity && !sendEmptyEntity;
                     try {
                         checkRedirectHeaders(response.headers());
-                        if (!RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+                        if (!RedirectionProcessor.keepsMethodAndEntity(lastRequest.method(), response.status())) {
                             method = Method.GET;
                             sendEntity = false;
                         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -185,6 +185,10 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
             }
         }
 
+        if (method() == Method.QUERY && !headers().contains(HeaderNames.CONTENT_TYPE)) {
+            throw new IllegalArgumentException("Content-Type header is required for method '" + Method.QUERY + "'");
+        }
+
         if (followRedirects()) {
             return RedirectionProcessor.invokeWithFollowRedirects(this, entityBytes);
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -46,9 +46,14 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1ClientResponse>
         implements Http1ClientRequest {
     private static final System.Logger LOGGER = System.getLogger(Http1ClientRequestImpl.class.getName());
-    // RFC 9110, section 8.1: these define the replayed representation data's format and encoding.
-    private static final Set<HeaderName> REPRESENTATION_HEADERS = Set.of(HeaderNames.CONTENT_TYPE,
-                                                                         HeaderNames.CONTENT_ENCODING);
+    private static final Set<HeaderName> REPLAYABLE_HEADERS = Set.of(HeaderNames.ACCEPT,
+                                                                     HeaderNames.ACCEPT_CHARSET,
+                                                                     HeaderNames.ACCEPT_ENCODING,
+                                                                     HeaderNames.ACCEPT_LANGUAGE,
+                                                                     HeaderNames.CONTENT_ENCODING,
+                                                                     HeaderNames.CONTENT_LANGUAGE,
+                                                                     HeaderNames.CONTENT_LOCATION,
+                                                                     HeaderNames.CONTENT_TYPE);
 
     private final Http1ClientImpl http1Client;
     private final FullClientRequest<?> delegate;
@@ -123,7 +128,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         outputStreamRedirect(request.outputStreamRedirect());
         outputStreamRedirects(request.outputStreamRedirects());
         if (preserveEntity) {
-            REPRESENTATION_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
+            REPLAYABLE_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
         }
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -36,17 +36,20 @@ class RedirectionProcessor {
             && status.family() == Status.Family.REDIRECTION;
     }
 
-    static boolean keepsMethodAndEntity(Status status) {
+    static boolean keepsMethodAndEntity(Method method, Status status) {
         int statusCode = status.code();
         return statusCode == Status.TEMPORARY_REDIRECT_307.code()
-                || statusCode == Status.PERMANENT_REDIRECT_308.code();
+                || statusCode == Status.PERMANENT_REDIRECT_308.code()
+                || (Method.QUERY.equals(method)
+                        && (statusCode == Status.MOVED_PERMANENTLY_301.code()
+                        || statusCode == Status.FOUND_302.code()));
     }
 
     static void validateEntityRedirect(Http1ClientRequestImpl request,
                                        Status status,
                                        ClientUri redirectUri,
                                        byte[] entity) {
-        if (keepsMethodAndEntity(status)
+        if (keepsMethodAndEntity(request.method(), status)
                 && entity.length > 0
                 && !request.canReplayEntityTo(redirectUri)) {
             throw new IllegalStateException("Cross-origin redirect with request entity is disabled.");
@@ -98,9 +101,9 @@ class RedirectionProcessor {
                     redirectUri.host(resolvedUri.host());
                     redirectUri.port(resolvedUri.port());
                 }
-                //Method and entity is required to be the same as with original request with 307 and 308 requests
+                // Method and entity must be retained for 307 and 308, and for QUERY with 301 and 302.
                 validateEntityRedirect(clientRequest, clientResponse.status(), redirectUri, entityToBeSent);
-                if (keepsMethodAndEntity(clientResponse.status())) {
+                if (keepsMethodAndEntity(clientRequest.method(), clientResponse.status())) {
                     clientRequest = new Http1ClientRequestImpl(clientRequest,
                                                                clientRequest.method(),
                                                                redirectUri,

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
@@ -33,8 +33,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class RedirectionProcessorTest {
+    private static final Header TEST_ACCEPT = HeaderValues.createCached(HeaderNames.ACCEPT, "application/json");
     private static final Header TEST_CONTENT_ENCODING = HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,
                                                                                    "test-encoding");
+    private static final Header TEST_CONTENT_LANGUAGE = HeaderValues.createCached(HeaderNames.CONTENT_LANGUAGE, "en");
 
     @Test
     void methodAndEntityPreservationUsesStatusCode() {
@@ -57,10 +59,12 @@ class RedirectionProcessorTest {
     }
 
     @Test
-    void entityPreservingRedirectPreservesContentEncoding() {
+    void entityPreservingRedirectPreservesReplayableHeaders() {
         Http1ClientRequestImpl request = (Http1ClientRequestImpl) Http1Client.create()
                 .put("http://localhost/source")
-                .header(TEST_CONTENT_ENCODING);
+                .header(TEST_ACCEPT)
+                .header(TEST_CONTENT_ENCODING)
+                .header(TEST_CONTENT_LANGUAGE);
 
         Http1ClientRequestImpl redirect = new Http1ClientRequestImpl(request,
                                                                      Method.PUT,
@@ -68,6 +72,8 @@ class RedirectionProcessorTest {
                                                                      Map.of(),
                                                                      true);
 
+        assertThat(redirect.headers(), hasHeader(TEST_ACCEPT));
         assertThat(redirect.headers(), hasHeader(TEST_CONTENT_ENCODING));
+        assertThat(redirect.headers(), hasHeader(TEST_CONTENT_LANGUAGE));
     }
 }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
@@ -38,11 +38,22 @@ class RedirectionProcessorTest {
 
     @Test
     void methodAndEntityPreservationUsesStatusCode() {
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.TEMPORARY_REDIRECT_307), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.PERMANENT_REDIRECT_308), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(307, "Custom")), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(308, "Custom")), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.FOUND_302), is(false));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.create(307, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.create(308, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.FOUND_302), is(false));
+    }
+
+    @Test
+    void queryPreservationUsesStatusCode() {
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.MOVED_PERMANENTLY_301), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.FOUND_302), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.create(301, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.create(302, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.SEE_OTHER_303), is(false));
     }
 
     @Test

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallEntityChain.java
@@ -24,6 +24,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.media.EntityWriter;
 import io.helidon.webclient.api.ClientUri;
@@ -72,7 +73,13 @@ class Http2CallEntityChain extends Http2CallChainBase {
         } else {
             entityBytes = entityBytes(entity, headers);
         }
-        // Keep the serialized request body available for a possible 307/308 replay decision.
+        if (clientRequest().method() == Method.QUERY) {
+            if (!headers.contains(HeaderNames.CONTENT_TYPE)) {
+                throw new IllegalArgumentException("Content-Type header is required for method '" + Method.QUERY + "'");
+            }
+            clientRequest().headers().set(headers.get(HeaderNames.CONTENT_TYPE));
+        }
+        // Keep the serialized request body available for a possible method-preserving redirect decision.
         requestEntity = entityBytes;
 
         if (!clientRequest().outputStreamRedirect()) {
@@ -101,7 +108,7 @@ class Http2CallEntityChain extends Http2CallChainBase {
 
     @Override
     protected WebClientServiceResponse doProceed(WebClientServiceRequest serviceRequest, HttpClientResponse response) {
-        if (RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+        if (RedirectionProcessor.keepsMethodAndEntity(clientRequest().method(), response.status())) {
             // HTTP/1 fallback can receive a redirect before an HTTP/2 stream exists. Do not serialize the body here;
             // redirect policy must be able to reject cross-origin replay before invoking media writers.
             hasRequestEntity = mayHaveEntity(entityHolder.entity());

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -143,10 +143,11 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(responseHeaders.status());
+            boolean sendEntity = RedirectionProcessor.keepsMethodAndEntity(outputStream.lastRequest.method(),
+                                                                           responseHeaders.status());
             ClientRequest.OutputStreamHandler handler = streamHandler;
             if (sendEntity && !outputStream.lastRequest.canReplayEntityTo(redirectUri)) {
-                // Replaying a 307/308 output-stream body to a new origin can leak credentials or form data.
+                // Replaying a method-preserving output-stream body to a new origin can leak credentials or form data.
                 if (outputStream.hasEntity()) {
                     try {
                         outputStream.stream.cancel();
@@ -216,7 +217,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 redirectUri.port(resolvedUri.port());
             }
 
-            if (RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+            if (RedirectionProcessor.keepsMethodAndEntity(clientRequest().method(), response.status())) {
                 method = clientRequest().method();
                 sendEntity = true;
             } else {
@@ -493,7 +494,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (RedirectionProcessor.keepsMethodAndEntity(lastStatus)) {
+            if (RedirectionProcessor.keepsMethodAndEntity(lastRequest.method(), lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -551,7 +552,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                     if (RedirectionProcessor.redirectionStatusCode(response.status())) {
                         try (response) {
                             checkRedirectHeaders(response.headers());
-                            if (!RedirectionProcessor.keepsMethodAndEntity(response.status())) {
+                            if (!RedirectionProcessor.keepsMethodAndEntity(lastRequest.method(), response.status())) {
                                 method = Method.GET;
                                 sendEntity = false;
                             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -300,7 +300,8 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         }
 
         boolean retainRequestEntity = followRedirects()
-                && RedirectionProcessor.keepsMethodAndEntity(serviceResponse.status());
+                && RedirectionProcessor.keepsMethodAndEntity(serviceResponse.serviceRequest().method(),
+                                                             serviceResponse.status());
         boolean hasRequestEntity = retainRequestEntity && callChain.hasRequestEntity();
         Object requestEntity = retainRequestEntity ? callChain.requestEntity() : null;
         long maxBufferedEntitySize = http2Client.protocolConfig().maxBufferedEntitySize().toBytes();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -37,9 +37,14 @@ import io.helidon.webclient.http1.Http1Client;
 
 class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2ClientResponse>
         implements Http2ClientRequest, Http2StreamConfig, FullClientRequest<Http2ClientRequest> {
-    // RFC 9110, section 8.1: these define the replayed representation data's format and encoding.
-    private static final Set<HeaderName> REPRESENTATION_HEADERS = Set.of(HeaderNames.CONTENT_TYPE,
-                                                                         HeaderNames.CONTENT_ENCODING);
+    private static final Set<HeaderName> REPLAYABLE_HEADERS = Set.of(HeaderNames.ACCEPT,
+                                                                     HeaderNames.ACCEPT_CHARSET,
+                                                                     HeaderNames.ACCEPT_ENCODING,
+                                                                     HeaderNames.ACCEPT_LANGUAGE,
+                                                                     HeaderNames.CONTENT_ENCODING,
+                                                                     HeaderNames.CONTENT_LANGUAGE,
+                                                                     HeaderNames.CONTENT_LOCATION,
+                                                                     HeaderNames.CONTENT_TYPE);
 
     private final Http2ClientImpl http2Client;
     private int priority = 16;
@@ -125,7 +130,7 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         request.sendExpectContinue().ifPresent(this::sendExpectContinue);
         this.outputStreamRedirect(request.outputStreamRedirect);
         if (preserveEntity) {
-            REPRESENTATION_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
+            REPLAYABLE_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
         }
     }
 
@@ -324,4 +329,5 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         return response;
 
     }
+
 }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
@@ -37,17 +37,20 @@ class RedirectionProcessor {
                 && status.family() == Status.Family.REDIRECTION;
     }
 
-    static boolean keepsMethodAndEntity(Status status) {
+    static boolean keepsMethodAndEntity(Method method, Status status) {
         int statusCode = status.code();
         return statusCode == Status.TEMPORARY_REDIRECT_307.code()
-                || statusCode == Status.PERMANENT_REDIRECT_308.code();
+                || statusCode == Status.PERMANENT_REDIRECT_308.code()
+                || (Method.QUERY.equals(method)
+                        && (statusCode == Status.MOVED_PERMANENTLY_301.code()
+                        || statusCode == Status.FOUND_302.code()));
     }
 
     static void validateEntityRedirect(Http2ClientRequestImpl request,
                                        Status status,
                                        ClientUri redirectUri,
                                        boolean hasEntity) {
-        if (keepsMethodAndEntity(status)
+        if (keepsMethodAndEntity(request.method(), status)
                 && hasEntity
                 && !request.canReplayEntityTo(redirectUri)) {
             throw new IllegalStateException("Cross-origin redirect with request entity is disabled.");
@@ -112,9 +115,9 @@ class RedirectionProcessor {
                 redirectUri.host(resolvedUri.host());
                 redirectUri.port(resolvedUri.port());
             }
-            //Method and entity is required to be the same as with original request with 307 and 308 requests
+            // Method and entity must be retained for 307 and 308, and for QUERY with 301 and 302.
             validateEntityRedirect(clientRequest, clientResponse.status(), redirectUri, clientResponse.hasRequestEntity());
-            if (keepsMethodAndEntity(clientResponse.status())) {
+            if (keepsMethodAndEntity(clientRequest.method(), clientResponse.status())) {
                 Object requestEntity = clientResponse.requestEntity();
                 if (requestEntity != null) {
                     entityToBeSent = requestEntity;

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
@@ -33,8 +33,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class RedirectionProcessorTest {
+    private static final Header TEST_ACCEPT = HeaderValues.createCached(HeaderNames.ACCEPT, "application/json");
     private static final Header TEST_CONTENT_ENCODING = HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,
                                                                                    "test-encoding");
+    private static final Header TEST_CONTENT_LANGUAGE = HeaderValues.createCached(HeaderNames.CONTENT_LANGUAGE, "en");
 
     @Test
     void methodAndEntityPreservationUsesStatusCode() {
@@ -62,10 +64,12 @@ class RedirectionProcessorTest {
     }
 
     @Test
-    void entityPreservingRedirectPreservesContentEncoding() {
+    void entityPreservingRedirectPreservesReplayableHeaders() {
         Http2ClientRequestImpl request = (Http2ClientRequestImpl) Http2Client.create()
                 .put("http://localhost/source")
-                .header(TEST_CONTENT_ENCODING);
+                .header(TEST_ACCEPT)
+                .header(TEST_CONTENT_ENCODING)
+                .header(TEST_CONTENT_LANGUAGE);
 
         Http2ClientRequestImpl redirect = new Http2ClientRequestImpl(request,
                                                                      Method.PUT,
@@ -73,6 +77,8 @@ class RedirectionProcessorTest {
                                                                      Map.of(),
                                                                      true);
 
+        assertThat(redirect.headers(), hasHeader(TEST_ACCEPT));
         assertThat(redirect.headers(), hasHeader(TEST_CONTENT_ENCODING));
+        assertThat(redirect.headers(), hasHeader(TEST_CONTENT_LANGUAGE));
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
@@ -38,11 +38,22 @@ class RedirectionProcessorTest {
 
     @Test
     void methodAndEntityPreservationUsesStatusCode() {
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.TEMPORARY_REDIRECT_307), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.PERMANENT_REDIRECT_308), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(307, "Custom")), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(308, "Custom")), is(true));
-        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.FOUND_302), is(false));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.create(307, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.create(308, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.PUT, Status.FOUND_302), is(false));
+    }
+
+    @Test
+    void queryPreservationUsesStatusCode() {
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.MOVED_PERMANENTLY_301), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.FOUND_302), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.create(301, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.create(302, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Method.QUERY, Status.SEE_OTHER_303), is(false));
     }
 
     @Test

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -83,8 +83,10 @@ class Http1ClientTest {
     private static final HeaderName REQ_CONTENT_LENGTH_HEADER_NAME = HeaderNames.create("X-Req-ContentLength");
     private static final HeaderName ENTITY_METADATA_HEADER = HeaderNames.create("X-Entity-Metadata");
     private static final String EXPECTED_GET_AFTER_REDIRECT_STRING = "GET after redirect endpoint reached";
+    private static final String QUERY_ACCEPT = "application/json";
     private static final String QUERY_CONTENT_TYPE = "application/sql";
     private static final String QUERY_ENTITY = "select * from example";
+    private static final String QUERY_LANGUAGE = "en";
     private static final long NO_CONTENT_LENGTH = -1L;
 
     private final String baseURI;
@@ -114,7 +116,14 @@ class Http1ClientTest {
         rules.route(Method.QUERY,
                     "/queryRedirect303",
                     (_, res) -> queryRedirect(res, Status.SEE_OTHER_303, "/queryRedirectGetTarget"));
+        rules.route(Method.QUERY,
+                    "/queryRedirectHeaders301",
+                    (_, res) -> queryRedirect(res, Status.MOVED_PERMANENTLY_301, "/queryRedirectHeadersTarget"));
+        rules.route(Method.QUERY,
+                    "/queryRedirectHeaders302",
+                    (_, res) -> queryRedirect(res, Status.FOUND_302, "/queryRedirectHeadersTarget"));
         rules.route(Method.QUERY, "/queryRedirectTarget", Http1ClientTest::queryRedirectTarget);
+        rules.route(Method.QUERY, "/queryRedirectHeadersTarget", Http1ClientTest::queryRedirectHeadersTarget);
         rules.get("/queryRedirectGetTarget", Http1ClientTest::queryRedirectGetTarget);
         rules.get("/redirectDropEntity", Http1ClientTest::redirectDropEntity);
         rules.get("/afterDropEntity", Http1ClientTest::afterDropEntity);
@@ -472,6 +481,21 @@ class Http1ClientTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302})
+    void queryRedirectPreservesRequestHeaders(int redirectStatus) {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/queryRedirectHeaders" + redirectStatus)
+                .header(HeaderNames.ACCEPT, QUERY_ACCEPT)
+                .header(HeaderNames.CONTENT_LANGUAGE, QUERY_LANGUAGE)
+                .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                .submit(QUERY_ENTITY)) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class),
+                       is(Method.QUERY + ":" + QUERY_ACCEPT + ":" + QUERY_LANGUAGE + ":" + QUERY_ENTITY));
+        }
+    }
+
     @Test
     void querySubmitUsesMediaWriterContentType() {
         try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
@@ -625,6 +649,15 @@ class Http1ClientTest {
     private static void queryRedirectTarget(ServerRequest request, ServerResponse response) {
         String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
         response.send(request.prologue().method() + ":" + contentType + ":" + request.content().as(String.class));
+    }
+
+    private static void queryRedirectHeadersTarget(ServerRequest request, ServerResponse response) {
+        String accept = request.headers().get(HeaderNames.ACCEPT).get();
+        String contentLanguage = request.headers().get(HeaderNames.CONTENT_LANGUAGE).get();
+        response.send(request.prologue().method()
+                              + ":" + accept
+                              + ":" + contentLanguage
+                              + ":" + request.content().as(String.class));
     }
 
     private static void queryRedirectGetTarget(ServerRequest request, ServerResponse response) {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.GenericType;
 import io.helidon.http.Header;
@@ -55,6 +56,8 @@ import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.noHeader;
@@ -80,6 +83,8 @@ class Http1ClientTest {
     private static final HeaderName REQ_CONTENT_LENGTH_HEADER_NAME = HeaderNames.create("X-Req-ContentLength");
     private static final HeaderName ENTITY_METADATA_HEADER = HeaderNames.create("X-Entity-Metadata");
     private static final String EXPECTED_GET_AFTER_REDIRECT_STRING = "GET after redirect endpoint reached";
+    private static final String QUERY_CONTENT_TYPE = "application/sql";
+    private static final String QUERY_ENTITY = "select * from example";
     private static final long NO_CONTENT_LENGTH = -1L;
 
     private final String baseURI;
@@ -100,6 +105,17 @@ class Http1ClientTest {
         rules.put("/redirectChainSecond", Http1ClientTest::redirectChainSecond);
         rules.put("/redirectChainFinal", Http1ClientTest::redirectChainFinal);
         rules.put("/redirect", Http1ClientTest::redirect);
+        rules.route(Method.QUERY,
+                    "/queryRedirect301",
+                    (_, res) -> queryRedirect(res, Status.MOVED_PERMANENTLY_301, "/queryRedirectTarget"));
+        rules.route(Method.QUERY,
+                    "/queryRedirect302",
+                    (_, res) -> queryRedirect(res, Status.FOUND_302, "/queryRedirectTarget"));
+        rules.route(Method.QUERY,
+                    "/queryRedirect303",
+                    (_, res) -> queryRedirect(res, Status.SEE_OTHER_303, "/queryRedirectGetTarget"));
+        rules.route(Method.QUERY, "/queryRedirectTarget", Http1ClientTest::queryRedirectTarget);
+        rules.get("/queryRedirectGetTarget", Http1ClientTest::queryRedirectGetTarget);
         rules.get("/redirectDropEntity", Http1ClientTest::redirectDropEntity);
         rules.get("/afterDropEntity", Http1ClientTest::afterDropEntity);
         rules.get("/afterRedirect", Http1ClientTest::afterRedirectGet);
@@ -444,6 +460,92 @@ class Http1ClientTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302})
+    void queryRedirectPreservesBufferedEntity(int redirectStatus) {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/queryRedirect" + redirectStatus)
+                .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                .submit(QUERY_ENTITY)) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(Method.QUERY + ":" + QUERY_CONTENT_TYPE + ":" + QUERY_ENTITY));
+        }
+    }
+
+    @Test
+    void querySubmitUsesMediaWriterContentType() {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/queryRedirectTarget")
+                .submit(QUERY_ENTITY)) {
+            String result = response.as(String.class);
+            assertThat(result, startsWith(Method.QUERY + ":text/plain"));
+            assertThat(result, containsString(":" + QUERY_ENTITY));
+        }
+    }
+
+    @Test
+    void querySubmitRejectsMissingContentType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> injectedHttp1client.method(Method.QUERY)
+                                                                   .uri("/queryRedirectTarget")
+                                                                   .submit(QUERY_ENTITY.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(exception.getMessage(), containsString("Content-Type header is required"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302})
+    void queryRedirectPreservesOutputStreamEntity(int redirectStatus) {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/queryRedirect" + redirectStatus)
+                .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                .outputStream(output -> {
+                    output.write(QUERY_ENTITY.getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(Method.QUERY + ":" + QUERY_CONTENT_TYPE + ":" + QUERY_ENTITY));
+        }
+    }
+
+    @Test
+    void querySeeOtherRedirectChangesToGetAndDropsEntity() {
+        try (HttpClientResponse response = injectedHttp1client.method(Method.QUERY)
+                .uri("/queryRedirect303")
+                .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                .submit(QUERY_ENTITY)) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("GET without entity metadata"));
+        }
+    }
+
+    @Test
+    void queryRedirectCompletesEveryServiceRequest() {
+        AtomicInteger requests = new AtomicInteger();
+        AtomicInteger completions = new AtomicInteger();
+        Http1Client client = Http1Client.builder()
+                .baseUri(baseURI)
+                .servicesDiscoverServices(false)
+                .addService((chain, request) -> {
+                    requests.incrementAndGet();
+                    request.whenComplete().thenRun(completions::incrementAndGet);
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            HttpClientResponse response = client.method(Method.QUERY)
+                    .uri("/queryRedirect302")
+                    .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                    .submit(QUERY_ENTITY);
+            assertThat(requests.get(), is(2));
+            assertThat(completions.get(), is(1));
+            response.close();
+            assertThat(completions.get(), is(2));
+        } finally {
+            client.closeResource();
+        }
+    }
+
     @Test
     void testReadTimeoutPerRequest() {
         String testEntity = "Test entity";
@@ -512,6 +614,25 @@ class Http1ClientTest {
         res.status(Status.FOUND_302)
                 .header(HeaderNames.LOCATION, "/afterRedirect")
                 .send();
+    }
+
+    private static void queryRedirect(ServerResponse response, Status status, String target) {
+        response.status(status)
+                .header(HeaderNames.LOCATION, target)
+                .send();
+    }
+
+    private static void queryRedirectTarget(ServerRequest request, ServerResponse response) {
+        String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
+        response.send(request.prologue().method() + ":" + contentType + ":" + request.content().as(String.class));
+    }
+
+    private static void queryRedirectGetTarget(ServerRequest request, ServerResponse response) {
+        if (request.content().hasEntity() || request.headers().contains(HeaderNames.CONTENT_TYPE)) {
+            response.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
+            return;
+        }
+        response.send("GET without entity metadata");
     }
 
     private static void redirectKeepMethod(ServerRequest req, ServerResponse res) {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/Http1CrossOriginRedirectEntityTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/Http1CrossOriginRedirectEntityTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.WebClientServiceRequest;
 import io.helidon.webclient.api.WebClientServiceResponse;
@@ -89,6 +90,66 @@ class Http1CrossOriginRedirectEntityTest {
                 assertThat(originRequest.path(), is("/token"));
                 assertThat(originRequest.body(), is(REQUEST_BODY));
                 secondHop.assertNoRequest();
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302})
+    @Timeout(20)
+    void doesNotReplayBufferedQueryAcrossCrossOriginRedirect(int redirectStatus) throws Exception {
+        try (SecondHopServer secondHop = new SecondHopServer(InetAddress.getByName(SECOND_HOP_HOST));
+             FirstHopServer firstHop = new FirstHopServer(InetAddress.getByName(FIRST_HOP_HOST),
+                                                          secondHop.port(),
+                                                          true,
+                                                          redirectStatus)) {
+            Http1Client client = newClient(firstHop.port());
+            try {
+                IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                               () -> client.method(Method.QUERY)
+                                                                       .uri("/token")
+                                                                       .readTimeout(REQUEST_TIMEOUT)
+                                                                       .header(HeaderNames.CONTENT_TYPE,
+                                                                               "application/x-www-form-urlencoded")
+                                                                       .submit(requestBodyBytes()));
+                assertThat(exception.getMessage(), is(BLOCKED_REDIRECT_MESSAGE));
+
+                CapturedRequest originRequest = firstHop.awaitRequest();
+                assertThat(originRequest.method(), is(Method.QUERY.text()));
+                assertThat(originRequest.body(), is(REQUEST_BODY));
+                secondHop.assertNoRequest();
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302})
+    @Timeout(20)
+    void followsCrossOriginQueryWithEntityWhenEnabled(int redirectStatus) throws Exception {
+        try (SecondHopServer secondHop = new SecondHopServer(InetAddress.getByName(SECOND_HOP_HOST));
+             FirstHopServer firstHop = new FirstHopServer(InetAddress.getByName(FIRST_HOP_HOST),
+                                                          secondHop.port(),
+                                                          true,
+                                                          redirectStatus)) {
+            Http1Client client = newClient(firstHop.port(), true);
+            try {
+                try (Http1ClientResponse response = client.method(Method.QUERY)
+                        .uri("/token")
+                        .readTimeout(REQUEST_TIMEOUT)
+                        .header(HeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                        .submit(requestBodyBytes())) {
+                    assertThat(response.status().code(), is(200));
+                }
+
+                CapturedRequest redirectRequest = secondHop.awaitRequest();
+                assertThat(redirectRequest.method(), is(Method.QUERY.text()));
+                assertThat(redirectRequest.header("authorization"), is((String) null));
+                assertThat(redirectRequest.header("content-type"), is("application/x-www-form-urlencoded"));
+                assertThat(redirectRequest.body(), is(REQUEST_BODY));
             } finally {
                 client.closeResource();
             }
@@ -713,6 +774,7 @@ class Http1CrossOriginRedirectEntityTest {
 
     private static String redirectReasonPhrase(int status) {
         return switch (status) {
+            case 301 -> "Moved Permanently";
             case 302 -> "Found";
             case 307 -> "Temporary Redirect";
             case 308 -> "Permanent Redirect";
@@ -1070,6 +1132,11 @@ class Http1CrossOriginRedirectEntityTest {
         private String path() {
             String[] parts = requestLine.split(" ");
             return parts.length > 1 ? parts[1] : requestLine;
+        }
+
+        private String method() {
+            String[] parts = requestLine.split(" ");
+            return parts.length > 0 ? parts[0] : requestLine;
         }
 
         private String header(String name) {

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
@@ -24,6 +24,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,7 @@ import io.helidon.common.GenericType;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.media.EntityReader;
@@ -76,6 +78,8 @@ class CrossOriginRedirectHeaderTest {
     private static final AtomicReference<CapturedHeaders> CROSS_ORIGIN_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<String> CROSS_ORIGIN_BODY_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<String> CROSS_ORIGIN_PROTOCOL_CAPTURE = new AtomicReference<>();
+    private static final AtomicReference<Method> CROSS_ORIGIN_METHOD_CAPTURE = new AtomicReference<>();
+    private static final AtomicReference<String> CROSS_ORIGIN_CONTENT_TYPE_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<Boolean> CROSS_ORIGIN_EXPECT_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<String> CROSS_ORIGIN_AUTHORITY_CAPTURE = new AtomicReference<>();
 
@@ -97,6 +101,17 @@ class CrossOriginRedirectHeaderTest {
                     CROSS_ORIGIN_PROTOCOL_CAPTURE.set(req.prologue().protocolVersion());
                     CROSS_ORIGIN_EXPECT_CAPTURE.set(req.headers().contains(HeaderNames.EXPECT));
                     CROSS_ORIGIN_AUTHORITY_CAPTURE.set(req.requestedUri().authority());
+                    try (InputStream inputStream = req.content().inputStream()) {
+                        CROSS_ORIGIN_BODY_CAPTURE.set(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+                        res.send("captured");
+                    } catch (Exception e) {
+                        res.status(Status.INTERNAL_SERVER_ERROR_500)
+                                .send(e.getMessage());
+                    }
+                }).route(Method.QUERY, "/capture-query", (req, res) -> {
+                    CROSS_ORIGIN_CAPTURE.set(capturedHeaders(req));
+                    CROSS_ORIGIN_METHOD_CAPTURE.set(req.prologue().method());
+                    CROSS_ORIGIN_CONTENT_TYPE_CAPTURE.set(req.headers().get(HeaderNames.CONTENT_TYPE).get());
                     try (InputStream inputStream = req.content().inputStream()) {
                         CROSS_ORIGIN_BODY_CAPTURE.set(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
                         res.send("captured");
@@ -152,6 +167,18 @@ class CrossOriginRedirectHeaderTest {
                                             "http://localhost:" + redirectTargetServer.port() + "/capture-body")
                                     .send();
                         })
+                        .route(Method.QUERY, "/redirect/cross-origin-query-301", (req, res) -> {
+                            res.status(Status.MOVED_PERMANENTLY_301)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/capture-query")
+                                    .send();
+                        })
+                        .route(Method.QUERY, "/redirect/cross-origin-query-302", (req, res) -> {
+                            res.status(Status.FOUND_302)
+                                    .header(HeaderNames.LOCATION,
+                                            "http://localhost:" + redirectTargetServer.port() + "/capture-query")
+                                    .send();
+                        })
                         .get("/capture", (req, res) -> {
                             SAME_ORIGIN_CAPTURE.set(capturedHeaders(req));
                             res.send("captured");
@@ -176,6 +203,8 @@ class CrossOriginRedirectHeaderTest {
         CROSS_ORIGIN_CAPTURE.set(null);
         CROSS_ORIGIN_BODY_CAPTURE.set(null);
         CROSS_ORIGIN_PROTOCOL_CAPTURE.set(null);
+        CROSS_ORIGIN_METHOD_CAPTURE.set(null);
+        CROSS_ORIGIN_CONTENT_TYPE_CAPTURE.set(null);
         CROSS_ORIGIN_EXPECT_CAPTURE.set(null);
         CROSS_ORIGIN_AUTHORITY_CAPTURE.set(null);
     }
@@ -255,6 +284,53 @@ class CrossOriginRedirectHeaderTest {
     @Test
     void rejectsBufferedEntityOnCrossOrigin308Redirect() {
         rejectBufferedEntityOnCrossOriginRedirect("/redirect/cross-origin-keep-method-308");
+    }
+
+    @Test
+    void rejectsBufferedQueryOnCrossOriginRedirect() {
+        for (String redirectPath : List.of("/redirect/cross-origin-query-301", "/redirect/cross-origin-query-302")) {
+            resetCapturedHeaders();
+            Http2Client client = newClient(true, true);
+            try {
+                IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                               () -> client.method(Method.QUERY)
+                                                                       .uri(redirectPath)
+                                                                       .header(HeaderNames.CONTENT_TYPE, "application/sql")
+                                                                       .submit(requestBodyBytes()));
+                assertThat(exception.getMessage(), is(BLOCKED_REDIRECT_MESSAGE));
+                assertThat(CROSS_ORIGIN_CAPTURE.get(), is(nullValue()));
+                assertThat(CROSS_ORIGIN_BODY_CAPTURE.get(), is(nullValue()));
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    @Test
+    void followsCrossOriginQueryWithEntityWhenEnabled() {
+        for (String redirectPath : List.of("/redirect/cross-origin-query-301", "/redirect/cross-origin-query-302")) {
+            resetCapturedHeaders();
+            Http2Client client = newClient(true, true, true);
+            try {
+                try (Http2ClientResponse response = client.method(Method.QUERY)
+                        .uri(redirectPath)
+                        .header(HeaderNames.CONTENT_TYPE, "application/sql")
+                        .submit(requestBodyBytes())) {
+                    assertThat(response.status(), is(Status.OK_200));
+                }
+
+                CapturedHeaders captured = CROSS_ORIGIN_CAPTURE.get();
+                assertThat(captured, is(notNullValue()));
+                assertThat(captured.authorization(), is(nullValue()));
+                assertThat(captured.proxyAuthorization(), is(nullValue()));
+                assertThat(captured.apiKey(), is(nullValue()));
+                assertThat(CROSS_ORIGIN_METHOD_CAPTURE.get(), is(Method.QUERY));
+                assertThat(CROSS_ORIGIN_CONTENT_TYPE_CAPTURE.get(), is("application/sql"));
+                assertThat(CROSS_ORIGIN_BODY_CAPTURE.get(), is(REQUEST_BODY));
+            } finally {
+                client.closeResource();
+            }
+        }
     }
 
     @Test

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -55,8 +55,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class FollowRedirectTest {
     private static final StringBuilder BUFFER = new StringBuilder();
     private static final String PATH_COOKIE = "pathOnly=redirect-secret";
+    private static final String QUERY_ACCEPT = "application/json";
     private static final String QUERY_CONTENT_TYPE = "application/sql";
     private static final String QUERY_ENTITY = "select * from example";
+    private static final String QUERY_LANGUAGE = "en";
     private static final HeaderName REDIRECT_HEADER = HeaderNames.create("X-Redirect-Test");
     private static final AtomicReference<String> REDIRECT_SOURCE_COOKIE = new AtomicReference<>();
     private static final AtomicReference<String> REDIRECT_TARGET_COOKIE = new AtomicReference<>();
@@ -82,7 +84,14 @@ class FollowRedirectTest {
                 .route(Method.QUERY,
                        "/queryRedirect303",
                        (_, res) -> queryRedirect(res, Status.SEE_OTHER_303, "/queryRedirectGetTarget"))
+                .route(Method.QUERY,
+                       "/queryRedirectHeaders301",
+                       (_, res) -> queryRedirect(res, Status.MOVED_PERMANENTLY_301, "/queryRedirectHeadersTarget"))
+                .route(Method.QUERY,
+                       "/queryRedirectHeaders302",
+                       (_, res) -> queryRedirect(res, Status.FOUND_302, "/queryRedirectHeadersTarget"))
                 .route(Method.QUERY, "/queryRedirectTarget", FollowRedirectTest::queryRedirectTarget)
+                .route(Method.QUERY, "/queryRedirectHeadersTarget", FollowRedirectTest::queryRedirectHeadersTarget)
                 .get("/queryRedirectGetTarget", FollowRedirectTest::queryRedirectGetTarget)
                 .route(Method.PUT, "/infiniteRedirect", (req, res) -> {
             res.status(Status.TEMPORARY_REDIRECT_307)
@@ -270,6 +279,22 @@ class FollowRedirectTest {
     }
 
     @Test
+    void queryRedirectPreservesRequestHeaders() {
+        for (int redirectStatus : new int[] {301, 302}) {
+            try (Http2ClientResponse response = webClient.method(Method.QUERY)
+                    .uri("/queryRedirectHeaders" + redirectStatus)
+                    .header(HeaderNames.ACCEPT, QUERY_ACCEPT)
+                    .header(HeaderNames.CONTENT_LANGUAGE, QUERY_LANGUAGE)
+                    .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                    .submit(QUERY_ENTITY)) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class),
+                           is(Method.QUERY + ":" + QUERY_ACCEPT + ":" + QUERY_LANGUAGE + ":" + QUERY_ENTITY));
+            }
+        }
+    }
+
+    @Test
     void querySubmitUsesMediaWriterContentType() {
         try (Http2ClientResponse response = webClient.method(Method.QUERY)
                 .uri("/queryRedirectTarget")
@@ -424,52 +449,6 @@ class FollowRedirectTest {
         assertEntityOutputStreamWithRedirectAfter();
     }
 
-    private void assertEmptyOutputStreamWithRedirectAfter() {
-        String expected = "Upload completed!";
-        try (Http2ClientResponse response = webClient.put()
-                .path("/redirectAfterUpload")
-                .outputStream(OutputStream::close)) {
-            assertThat(response.entity().as(String.class), is(expected));
-        }
-    }
-
-    private void assertEntityOutputStreamWithRedirectAfter() {
-        String expected = """
-                Upload completed!
-                0123456789
-                0123456789
-                0123456789""";
-        try (Http2ClientResponse response = webClient.put()
-                .path("/redirectAfterUpload")
-                .outputStream(it -> {
-                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
-                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
-                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
-                    it.close();
-                })) {
-            assertThat(response.entity().as(String.class), is(expected));
-        }
-    }
-
-    private static void queryRedirect(ServerResponse response, Status status, String target) {
-        response.status(status)
-                .header(HeaderNames.LOCATION, target)
-                .send();
-    }
-
-    private static void queryRedirectTarget(ServerRequest request, ServerResponse response) {
-        String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
-        response.send(request.prologue().method() + ":" + contentType + ":" + request.content().as(String.class));
-    }
-
-    private static void queryRedirectGetTarget(ServerRequest request, ServerResponse response) {
-        if (request.content().hasEntity() || request.headers().contains(HeaderNames.CONTENT_TYPE)) {
-            response.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
-            return;
-        }
-        response.send("GET without entity metadata");
-    }
-
     @Test
     void testOutputStreamEntityNotKeptIntercepted() {
         String expected = "GET plain endpoint reached";
@@ -513,6 +492,61 @@ class FollowRedirectTest {
                 }, String.class);
 
         assertThat(http2ClientResponse.entity(), is("Request did not timeout"));
+    }
+
+    private static void queryRedirect(ServerResponse response, Status status, String target) {
+        response.status(status)
+                .header(HeaderNames.LOCATION, target)
+                .send();
+    }
+
+    private static void queryRedirectTarget(ServerRequest request, ServerResponse response) {
+        String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
+        response.send(request.prologue().method() + ":" + contentType + ":" + request.content().as(String.class));
+    }
+
+    private static void queryRedirectHeadersTarget(ServerRequest request, ServerResponse response) {
+        String accept = request.headers().get(HeaderNames.ACCEPT).get();
+        String contentLanguage = request.headers().get(HeaderNames.CONTENT_LANGUAGE).get();
+        response.send(request.prologue().method()
+                              + ":" + accept
+                              + ":" + contentLanguage
+                              + ":" + request.content().as(String.class));
+    }
+
+    private static void queryRedirectGetTarget(ServerRequest request, ServerResponse response) {
+        if (request.content().hasEntity() || request.headers().contains(HeaderNames.CONTENT_TYPE)) {
+            response.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
+            return;
+        }
+        response.send("GET without entity metadata");
+    }
+
+    private void assertEmptyOutputStreamWithRedirectAfter() {
+        String expected = "Upload completed!";
+        try (Http2ClientResponse response = webClient.put()
+                .path("/redirectAfterUpload")
+                .outputStream(OutputStream::close)) {
+            assertThat(response.entity().as(String.class), is(expected));
+        }
+    }
+
+    private void assertEntityOutputStreamWithRedirectAfter() {
+        String expected = """
+                Upload completed!
+                0123456789
+                0123456789
+                0123456789""";
+        try (Http2ClientResponse response = webClient.put()
+                .path("/redirectAfterUpload")
+                .outputStream(it -> {
+                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.write("0123456789".getBytes(StandardCharsets.UTF_8));
+                    it.close();
+                })) {
+            assertThat(response.entity().as(String.class), is(expected));
+        }
     }
 
 }

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.http.HeaderName;
@@ -35,6 +36,8 @@ import io.helidon.webclient.api.WebClientCookieManager;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientResponse;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
 
@@ -52,12 +55,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class FollowRedirectTest {
     private static final StringBuilder BUFFER = new StringBuilder();
     private static final String PATH_COOKIE = "pathOnly=redirect-secret";
+    private static final String QUERY_CONTENT_TYPE = "application/sql";
+    private static final String QUERY_ENTITY = "select * from example";
     private static final HeaderName REDIRECT_HEADER = HeaderNames.create("X-Redirect-Test");
     private static final AtomicReference<String> REDIRECT_SOURCE_COOKIE = new AtomicReference<>();
     private static final AtomicReference<String> REDIRECT_TARGET_COOKIE = new AtomicReference<>();
+    private final URI baseUri;
     private final Http2Client webClient;
 
     FollowRedirectTest(URI uri) {
+        this.baseUri = uri;
         this.webClient = Http2Client.builder()
                 .baseUri(uri)
                 .cookieManager(WebClientCookieManager.builder().automaticStoreEnabled(true).build())
@@ -66,7 +73,18 @@ class FollowRedirectTest {
 
     @SetUpRoute
     static void router(HttpRouting.Builder router) {
-        router.route(Method.PUT, "/infiniteRedirect", (req, res) -> {
+        router.route(Method.QUERY,
+                     "/queryRedirect301",
+                     (_, res) -> queryRedirect(res, Status.MOVED_PERMANENTLY_301, "/queryRedirectTarget"))
+                .route(Method.QUERY,
+                       "/queryRedirect302",
+                       (_, res) -> queryRedirect(res, Status.FOUND_302, "/queryRedirectTarget"))
+                .route(Method.QUERY,
+                       "/queryRedirect303",
+                       (_, res) -> queryRedirect(res, Status.SEE_OTHER_303, "/queryRedirectGetTarget"))
+                .route(Method.QUERY, "/queryRedirectTarget", FollowRedirectTest::queryRedirectTarget)
+                .get("/queryRedirectGetTarget", FollowRedirectTest::queryRedirectGetTarget)
+                .route(Method.PUT, "/infiniteRedirect", (req, res) -> {
             res.status(Status.TEMPORARY_REDIRECT_307)
                     .header(HeaderNames.LOCATION, "/infiniteRedirect2")
                     .send();
@@ -239,6 +257,94 @@ class FollowRedirectTest {
     }
 
     @Test
+    void queryRedirectPreservesBufferedEntity() {
+        for (int redirectStatus : new int[] {301, 302}) {
+            try (Http2ClientResponse response = webClient.method(Method.QUERY)
+                    .uri("/queryRedirect" + redirectStatus)
+                    .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                    .submit(QUERY_ENTITY)) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(Method.QUERY + ":" + QUERY_CONTENT_TYPE + ":" + QUERY_ENTITY));
+            }
+        }
+    }
+
+    @Test
+    void querySubmitUsesMediaWriterContentType() {
+        try (Http2ClientResponse response = webClient.method(Method.QUERY)
+                .uri("/queryRedirectTarget")
+                .submit(QUERY_ENTITY)) {
+            String result = response.as(String.class);
+            assertThat(result, containsString(Method.QUERY + ":text/plain"));
+            assertThat(result, containsString(":" + QUERY_ENTITY));
+        }
+    }
+
+    @Test
+    void querySubmitRejectsMissingContentType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> webClient.method(Method.QUERY)
+                                                                   .uri("/queryRedirectTarget")
+                                                                   .submit(QUERY_ENTITY.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(exception.getMessage(), containsString("Content-Type header is required"));
+    }
+
+    @Test
+    void queryRedirectPreservesOutputStreamEntity() {
+        for (int redirectStatus : new int[] {301, 302}) {
+            try (Http2ClientResponse response = webClient.method(Method.QUERY)
+                    .uri("/queryRedirect" + redirectStatus)
+                    .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                    .outputStream(output -> {
+                        output.write(QUERY_ENTITY.getBytes(StandardCharsets.UTF_8));
+                        output.close();
+                    })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.as(String.class), is(Method.QUERY + ":" + QUERY_CONTENT_TYPE + ":" + QUERY_ENTITY));
+            }
+        }
+    }
+
+    @Test
+    void querySeeOtherRedirectChangesToGetAndDropsEntity() {
+        try (Http2ClientResponse response = webClient.method(Method.QUERY)
+                .uri("/queryRedirect303")
+                .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                .submit(QUERY_ENTITY)) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("GET without entity metadata"));
+        }
+    }
+
+    @Test
+    void queryRedirectCompletesEveryServiceRequest() {
+        AtomicInteger requests = new AtomicInteger();
+        AtomicInteger completions = new AtomicInteger();
+        Http2Client client = Http2Client.builder()
+                .baseUri(baseUri)
+                .servicesDiscoverServices(false)
+                .addService((chain, request) -> {
+                    requests.incrementAndGet();
+                    request.whenComplete().thenRun(completions::incrementAndGet);
+                    return chain.proceed(request);
+                })
+                .build();
+        try {
+            Http2ClientResponse response = client.method(Method.QUERY)
+                    .uri("/queryRedirect302")
+                    .header(HeaderNames.CONTENT_TYPE, QUERY_CONTENT_TYPE)
+                    .submit(QUERY_ENTITY);
+            assertThat(requests.get(), is(2));
+            assertThat(completions.get(), is(1));
+            response.close();
+            assertThat(completions.get(), is(2));
+        } finally {
+            client.closeResource();
+        }
+    }
+
+    @Test
     void testReadTimeoutPreservedAcrossMixedRedirects() {
         String expected = "GET delayed endpoint reached";
         try (Http2ClientResponse response = webClient.put()
@@ -343,6 +449,25 @@ class FollowRedirectTest {
                 })) {
             assertThat(response.entity().as(String.class), is(expected));
         }
+    }
+
+    private static void queryRedirect(ServerResponse response, Status status, String target) {
+        response.status(status)
+                .header(HeaderNames.LOCATION, target)
+                .send();
+    }
+
+    private static void queryRedirectTarget(ServerRequest request, ServerResponse response) {
+        String contentType = request.headers().get(HeaderNames.CONTENT_TYPE).get();
+        response.send(request.prologue().method() + ":" + contentType + ":" + request.content().as(String.class));
+    }
+
+    private static void queryRedirectGetTarget(ServerRequest request, ServerResponse response) {
+        if (request.content().hasEntity() || request.headers().contains(HeaderNames.CONTENT_TYPE)) {
+            response.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
+            return;
+        }
+        response.send("GET without entity metadata");
     }
 
     @Test

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigBlueprint.java
@@ -77,9 +77,9 @@ interface AutoHttpMetricsConfigBlueprint {
      * {@code LIST}; assigning this value fully replaces the set of method names.
      * <p>
      * Default known HTTP methods: {@code CONNECT}, {@code DELETE}, {@code GET}, {@code HEAD}, {@code LIST},
-     * {@code OPTIONS}, {@code PATCH}, {@code POST}, {@code PUT}, and {@code TRACE}. Unlisted methods are reported as
-     * {@code _OTHER}, so configurations that add additional method names must also include default methods they intend
-     * to retain.
+     * {@code OPTIONS}, {@code PATCH}, {@code POST}, {@code PUT}, {@code QUERY}, and {@code TRACE}. Unlisted methods are
+     * reported as {@code _OTHER}, so configurations that add additional method names must also include default methods
+     * they intend to retain.
      * <p>
      * Method names are canonicalized using Helidon's HTTP method model.
      * See the <a href="https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-method">

--- a/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigSupport.java
+++ b/webserver/observe/metrics/src/main/java/io/helidon/webserver/observe/metrics/AutoHttpMetricsConfigSupport.java
@@ -25,7 +25,7 @@ import io.helidon.http.Method;
 class AutoHttpMetricsConfigSupport {
 
     static final List<String> DEFAULT_KNOWN_METHODS = List.of(
-            "CONNECT", "DELETE", "GET", "HEAD", "LIST", "OPTIONS", "PATCH", "POST", "PUT", "TRACE");
+            "CONNECT", "DELETE", "GET", "HEAD", "LIST", "OPTIONS", "PATCH", "POST", "PUT", "QUERY", "TRACE");
 
     private static final List<AutoHttpMetricsPathConfig> MEASUREMENT_DISABLED_HELIDON_ENDPOINTS = List.of(
             disabled("/metrics/*"),

--- a/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoMetricsConfig.java
+++ b/webserver/observe/metrics/src/test/java/io/helidon/webserver/observe/metrics/TestAutoMetricsConfig.java
@@ -127,7 +127,9 @@ class TestAutoMetricsConfig {
 
         assertThat("GET /metrics", config.isMeasured(Method.GET, UriPath.create("/metrics")), is(false));
         assertThat("Updated HTTP metrics default", config.useUpdatedHttpMetrics(), is(true));
-        assertThat(config.knownMethods(), is(AutoHttpMetricsConfigSupport.DEFAULT_KNOWN_METHODS));
+        assertThat(config.knownMethods(),
+                   is(List.of("CONNECT", "DELETE", "GET", "HEAD", "LIST", "OPTIONS", "PATCH", "POST", "PUT",
+                              "QUERY", "TRACE")));
 
     }
 

--- a/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
+++ b/webserver/observe/telemetry/metrics/src/test/java/io/helidon/webserver/observe/telemetry/metrics/OpenTelemetryMetricsHttpSemanticConventionsTest.java
@@ -83,6 +83,18 @@ class OpenTelemetryMetricsHttpSemanticConventionsTest {
     }
 
     @Test
+    void queryHttpMethodUsesMethodMetricAttribute() throws Exception {
+        AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
+        AtomicReference<Runnable> whenSent = new AtomicReference<>();
+
+        filter(recordedAttributes::set)
+                .filter(mock(FilterChain.class), request(Method.QUERY), response(whenSent));
+        whenSent.get().run();
+
+        assertThat(methodAttribute(recordedAttributes.get()), is("QUERY"));
+    }
+
+    @Test
     void knownExtensionHttpMethodUsesMethodMetricAttribute() throws Exception {
         AtomicReference<Attributes> recordedAttributes = new AtomicReference<>();
         AtomicReference<Runnable> whenSent = new AtomicReference<>();

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/QueryTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/QueryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class QueryTest {
+    private static final String QUERY = "name=Joe";
+    private static final HeaderName CONNECTION_ID = HeaderNames.create("X-Connection-Id");
+    private static final AtomicInteger INVALID_ROUTE_INVOCATIONS = new AtomicInteger();
+
+    private final HttpClient client;
+    private final URI uri;
+
+    QueryTest(URI uri) {
+        this.uri = uri;
+        this.client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.addFilter((chain, req, res) -> {
+            res.header(CONNECTION_ID, req.socketId());
+            chain.proceed();
+        }).route(Method.QUERY, "/valid", (req, res) -> res.send(req.content().as(String.class)))
+                .route(Method.QUERY, "/invalid", (_, res) -> {
+                    INVALID_ROUTE_INVOCATIONS.incrementAndGet();
+                    res.send("Unexpected route invocation");
+                });
+    }
+
+    @Test
+    void validQueryBodyRoutes() throws Exception {
+        establishHttp2();
+        assertValidQuery();
+    }
+
+    @Test
+    void missingContentTypeIsBadRequestAndSessionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(HttpRequest.newBuilder()
+                                          .uri(uri.resolve("/invalid")));
+    }
+
+    @Test
+    void repeatedContentTypeIsBadRequestAndSessionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(HttpRequest.newBuilder()
+                                          .uri(uri.resolve("/invalid"))
+                                          .header("Content-Type", "text/plain")
+                                          .header("Content-Type", "application/json"));
+    }
+
+    @Test
+    void malformedContentTypeIsBadRequestAndSessionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(HttpRequest.newBuilder()
+                                          .uri(uri.resolve("/invalid"))
+                                          .header("Content-Type", "invalid"));
+    }
+
+    private void assertBadRequestThenValid(HttpRequest.Builder requestBuilder) throws Exception {
+        establishHttp2();
+        int invocationCount = INVALID_ROUTE_INVOCATIONS.get();
+        HttpResponse<String> response = client.send(requestBuilder
+                                                            .timeout(Duration.ofSeconds(5))
+                                                            .method(Method.QUERY.text(),
+                                                                    HttpRequest.BodyPublishers.ofString(QUERY))
+                                                            .build(),
+                                                    HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode(), is(Status.BAD_REQUEST_400.code()));
+        assertThat(response.version(), is(HttpClient.Version.HTTP_2));
+        assertThat(INVALID_ROUTE_INVOCATIONS.get(), is(invocationCount));
+        String connectionId = response.headers().firstValue(CONNECTION_ID.lowerCase()).orElseThrow();
+        HttpResponse<String> validResponse = assertValidQuery();
+        assertThat(validResponse.headers().firstValue(CONNECTION_ID.lowerCase()).orElseThrow(), is(connectionId));
+    }
+
+    private HttpResponse<String> assertValidQuery() throws IOException, InterruptedException {
+        HttpResponse<String> response = client.send(HttpRequest.newBuilder()
+                                                            .uri(uri.resolve("/valid"))
+                                                            .timeout(Duration.ofSeconds(5))
+                                                            .header("Content-Type", "application/x-www-form-urlencoded")
+                                                            .method(Method.QUERY.text(),
+                                                                    HttpRequest.BodyPublishers.ofString(QUERY))
+                                                            .build(),
+                                                    HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode(), is(Status.OK_200.code()));
+        assertThat(response.body(), is(QUERY));
+        assertThat(response.version(), is(HttpClient.Version.HTTP_2));
+        return response;
+    }
+
+    private void establishHttp2() throws IOException, InterruptedException {
+        client.send(HttpRequest.newBuilder()
+                            .uri(uri.resolve("/valid"))
+                            .timeout(Duration.ofSeconds(5))
+                            .HEAD()
+                            .build(),
+                    HttpResponse.BodyHandlers.discarding());
+    }
+}

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/QueryTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/QueryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class QueryTest {
+    private static final String QUERY = "name=Joe";
+    private static final AtomicInteger INVALID_ROUTE_INVOCATIONS = new AtomicInteger();
+
+    private final URI uri;
+
+    QueryTest(URI uri) {
+        this.uri = uri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.route(Method.QUERY, "/valid", (req, res) -> res.send(req.content().as(String.class)))
+                .route(Method.QUERY, "/invalid", (_, res) -> {
+                    INVALID_ROUTE_INVOCATIONS.incrementAndGet();
+                    res.send("Unexpected route invocation");
+                });
+    }
+
+    @Test
+    void validQueryBodyRoutes() throws Exception {
+        try (SocketHttpClient client = socketClient()) {
+            assertValidQuery(client);
+        }
+    }
+
+    @Test
+    void missingContentTypeIsBadRequestAndConnectionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(List.of());
+    }
+
+    @Test
+    void repeatedContentTypeIsBadRequestAndConnectionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(List.of("Content-Type: text/plain", "Content-Type: application/json"));
+    }
+
+    @Test
+    void malformedContentTypeIsBadRequestAndConnectionRemainsUsable() throws Exception {
+        assertBadRequestThenValid(List.of("Content-Type: invalid"));
+    }
+
+    private void assertBadRequestThenValid(List<String> headers) throws Exception {
+        int invocationCount = INVALID_ROUTE_INVOCATIONS.get();
+        try (SocketHttpClient client = socketClient()) {
+            String response = client.sendAndReceive(Method.QUERY, "/invalid", QUERY, headers);
+
+            assertThat(SocketHttpClient.statusFromResponse(response), is(Status.BAD_REQUEST_400));
+            assertThat(INVALID_ROUTE_INVOCATIONS.get(), is(invocationCount));
+            assertValidQuery(client);
+        }
+    }
+
+    private void assertValidQuery(SocketHttpClient client) {
+        String response = client.sendAndReceive(Method.QUERY,
+                                                "/valid",
+                                                QUERY,
+                                                List.of("Content-Type: application/x-www-form-urlencoded"));
+
+        assertThat(SocketHttpClient.statusFromResponse(response), is(Status.OK_200));
+        assertThat(SocketHttpClient.entityFromResponse(response, true), is(QUERY));
+    }
+
+    private SocketHttpClient socketClient() {
+        return SocketHttpClient.create(uri.getHost(), uri.getPort(), Duration.ofSeconds(5));
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpRoutingImpl.java
@@ -25,10 +25,13 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import io.helidon.common.Weights;
+import io.helidon.http.BadRequestException;
 import io.helidon.http.DirectHandler;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.HttpException;
 import io.helidon.http.HttpPrologue;
 import io.helidon.http.LogFormatter;
+import io.helidon.http.Method;
 import io.helidon.http.NotFoundException;
 import io.helidon.http.RequestException;
 import io.helidon.http.Status;
@@ -192,6 +195,22 @@ final class HttpRoutingImpl implements HttpRouting, Http1UpgradeRouting {
 
         private RoutingResult doRoute(ConnectionContext ctx, RoutingRequest request, RoutingResponse response) throws Exception {
             HttpPrologue prologue = request.prologue();
+            if (prologue.method() == Method.QUERY) {
+                if (!request.headers().contains(HeaderNames.CONTENT_TYPE)
+                        || request.headers().get(HeaderNames.CONTENT_TYPE).valueCount() != 1) {
+                    throw new HttpException("QUERY requests require exactly one Content-Type header",
+                                            Status.BAD_REQUEST_400,
+                                            true);
+                }
+                try {
+                    request.headers().contentType();
+                } catch (BadRequestException e) {
+                    throw new HttpException("Invalid Content-Type header for QUERY request",
+                                            Status.BAD_REQUEST_400,
+                                            e,
+                                            true);
+                }
+            }
             RouteCrawler crawler = rootRoute.crawler(ctx, request);
 
             while (crawler.hasNext()) {


### PR DESCRIPTION
Resolves #12174

Adds RFC 10008 `QUERY` support across HTTP, WebClient, WebServer, declarative clients and servers, and HTTP metrics.

- Adds `Method.QUERY` and `@Http.QUERY`; declarative code generation uses the existing generic client and routing APIs without adding QUERY convenience methods.
- Validates QUERY `Content-Type` requirements in WebServer and WebClient.
- Preserves the QUERY method and entity across 301, 302, 307, and 308 redirects, changes to GET for 303, and retains cross-origin replay protection.
- Adds RFC 9651 `Accept-Query` constants and typed response-header helpers backed by a package-private parser.
- Includes documentation and targeted redirect benchmarks.

This replaces #12178.
