### PR TITLE
Restore default-port CORS origin matching

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsPathValidator.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import io.helidon.common.uri.UriValidationException;
+import io.helidon.common.uri.UriValidator;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.PathMatcher;
 import io.helidon.http.PathMatchers;
@@ -79,6 +81,7 @@ class CorsPathValidator {
                     originPatterns.add(Pattern.compile(origin, Pattern.CASE_INSENSITIVE));
                 } else {
                     exactMatchOrigins.add(origin);
+                    exactMatchOrigins.add(normalizeDefaultPort(origin));
                 }
             }
 
@@ -230,6 +233,33 @@ class CorsPathValidator {
             }
         }
         return Result.ALLOWED;
+    }
+
+    private static String normalizeDefaultPort(String origin) {
+        int authorityOffset;
+        int portLength;
+        if (origin.startsWith("http://") && origin.endsWith(":80")) {
+            authorityOffset = "http://".length();
+            portLength = 3;
+        } else if (origin.startsWith("https://") && origin.endsWith(":443")) {
+            authorityOffset = "https://".length();
+            portLength = 4;
+        } else {
+            return origin;
+        }
+        int portOffset = origin.length() - portLength;
+        if (portOffset == authorityOffset
+                || origin.indexOf('/', authorityOffset) != -1
+                || origin.indexOf('?', authorityOffset) != -1
+                || origin.indexOf('#', authorityOffset) != -1) {
+            return origin;
+        }
+        try {
+            UriValidator.validateHost(origin.substring(authorityOffset, portOffset));
+        } catch (UriValidationException ignored) {
+            return origin;
+        }
+        return origin.substring(0, portOffset);
     }
 
     private boolean invalidHeaders(ServerRequest req, ServerResponse res, List<String> headers) {

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsPathValidatorTest.java
@@ -167,6 +167,60 @@ public class CorsPathValidatorTest {
     }
 
     @Test
+    public void testPreFlightConfiguredDefaultPortOrigins() {
+        assertDefaultPortOriginAllowed("http://example.com:80", "http://example.com");
+        assertDefaultPortOriginAllowed("http://example.com:80", "http://example.com:80");
+        assertDefaultPortOriginAllowed("https://example.com:443", "https://example.com");
+        assertDefaultPortOriginAllowed("https://example.com:443", "https://example.com:443");
+    }
+
+    @Test
+    public void testPreFlightNonDefaultPortOriginForbidden() {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of("https://example.com:444"))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, "https://example.com");
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var statusCaptor = ArgumentCaptor.forClass(Status.class);
+        var response = response(ServerResponseHeaders.create());
+        when(response.status(statusCaptor.capture())).thenReturn(response);
+
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders), response);
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(false));
+        assertThat(statusCaptor.getValue(), is(Status.FORBIDDEN_403));
+        verify(response, times(1)).send();
+    }
+
+    @Test
+    public void testPreFlightMalformedDefaultPortOriginForbidden() {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of("https://example.com:8443:443"))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, "https://example.com:8443");
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var statusCaptor = ArgumentCaptor.forClass(Status.class);
+        var response = response(ServerResponseHeaders.create());
+        when(response.status(statusCaptor.capture())).thenReturn(response);
+
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders), response);
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(false));
+        assertThat(statusCaptor.getValue(), is(Status.FORBIDDEN_403));
+        verify(response, times(1)).send();
+    }
+
+    @Test
     public void testPreFlightCustomPattern() {
         CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
                                                                        .pathPattern("/greet")
@@ -494,6 +548,25 @@ public class CorsPathValidatorTest {
 
         assertThat("There should be 1 configured response header", responseHeaders.size(), is(1));
         assertThat(responseHeaders, hasHeaderValue(ACCESS_CONTROL_ALLOW_ORIGIN, is(Cors.ALLOW_ALL)));
+    }
+
+    private static void assertDefaultPortOriginAllowed(String allowedOrigin, String origin) {
+        CorsPathValidator validator = CorsPathValidator.create(CorsPathConfig.builder()
+                                                                       .pathPattern("/greet")
+                                                                       .allowOrigins(Set.of(allowedOrigin))
+                                                                       .build());
+
+        var requestHeaders = WritableHeaders.create();
+        requestHeaders.set(HeaderNames.ORIGIN, origin);
+        requestHeaders.set(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+
+        var responseHeaders = ServerResponseHeaders.create();
+        CorsPathValidator.Result result = validator.preFlight(request("/greet", requestHeaders),
+                                                              response(responseHeaders));
+
+        assertThat(result.matched(), is(true));
+        assertThat(result.shouldContinue(), is(true));
+        assertThat(responseHeaders, hasHeaderValue(ACCESS_CONTROL_ALLOW_ORIGIN, is(origin)));
     }
 
     private static ServerRequest request(String path, Headers headers) {


### PR DESCRIPTION
Resolves #12511

Carry the default-port CORS origin correction from #12512 forward to `main`.
Configured exact HTTP and HTTPS origins with explicit default ports now match
browser-serialized `Origin` headers.
