### PR TITLE
Stabilize WebServer transport port reuse test (27.x)

### DIFF
--- a/webserver/webserver/src/test/java/io/helidon/webserver/TestTransportBindingProvider.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/TestTransportBindingProvider.java
@@ -16,10 +16,11 @@
 
 package io.helidon.webserver;
 
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -163,12 +164,14 @@ public class TestTransportBindingProvider implements TransportBindingFactoryProv
     }
 
     private static int bindDatagramSocket(String name) {
-        try {
-            DatagramSocket socket = new DatagramSocket(0, InetAddress.getLoopbackAddress());
+        InetAddress address = InetAddress.getLoopbackAddress();
+        try (ServerSocket tcpSocket = new ServerSocket(0, 50, address)) {
+            // The lifecycle test reuses this port for TCP, so select it from the TCP allocator.
+            DatagramSocket socket = new DatagramSocket(tcpSocket.getLocalPort(), address);
             closeBoundSocket(name);
             BOUND_SOCKETS.put(name, socket);
             return socket.getLocalPort();
-        } catch (SocketException e) {
+        } catch (IOException e) {
             throw new IllegalStateException("Failed to bind test transport socket", e);
         }
     }


### PR DESCRIPTION
The WebServer transport-binding lifecycle test now selects its shared random port through TCP before retaining the same port in UDP. This avoids Windows choosing a UDP ephemeral port that is unavailable to the later TCP binding while preserving the existing end-to-end port reuse and connection assertions.
