### PR TITLE
Remove declarative ignore-incubating option (27.x)

### DIFF
--- a/common/common/src/main/java/io/helidon/common/Default.java
+++ b/common/common/src/main/java/io/helidon/common/Default.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * A container class for default values related types for Helidon declarative.
  */
-@Api.Incubating
+@Api.Preview
 public final class Default {
     private Default() {
     }
@@ -35,7 +35,7 @@ public final class Default {
      * <p>
      * Depending on the usage, this may be mapped to other types as needed.
      */
-    @Api.Incubating
+    @Api.Preview
     @Target({ElementType.PARAMETER, ElementType.FIELD})
     @Retention(RetentionPolicy.CLASS)
     @Documented
@@ -52,7 +52,7 @@ public final class Default {
      * A default value specified as an integer.
      * This can only be used on element of the correct type.
      */
-    @Api.Incubating
+    @Api.Preview
     @Target({ElementType.PARAMETER, ElementType.FIELD})
     @Retention(RetentionPolicy.CLASS)
     @Documented
@@ -69,7 +69,7 @@ public final class Default {
      * A default value specified as a long.
      * This can only be used on element of the correct type.
      */
-    @Api.Incubating
+    @Api.Preview
     @Target({ElementType.PARAMETER, ElementType.FIELD})
     @Retention(RetentionPolicy.CLASS)
     @Documented
@@ -86,7 +86,7 @@ public final class Default {
      * A default value specified as a double.
      * This can only be used on element of the correct type.
      */
-    @Api.Incubating
+    @Api.Preview
     @Target({ElementType.PARAMETER, ElementType.FIELD})
     @Retention(RetentionPolicy.CLASS)
     @Documented
@@ -103,7 +103,7 @@ public final class Default {
      * A default value specified as a boolean.
      * This can only be used on element of the correct type.
      */
-    @Api.Incubating
+    @Api.Preview
     @Target({ElementType.PARAMETER, ElementType.FIELD})
     @Retention(RetentionPolicy.CLASS)
     @Documented

--- a/config/config/src/main/java/io/helidon/config/Configuration.java
+++ b/config/config/src/main/java/io/helidon/config/Configuration.java
@@ -28,8 +28,8 @@ import io.helidon.service.registry.Service;
 /**
  * Container class for annotations related to Helidon Configuration when using declarative programming model.
  * <p>
- * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
- *               but it is intended for supported external use.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain backward
+ * compatible within a major version. It may change without deprecation in a new major version.
  */
 @Api.Preview
 public final class Configuration {

--- a/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigurationValueFactoryTest.java
@@ -267,7 +267,7 @@ class ConfigurationValueFactoryTest {
         ConfigurationValueFactory factory = factory(Map.of());
 
         List<Service.QualifiedInstance<Object>> values = factory.list(Qualifier.create(Configuration.Value.class,
-                                                                                      "${declarative.ignore-incubating:false}"),
+                                                                                      "${app.enabled:false}"),
                                                                       Lookup.create(boolean.class),
                                                                       asObjectType(GenericType.create(boolean.class)));
 

--- a/data/README.md
+++ b/data/README.md
@@ -3,6 +3,9 @@ Helidon Data
 
 Repository based database access.
 
+Helidon Data is a preview feature. It is ready for production use, but its APIs may change without
+the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
+
 # Glossary
 
 | Name             | Description                                                                                                          |

--- a/data/data/src/main/java/io/helidon/data/Data.java
+++ b/data/data/src/main/java/io/helidon/data/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.registry.Service;
 
 /**
  * Helidon Data Repository annotations and interfaces.
  */
+@Api.Preview
 public final class Data {
 
     private Data() {

--- a/data/data/src/main/java/io/helidon/data/DataException.java
+++ b/data/data/src/main/java/io/helidon/data/DataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@ package io.helidon.data;
 
 import java.util.Objects;
 
+import io.helidon.common.Api;
+
 /**
  * A {@link RuntimeException} that indicates an operation on a data repository has failed.
  */
+@Api.Preview
 public class DataException extends RuntimeException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/EntityExistsException.java
+++ b/data/data/src/main/java/io/helidon/data/EntityExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when persistence entity being inserted already exists.
  */
+@Api.Preview
 public class EntityExistsException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/EntityNotFoundException.java
+++ b/data/data/src/main/java/io/helidon/data/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when requested persistence entity cannot be found.
  */
+@Api.Preview
 public class EntityNotFoundException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/NoResultException.java
+++ b/data/data/src/main/java/io/helidon/data/NoResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when a query was expected to produce a result, but did not.
  */
+@Api.Preview
 public class NoResultException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/NonUniqueResultException.java
+++ b/data/data/src/main/java/io/helidon/data/NonUniqueResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when a query was expected to produce exactly one record but produced many instead.
  */
+@Api.Preview
 public class NonUniqueResultException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/OptimisticLockException.java
+++ b/data/data/src/main/java/io/helidon/data/OptimisticLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Thrown when an optimistic locking conflict occurs.
  */
+@Api.Preview
 public class OptimisticLockException extends DataException {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/OrderBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/OrderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package io.helidon.data;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Single rule of the dynamic ordering of the query result.
@@ -26,6 +27,7 @@ import io.helidon.builder.api.Prototype;
  * {@code SELECT t FROM Type t WHERE t.name = :name ORDER BY t.name DESC, t.id} this is the
  * {@code t.name DESC} and {@code t.id} as two separate {@link Order} instances.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(OrderSupport.class)
 interface OrderBlueprint {

--- a/data/data/src/main/java/io/helidon/data/OrderDirection.java
+++ b/data/data/src/main/java/io/helidon/data/OrderDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.data;
 
+import io.helidon.common.Api;
+
 /**
  * Direction of the query result ordering.
  */
+@Api.Preview
 public enum OrderDirection {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/Page.java
+++ b/data/data/src/main/java/io/helidon/data/Page.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package io.helidon.data;
 
 import java.util.List;
 
+import io.helidon.common.Api;
+
 /**
  * Pageable query result as pages with total size of the result.
  * <p>
@@ -29,6 +31,7 @@ import java.util.List;
  *
  * @param <T> query result type (entity or entity attribute)
  */
+@Api.Preview
 public interface Page<T> extends Slice<T> {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/PageRequestBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/PageRequestBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.data;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Request pageable query result as page with page number and size.
@@ -27,6 +28,7 @@ import io.helidon.builder.api.Prototype;
  * Repository interface method must always be of {@link Slice} or {@link Page} type when
  * it contains {@link PageRequest} argument.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(PageRequestSupport.class)
 interface PageRequestBlueprint {

--- a/data/data/src/main/java/io/helidon/data/Slice.java
+++ b/data/data/src/main/java/io/helidon/data/Slice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.data;
 import java.util.List;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
+
 /**
  * Pageable query result as pages without total size of the result.
  * <p>
@@ -29,6 +31,7 @@ import java.util.stream.Stream;
  *
  * @param <T> query result type (entity or entity attribute)
  */
+@Api.Preview
 public interface Slice<T> extends Iterable<T> {
 
     /**

--- a/data/data/src/main/java/io/helidon/data/SortBlueprint.java
+++ b/data/data/src/main/java/io/helidon/data/SortBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.List;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Dynamic ordering of the query result.
@@ -27,6 +28,7 @@ import io.helidon.builder.api.Prototype;
  * {@code SELECT t FROM Type t WHERE t.name = :name ORDER BY t.name DESC, t.id} this is the whole
  * content of the {@code ORDER BY} clause.
  */
+@Api.Preview
 @Prototype.Blueprint
 @Prototype.CustomMethods(SortSupport.class)
 interface SortBlueprint {

--- a/data/data/src/main/java/io/helidon/data/package-info.java
+++ b/data/data/src/main/java/io/helidon/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,5 +39,8 @@
  *         </ul>
  *     </li>
  * </ul>
+ *
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data;

--- a/data/data/src/main/java/module-info.java
+++ b/data/data/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,21 @@ import io.helidon.common.features.api.Features;
 
 /**
  * Helidon Data Repository API.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
+ *
  * @see io.helidon.data
  */
 @Features.Name("Data")
 @Features.Since("4.3.0")
 @Features.Path("Data")
 @Features.Description("Helidon Data - repository pattern")
-@Features.Incubating
+@Features.Preview
 module io.helidon.data {
 
     requires static io.helidon.common.features.api;
+    requires static io.helidon.common;
     requires io.helidon.service.registry;
     requires transitive io.helidon.builder.api;
 

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaPersistenceUnitConfigBlueprint.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaPersistenceUnitConfigBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,14 @@ import java.util.Set;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.data.sql.common.SqlConfig;
 import io.helidon.service.registry.Service;
 
 /**
  * Configuration of Helidon Data for Jakarta Persistence.
  */
+@Api.Preview
 @SuppressWarnings("rawtypes")
 @Prototype.Blueprint
 @Prototype.Configured(value = PersistenceUnitFactory.JPA_PU_CONFIG_KEY)

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/JpaRepositoryExecutor.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Functions;
 import io.helidon.service.registry.Service;
 
@@ -30,6 +31,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 /**
  * Jakarta Persistence specific repository tasks executor.
  */
+@Api.Preview
 @Service.Contract
 public interface JpaRepositoryExecutor extends AutoCloseable {
     /**

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitTransactionType.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/PersistenceUnitTransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.data.jakarta.persistence;
 
+import io.helidon.common.Api;
 import io.helidon.data.DataException;
 
 /**
@@ -23,6 +24,7 @@ import io.helidon.data.DataException;
  *
  * @deprecated Will be replaced by Jakarta Persistence 3.2 API
  */
+@Api.Preview
 @Deprecated
 public enum PersistenceUnitTransactionType {
 

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/package-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,8 @@
 
 /**
  * Helidon Data Repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data.jakarta.persistence;

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/JpaEntityProvider.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/JpaEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.data.jakarta.persistence.spi;
 
+import io.helidon.common.Api;
 import io.helidon.service.registry.Service;
 
 /**
@@ -28,6 +29,7 @@ import io.helidon.service.registry.Service;
  *
  * @param <T> type of the entity supported by this provider
  */
+@Api.Preview
 @Service.Contract
 public interface JpaEntityProvider<T> {
     /**

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/package-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/io/helidon/data/jakarta/persistence/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,8 @@
 
 /**
  * Service provider interface for repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 package io.helidon.data.jakarta.persistence.spi;

--- a/data/jakarta-persistence/jakarta-persistence/src/main/java/module-info.java
+++ b/data/jakarta-persistence/jakarta-persistence/src/main/java/module-info.java
@@ -16,12 +16,16 @@
 
 /**
  * Helidon Data Repository with Jakarta Persistence Runtime.
+ * <p>
+ * This is a preview feature of Helidon - it is ready for production use, but we reserve the rights to change APIs
+ * without the usual deprecation process. This feature will be backward compatible within a major version of Helidon.
  */
 module io.helidon.data.jakarta.persistence {
 
     requires transitive jakarta.persistence;
     requires transitive io.helidon.service.registry;
 
+    requires io.helidon.common;
     requires io.helidon.config;
     requires io.helidon.data;
     requires io.helidon.data.sql.common;

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/AbstractParametersProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/AbstractParametersProvider.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
@@ -34,6 +35,7 @@ import static io.helidon.declarative.codegen.http.HttpTypes.HTTP_SUPPORT;
  * A provider of parameters when code generating call of methods with annotated parameter, such
  * as HTTP headers, path parameters etc.
  */
+@Api.Preview
 public abstract class AbstractParametersProvider {
     /**
      * Constructor with no side effects.

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParameterCodegenContext.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/ParameterCodegenContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
 import io.helidon.service.codegen.FieldHandler;
@@ -27,6 +28,7 @@ import io.helidon.service.codegen.FieldHandler;
 /**
  * Information related to parameter processing.
  */
+@Api.Preview
 public interface ParameterCodegenContext {
     /**
      * Constant handler for the type being created.

--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/spi/HttpParameterCodegenProvider.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/http/webserver/spi/HttpParameterCodegenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.declarative.codegen.http.webserver.spi;
 
+import io.helidon.common.Api;
 import io.helidon.declarative.codegen.http.webserver.ParameterCodegenContext;
 
 /**
@@ -23,6 +24,7 @@ import io.helidon.declarative.codegen.http.webserver.ParameterCodegenContext;
  * methods.
  * The parameter retrieval is expected to be code-generated.
  */
+@Api.Preview
 public interface HttpParameterCodegenProvider {
     /**
      * Code generate parameter assignment.

--- a/docs/modules/data.md
+++ b/docs/modules/data.md
@@ -18,8 +18,9 @@ The Helidon Data Repository supports Jakarta Persistence and major providers
 such as EclipseLink and Hibernate.
 
 > [!NOTE]
-> Helidon Data Repository is an incubating feature. Its APIs are subject to
-> change and will be finalized in a future release of Helidon.
+> Helidon Data Repository is a preview feature. It is ready for production use,
+> but its APIs may change without the usual deprecation process. This feature
+> will be backward compatible within a major version of Helidon.
 
 ## Maven Coordinates
 

--- a/docs/modules/injection/declarative.md
+++ b/docs/modules/injection/declarative.md
@@ -19,9 +19,9 @@ Our declarative approach has the following advantages:
   not require additional dependencies)
 
 > [!NOTE]
-> Helidon Declarative is a preview feature. The APIs shown here are subject to
-> change between major releases without deprecation, but they are intended for
-> supported external use.
+> Helidon Declarative is a preview feature. It is ready for production use. Its
+> APIs will remain backward compatible within a major version, but may change
+> without the usual deprecation process in a new major version.
 
 ## Usage
 

--- a/docs/modules/injection/declarative.md
+++ b/docs/modules/injection/declarative.md
@@ -19,8 +19,9 @@ Our declarative approach has the following advantages:
   not require additional dependencies)
 
 > [!NOTE]
-> Helidon Declarative is an incubating feature. The APIs shown here are subject
-> to change. These APIs will be finalized in a future release of Helidon.
+> Helidon Declarative is a preview feature. The APIs shown here are subject to
+> change between major releases without deprecation, but they are intended for
+> supported external use.
 
 ## Usage
 

--- a/grpc/api/src/main/java/io/helidon/grpc/api/Grpc.java
+++ b/grpc/api/src/main/java/io/helidon/grpc/api/Grpc.java
@@ -90,7 +90,7 @@ public interface Grpc {
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @Inherited
-    @Api.Incubating
+    @Api.Preview
     @interface ProtoDescriptor {
         /**
          * The generated protocol buffer class.

--- a/http/http/src/main/java/io/helidon/http/Http.java
+++ b/http/http/src/main/java/io/helidon/http/Http.java
@@ -42,7 +42,7 @@ import io.helidon.service.registry.Service;
  * <li>{@link io.helidon.http.DateTime}</li>
  * </ul>
  */
-@Api.Incubating
+@Api.Preview
 @Api.Since("4.3.0")
 public final class Http {
     private Http() {

--- a/service/registry/src/main/java/io/helidon/service/registry/Interception.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Interception.java
@@ -29,6 +29,7 @@ import io.helidon.common.Api;
  * Interception annotations and types.
  * This is the entry point for any annotation and type related to interception in Helidon Service Registry.
  */
+@Api.Preview
 public final class Interception {
     private Interception() {
     }
@@ -159,7 +160,7 @@ public final class Interception {
      * using Helidon Declarative. This is not triggered when using injection without declarative endpoint (i.e. when setting
      * up WebServer using routing imperatively).
      */
-    @Api.Incubating
+    @Api.Preview
     @Api.Since("4.3.0")
     @Service.Contract
     public interface EntryPointInterceptor {

--- a/service/registry/src/main/java/io/helidon/service/registry/Interception.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Interception.java
@@ -29,7 +29,7 @@ import io.helidon.common.Api;
  * Interception annotations and types.
  * This is the entry point for any annotation and type related to interception in Helidon Service Registry.
  */
-@Api.Preview
+@Api.Stable
 public final class Interception {
     private Interception() {
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -42,6 +42,7 @@ import io.helidon.common.types.TypeName;
  * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle,
  * including construction, post-construct, business methods, and pre-destroy.
  */
+@Api.Preview
 public final class Service {
     private Service() {
     }
@@ -476,7 +477,7 @@ public final class Service {
      * This annotation is used by framework developers that need to extend the set of entry points of an
      * application.
      */
-    @Api.Incubating
+    @Api.Preview
     @Api.Since("4.3.0")
     @Retention(RetentionPolicy.CLASS)
     @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -42,7 +42,7 @@ import io.helidon.common.types.TypeName;
  * {@link io.helidon.service.registry.ServiceRegistry} instead. This restriction applies throughout the service lifecycle,
  * including construction, post-construct, business methods, and pre-destroy.
  */
-@Api.Preview
+@Api.Stable
 public final class Service {
     private Service() {
     }

--- a/webclient/api/src/main/java/io/helidon/webclient/api/RestClient.java
+++ b/webclient/api/src/main/java/io/helidon/webclient/api/RestClient.java
@@ -36,7 +36,7 @@ import io.helidon.service.registry.Service;
  * <p>
  * The type safe rest client is backed by Helidon {@link io.helidon.webclient.api.WebClient}.
  */
-@Api.Incubating
+@Api.Preview
 public final class RestClient {
     private RestClient() {
     }

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcServiceClient.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/GrpcServiceClient.java
@@ -127,7 +127,7 @@ public interface GrpcServiceClient {
      * @return response stream
      * @throws UnsupportedOperationException if this implementation does not support resource-owning streams
      */
-    @Api.Incubating
+    @Api.Preview
     default <ReqT, ResT> Stream<ResT> serverStreaming(String methodName, ReqT request) {
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(request, "request");
@@ -149,7 +149,7 @@ public interface GrpcServiceClient {
      * @return response
      * @throws UnsupportedOperationException if this implementation does not support resource-owning streams
      */
-    @Api.Incubating
+    @Api.Preview
     default <ReqT, ResT> ResT clientStreaming(String methodName, Stream<ReqT> requests) {
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(requests, "requests");
@@ -169,7 +169,7 @@ public interface GrpcServiceClient {
      * @return response stream
      * @throws UnsupportedOperationException if this implementation does not support resource-owning streams
      */
-    @Api.Incubating
+    @Api.Preview
     default <ReqT, ResT> Stream<ResT> bidirectional(String methodName, Stream<ReqT> requests) {
         Objects.requireNonNull(methodName, "methodName");
         Objects.requireNonNull(requests, "requests");

--- a/webclient/grpc/src/main/java/io/helidon/webclient/grpc/RpcClient.java
+++ b/webclient/grpc/src/main/java/io/helidon/webclient/grpc/RpcClient.java
@@ -28,7 +28,7 @@ import io.helidon.service.registry.Service;
 /**
  * Declarative gRPC client annotations.
  */
-@Api.Incubating
+@Api.Preview
 public final class RpcClient {
     private RpcClient() {
     }

--- a/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
+++ b/webclient/websocket/src/main/java/io/helidon/webclient/websocket/WebSocketClient.java
@@ -31,7 +31,8 @@ import io.helidon.service.registry.Service;
  * <p>
  * The type safe WebSocket client is backed by Helidon {@link io.helidon.webclient.websocket.WsClient}.
  * <p>
- * This API is preview and may change between minor releases.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain backward
+ * compatible within a major version. It may change without deprecation in a new major version.
  */
 @Api.Preview
 public final class WebSocketClient {

--- a/webserver/graphql/src/main/java/io/helidon/webserver/graphql/GraphQlEntryPoint.java
+++ b/webserver/graphql/src/main/java/io/helidon/webserver/graphql/GraphQlEntryPoint.java
@@ -34,8 +34,8 @@ import graphql.schema.DataFetchingEnvironment;
 /**
  * Container class for types related to GraphQL resolver entry points.
  * <p>
- * NOTE: this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- * and full removal. We welcome feedback for incubating features.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain backward
+ * compatible within a major version. It may change without deprecation in a new major version.
  */
 @Api.Preview
 @Api.Since("27.0.0")

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcEntryPoint.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcEntryPoint.java
@@ -34,10 +34,10 @@ import io.grpc.ServerInterceptor;
 /**
  * Container class for types related to gRPC entry points.
  * <p>
- * NOTE: this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *               and full removal. We welcome feedback for incubating features.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain backward
+ * compatible within a major version. It may change without deprecation in a new major version.
  */
-@Api.Incubating
+@Api.Preview
 public class GrpcEntryPoint {
     private GrpcEntryPoint() {
     }

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteRegistration.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/GrpcRouteRegistration.java
@@ -26,7 +26,7 @@ import io.helidon.webserver.WebServer;
  * The implementing types are expected to be {@link io.helidon.service.registry.ServiceRegistry} services,
  * and will be loaded through a {@link io.helidon.webserver.spi.ServerFeature}.
  */
-@Api.Incubating
+@Api.Preview
 @Service.Contract
 public interface GrpcRouteRegistration {
     /**

--- a/webserver/grpc/src/main/java/io/helidon/webserver/grpc/RpcServer.java
+++ b/webserver/grpc/src/main/java/io/helidon/webserver/grpc/RpcServer.java
@@ -28,7 +28,7 @@ import io.helidon.common.Api;
 /**
  * Declarative gRPC server annotations.
  */
-@Api.Incubating
+@Api.Preview
 public final class RpcServer {
     private RpcServer() {
     }

--- a/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
+++ b/webserver/tests/observe/observe/src/test/java/io/helidon/webserver/tests/observe/ObserveRegistryBootstrapTest.java
@@ -204,7 +204,6 @@ class ObserveRegistryBootstrapTest {
                 .addObserver(observer)
                 .build();
         Config config = Config.just(ConfigSources.create(Map.of(
-                "declarative.ignore-incubating", "true",
                 "server.port", "0")));
         ServiceRegistryConfig registryConfig = ServiceRegistryConfig.builder()
                 .putContractInstance(Config.class, config)
@@ -258,7 +257,6 @@ class ObserveRegistryBootstrapTest {
                 .addObserver(observer)
                 .build();
         Config config = Config.just(ConfigSources.create(Map.of(
-                "declarative.ignore-incubating", "true",
                 "server.port", "0")));
         ServiceRegistryConfig registryConfig = ServiceRegistryConfig.builder()
                 .putContractInstance(Config.class, config)
@@ -306,7 +304,6 @@ class ObserveRegistryBootstrapTest {
 
     private static Config automaticConfig(String marker) {
         return Config.just(ConfigSources.create(Map.ofEntries(
-                entry("declarative.ignore-incubating", "true"),
                 entry("server.port", "0"),
                 entry("server.features.observe.endpoint", ENDPOINT),
                 entry("server.features.observe.observers.config.permit-all", "true"),
@@ -317,7 +314,6 @@ class ObserveRegistryBootstrapTest {
 
     private static Config isolatedConfig(String marker) {
         return Config.just(ConfigSources.create(Map.ofEntries(
-                entry("declarative.ignore-incubating", "true"),
                 entry("server.port", "0"),
                 entry("server.features.observe.endpoint", ENDPOINT),
                 entry("server.features.observe.observers-discover-services", "false"),
@@ -328,7 +324,6 @@ class ObserveRegistryBootstrapTest {
 
     private static Config manualConfig() {
         return Config.just(ConfigSources.create(Map.of(
-                "declarative.ignore-incubating", "true",
                 "server.port", "0",
                 "server.features-discover-services", "false")));
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerStarterService.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerStarterService.java
@@ -16,33 +16,20 @@
 
 package io.helidon.webserver;
 
-import io.helidon.config.Configuration;
 import io.helidon.service.registry.Service;
 
 @Service.Singleton
 @Service.RunLevel(Service.RunLevel.SERVER)
 class WebServerStarterService {
-    private static final System.Logger LOGGER = System.getLogger(WebServerStarterService.class.getName());
-
     private final LoomServer server;
-    private final boolean ignoreIncubating;
 
-    WebServerStarterService(LoomServer server,
-                            @Configuration.Value("${declarative.ignore-incubating:false}")
-                            boolean ignoreIncubating) {
+    WebServerStarterService(LoomServer server) {
         this.server = server;
-        this.ignoreIncubating = ignoreIncubating;
     }
 
     @Service.PostConstruct
     void postConstruct() {
         server.start();
-        if (!ignoreIncubating) {
-            LOGGER.log(System.Logger.Level.WARNING,
-                       "Helidon WebServer is starting through Helidon Declarative. This is currently an incubating feature (and"
-                               + " as such it may be changed including backward incompatible changes). This warning can be "
-                               + "disabled by setting configuration option 'declarative.ignore-incubating' to true");
-        }
     }
 
     @Service.PreDestroy

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
@@ -31,10 +31,10 @@ import io.helidon.service.registry.ServiceDescriptor;
 /**
  * Container class for types related to HTTP entry points.
  * <p>
- * NOTE: this API is part of incubating features of Helidon. This API may change including backward incompatible changes
- *               and full removal. We welcome feedback for incubating features.
+ * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
+ *               but it is intended for supported external use.
  */
-@Api.Incubating
+@Api.Preview
 public class HttpEntryPoint {
     private HttpEntryPoint() {
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/HttpEntryPoint.java
@@ -31,8 +31,8 @@ import io.helidon.service.registry.ServiceDescriptor;
 /**
  * Container class for types related to HTTP entry points.
  * <p>
- * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
- *               but it is intended for supported external use.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain backward
+ * compatible within a major version. It may change without deprecation in a new major version.
  */
 @Api.Preview
 public class HttpEntryPoint {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/RestServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/RestServer.java
@@ -40,7 +40,7 @@ import io.helidon.service.registry.Service;
  * Declarative response metadata has the same lifecycle as metadata configured imperatively on {@link ServerResponse}:
  * it remains on the current response unless later route or error handling changes it.
  */
-@Api.Incubating
+@Api.Preview
 public final class RestServer {
     private RestServer() {
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http/spi/ErrorHandlerProvider.java
@@ -26,8 +26,8 @@ import io.helidon.webserver.http.ErrorHandler;
  * Instances of this service discovered by service registry are only used when the whole server is started using it
  * (i.e. Helidon Declarative approach).
  * <p>
- * NOTE: this API is part of preview features of Helidon. This API may still change between minor releases,
- * but it is intended for supported external use.
+ * This API is part of Helidon Declarative preview. It is intended for supported external use and will remain
+ * backward compatible within a major version. It may change without deprecation in a new major version.
  * <p>
  * To manually register an error handler, please use
  * {@link io.helidon.webserver.http.HttpRouting.Builder#error(Class, io.helidon.webserver.http.ErrorHandler)}.


### PR DESCRIPTION
Removes the Declarative startup warning and its `declarative.ignore-incubating` suppression option.

The primitive configuration-expression regression remains covered under a neutral test key, and unrelated test configurations no longer carry the removed setting.
