### PR TITLE
Drain direct HTTP/1 error responses before close (27.x)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -727,6 +727,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         try {
             entityReadLatch.await();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw RequestException.builder()
                     .type(EventType.INTERNAL_ERROR)
                     .request(DirectTransportRequest.create(prologue, headers))

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -728,12 +728,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
             entityReadLatch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw RequestException.builder()
-                    .type(EventType.INTERNAL_ERROR)
-                    .request(DirectTransportRequest.create(prologue, headers))
-                    .message("Failed to wait for pipeline")
-                    .cause(e)
-                    .build();
+            throw new CloseConnectionException("Interrupted while waiting for request entity", e);
         }
         return response.keepConnectionOpen();
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -912,6 +912,7 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         } catch (SocketWriterException | UncheckedIOException writeException) {
             throw new ServerConnectionException("Failed to write request exception", writeException);
         }
+        flushBeforeClose();
 
         if (status == Status.INTERNAL_SERVER_ERROR_500) {
             LOGGER.log(WARNING, "Internal server error", e);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -912,10 +912,12 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         } catch (SocketWriterException | UncheckedIOException writeException) {
             throw new ServerConnectionException("Failed to write request exception", writeException);
         }
-        if (status == Status.INTERNAL_SERVER_ERROR_500) {
-            LOGGER.log(WARNING, "Internal server error", e);
+        try {
+            if (status == Status.INTERNAL_SERVER_ERROR_500) {
+                LOGGER.log(WARNING, "Internal server error", e);
+            }
+        } finally {
+            flushBeforeClose();
         }
-
-        flushBeforeClose();
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -912,10 +912,10 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         } catch (SocketWriterException | UncheckedIOException writeException) {
             throw new ServerConnectionException("Failed to write request exception", writeException);
         }
-        flushBeforeClose();
-
         if (status == Status.INTERNAL_SERVER_ERROR_500) {
             LOGGER.log(WARNING, "Internal server error", e);
         }
+
+        flushBeforeClose();
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -154,6 +155,41 @@ class Http1ConnectionTest {
         } finally {
             writer.releaseFlush.countDown();
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void forcedCloseInterruptReachesDirectErrorFlush() throws InterruptedException {
+        byte[] requestBytes = ("""
+                POST / HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                Content-Length: 1\r
+                \r
+                """).getBytes(StandardCharsets.US_ASCII);
+        AtomicReference<Http1Connection> connectionRef = new AtomicReference<>();
+        BlockingDataWriter writer = new BlockingDataWriter();
+        Router router = Router.builder()
+                .addRouting(HttpRouting.builder()
+                                    .post("/", (_, res) -> {
+                                        connectionRef.get().close(true);
+                                        res.send("done");
+                                    }))
+                .build();
+        Http1Connection connection = createConnection(DataReader.create(() -> requestBytes),
+                                                      writer,
+                                                      DirectHandlers.create(),
+                                                      router);
+        connectionRef.set(connection);
+        writer.releaseFlush.countDown();
+        try {
+            connection.handle(FixedLimit.create());
+
+            assertThat("Forced close interrupt was cleared before the direct error response flush",
+                       writer.interrupted,
+                       is(true));
+        } finally {
+            Thread.interrupted();
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -143,6 +143,9 @@ class Http1ConnectionTest {
             assertThat("Direct error response did not reach the final flush",
                        writer.flushStarted.await(10, TimeUnit.SECONDS),
                        is(true));
+            assertThat("Direct error response was not queued before the final flush",
+                       writer.writeCalled.getCount(),
+                       is(0L));
             assertThat("Connection returned before the direct error response was flushed",
                        connectionTask.isDone(),
                        is(false));
@@ -267,6 +270,7 @@ class Http1ConnectionTest {
     }
 
     private static final class BlockingDataWriter implements DataWriter {
+        private final CountDownLatch writeCalled = new CountDownLatch(1);
         private final CountDownLatch flushStarted = new CountDownLatch(1);
         private final CountDownLatch releaseFlush = new CountDownLatch(1);
         private volatile boolean interrupted;
@@ -277,6 +281,7 @@ class Http1ConnectionTest {
 
         @Override
         public void write(BufferData buffer) {
+            writeCalled.countDown();
         }
 
         @Override

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -43,6 +43,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
@@ -159,7 +160,7 @@ class Http1ConnectionTest {
     }
 
     @Test
-    void forcedCloseInterruptReachesDirectErrorFlush() throws InterruptedException {
+    void forcedCloseInterruptSkipsDirectErrorFlush() {
         byte[] requestBytes = ("""
                 POST / HTTP/1.1\r
                 Host: localhost\r
@@ -183,11 +184,18 @@ class Http1ConnectionTest {
         connectionRef.set(connection);
         writer.releaseFlush.countDown();
         try {
-            connection.handle(FixedLimit.create());
+            CloseConnectionException exception = assertThrows(CloseConnectionException.class,
+                                                              () -> connection.handle(FixedLimit.create()));
 
-            assertThat("Forced close interrupt was cleared before the direct error response flush",
-                       writer.interrupted,
-                       is(true));
+            assertAll(
+                    () -> assertThat(exception.getCause(), instanceOf(InterruptedException.class)),
+                    () -> assertThat("Forced close interrupt was cleared",
+                                     Thread.currentThread().isInterrupted(),
+                                     is(true)),
+                    () -> assertThat("Forced close reached the direct error response flush",
+                                     writer.flushStarted.getCount(),
+                                     is(1L))
+            );
         } finally {
             Thread.interrupted();
         }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -118,6 +118,43 @@ class Http1ConnectionTest {
     }
 
     @Test
+    void directErrorResponseFlushesBeforeConnectionReturns() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        BlockingDataWriter writer = new BlockingDataWriter();
+        DirectHandlers directHandlers = DirectHandlers.builder()
+                .addHandler(DirectHandler.EventType.OTHER,
+                            (_, _, _, _, _) -> DirectHandler.TransportResponse.builder()
+                                    .status(Status.SERVICE_UNAVAILABLE_503)
+                                    .entity("error")
+                                    .build())
+                .build();
+        Limit limit = mock(Limit.class);
+        when(limit.tryAcquireOutcome(true)).thenReturn(LimitAlgorithm.Outcome.immediateRejection("test", "test"));
+        Http1Connection connection = createConnection(DataReader.create(() -> CONNECTION_CLOSE_REQUEST),
+                                                      writer,
+                                                      directHandlers,
+                                                      Router.empty());
+        try {
+            Future<?> connectionTask = executor.submit(() -> {
+                connection.handle(limit);
+                return null;
+            });
+
+            assertThat("Direct error response did not reach the final flush",
+                       writer.flushStarted.await(10, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("Connection returned before the direct error response was flushed",
+                       connectionTask.isDone(),
+                       is(false));
+            writer.releaseFlush.countDown();
+            connectionTask.get(2, TimeUnit.SECONDS);
+        } finally {
+            writer.releaseFlush.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void continueImmediatelyWrapsSocketWriterExceptionFromSmartWriter() {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         SocketWriter writer = smartFailingWriter(executor);


### PR DESCRIPTION
Resolves #12428

Flush direct HTTP/1 error responses before connection shutdown so queued buffers are sent. Add deterministic regression coverage for the response-drain ordering.
