### PR TITLE
Annotate Builder APIs with API stability (27.x)

### DIFF
--- a/builder/api/pom.xml
+++ b/builder/api/pom.xml
@@ -38,4 +38,34 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/builder/api/src/main/java/io/helidon/builder/api/BuilderSupport.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/BuilderSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.HelidonServiceLoader;
  * This only contains methods that can be used without additional dependencies (i.e. {@link java.util.ServiceLoader} based).
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@Api.Stable
 public final class BuilderSupport {
     private BuilderSupport() {
     }

--- a/builder/api/src/main/java/io/helidon/builder/api/Description.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.helidon.common.Api;
+
 /**
  * Custom description. The description is copied from javadoc by default.
  * Use this annotation to customize the description, or when the javadoc is not available within
@@ -30,6 +32,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Inherited
 @Retention(RetentionPolicy.CLASS)
+@Api.Stable
 public @interface Description {
     /**
      * Custom description.

--- a/builder/api/src/main/java/io/helidon/builder/api/GeneratedBuilder.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/GeneratedBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@ package io.helidon.builder.api;
 import java.util.Arrays;
 import java.util.Optional;
 
+import io.helidon.common.Api;
+
 /**
  * Types used from generated code.
  */
+@Api.Stable
 public final class GeneratedBuilder {
     private GeneratedBuilder() {
     }

--- a/builder/api/src/main/java/io/helidon/builder/api/Option.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Option.java
@@ -28,6 +28,7 @@ import io.helidon.common.Api;
 /**
  * Prototype option annotations.
  */
+@Api.Stable
 public final class Option {
     private Option() {
     }

--- a/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/Prototype.java
@@ -25,10 +25,13 @@ import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Set;
 
+import io.helidon.common.Api;
+
 /**
  * Prototype is generated from a prototype blueprint, and it is expected to be part of the public API of the module.
  * This class holds all types related to generating prototypes form a blueprint.
  */
+@Api.Stable
 public final class Prototype {
     private Prototype() {
     }
@@ -529,6 +532,7 @@ public final class Prototype {
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.CLASS)
     @Repeatable(Extensions.class)
+    @io.helidon.common.Api.Incubating
     public @interface Extension {
         /**
          * Type the extension supports, see documentation of appropriate extension.
@@ -544,6 +548,7 @@ public final class Prototype {
      */
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.CLASS)
+    @io.helidon.common.Api.Incubating
     public @interface Extensions {
         /**
          * Extensions to use.

--- a/builder/api/src/main/java/io/helidon/builder/api/RuntimeType.java
+++ b/builder/api/src/main/java/io/helidon/builder/api/RuntimeType.java
@@ -16,9 +16,12 @@
 
 package io.helidon.builder.api;
 
+import io.helidon.common.Api;
+
 /**
  * This class holds all types related to runtime types, configured from prototypes.
  */
+@Api.Stable
 public final class RuntimeType {
     private RuntimeType() {
     }

--- a/builder/codegen-jackson/pom.xml
+++ b/builder/codegen-jackson/pom.xml
@@ -33,6 +33,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>
@@ -54,4 +59,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/builder/codegen-jackson/src/main/java/io/helidon/builder/codegen/jackson/JacksonBuilderExtensionProvider.java
+++ b/builder/codegen-jackson/src/main/java/io/helidon/builder/codegen/jackson/JacksonBuilderExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@ package io.helidon.builder.codegen.jackson;
 
 import io.helidon.builder.codegen.spi.BuilderCodegenExtension;
 import io.helidon.builder.codegen.spi.BuilderCodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * Java {@link java.util.ServiceLoader} provider implementation to add Jackson support to the builder code generator.
  */
+@Api.Internal
 public class JacksonBuilderExtensionProvider implements BuilderCodegenExtensionProvider {
     /**
      * Constructor required by Java {@link java.util.ServiceLoader}.

--- a/builder/codegen-jackson/src/main/java/module-info.java
+++ b/builder/codegen-jackson/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
  * </ul>
  */
 module io.helidon.builder.codegen.jackson {
+    requires static io.helidon.common;
     requires io.helidon.common.types;
     requires io.helidon.builder.codegen;
     requires io.helidon.codegen.classmodel;

--- a/builder/codegen/pom.xml
+++ b/builder/codegen/pom.xml
@@ -68,4 +68,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/BuilderCodegenProvider.java
@@ -28,6 +28,7 @@ import io.helidon.common.types.TypeName;
  * {@link java.util.ServiceLoader} provider implementation for {@link io.helidon.codegen.spi.CodegenExtensionProvider},
  * that code generates builders and implementations for blueprints.
  */
+@Api.Internal
 public class BuilderCodegenProvider implements CodegenExtensionProvider {
     /**
      * Required public constructor for {@link java.util.ServiceLoader}.

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryMethod.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryMethod.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.TypeName;
 
@@ -34,6 +35,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface FactoryMethod extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GeneratedMethod.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GeneratedMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.TypedElementInfo;
 
@@ -40,6 +41,7 @@ import io.helidon.common.types.TypedElementInfo;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface GeneratedMethod extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionAllowedValue.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionAllowedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -27,6 +28,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionAllowedValue extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.TypeName;
 
@@ -33,6 +34,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionBuilder extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionConfigured.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionConfigured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionConfigured extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionDeprecation.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionDeprecation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -28,6 +29,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionDeprecation extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionInfo.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotated;
@@ -39,6 +40,7 @@ import io.helidon.common.types.TypedElementInfo;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionInfo extends Prototype.Api, Annotated {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionMethodType.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionMethodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package io.helidon.builder.codegen;
 
+import io.helidon.common.Api;
+
 /**
  * All possible setters to be generated.
  */
+@Api.Incubating
 public enum OptionMethodType {
     /**
      * Getter added to the prototype interface. This method may not be generated if the method is inherited from a public

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionProvider.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionProvider.java
@@ -32,6 +32,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionProvider extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionSingular.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/OptionSingular.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -27,6 +28,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface OptionSingular extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeConfigured.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeConfigured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 
 /**
@@ -29,6 +30,7 @@ import io.helidon.common.types.AccessModifier;
  * @see #builder()
  * @see #create()
  */
+@Api.Incubating
 public interface PrototypeConfigured extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeConstant.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.TypeName;
 
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface PrototypeConstant extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/PrototypeInfo.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotated;
@@ -42,6 +43,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface PrototypeInfo extends Prototype.Api, Annotated {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/RuntimeTypeInfo.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/RuntimeTypeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Incubating
 public interface RuntimeTypeInfo extends Prototype.Api {
 
     /**

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/spi/BuilderCodegenExtension.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/spi/BuilderCodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,12 @@ import io.helidon.builder.codegen.PrototypeInfo;
 import io.helidon.codegen.classmodel.ClassBase;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.classmodel.Method;
+import io.helidon.common.Api;
 
 /**
  * Extension to modify the builder and prototype that is generated.
  */
+@Api.Incubating
 public interface BuilderCodegenExtension {
     /**
      * An extension can update the prototype information, add annotations to types, add custom methods etc.

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/spi/BuilderCodegenExtensionProvider.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/spi/BuilderCodegenExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 
 package io.helidon.builder.codegen.spi;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * An extension provider to modify the behavior of the builder code generator.
  */
+@Api.Incubating
 public interface BuilderCodegenExtensionProvider {
     /**
      * Whether this extension provider supports the given type, that is configured by the user in

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/FactoryMethodBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/FactoryMethodBlueprint.java
@@ -19,6 +19,7 @@ package io.helidon.builder.codegen;
 import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -27,6 +28,7 @@ import io.helidon.common.types.TypeName;
  * Such methods can be used to map from configuration to a type, or from a prototype to a
  * third party runtime-type.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface FactoryMethodBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/GeneratedMethodBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/GeneratedMethodBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypedElementInfo;
 
 /**
@@ -34,6 +35,7 @@ import io.helidon.common.types.TypedElementInfo;
  *     <li>Custom factory methods are simply referenced</li>
  * </ul>
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface GeneratedMethodBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionAllowedValueBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionAllowedValueBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package io.helidon.builder.codegen;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Option allowed value.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionAllowedValueBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionBuilderBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionBuilderBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.builder.codegen;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -26,6 +27,7 @@ import io.helidon.common.types.TypeName;
  * The type must have a {@code builder} method that returns a builder type.
  * The builder then must have a {@code build} method that returns the option type, or a {@code buildPrototype} method.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionBuilderBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionConfiguredBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionConfiguredBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Setup of configured option.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionConfiguredBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionDeprecationBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionDeprecationBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Deprecated option information.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionDeprecationBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionInfoBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionInfoBlueprint.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotated;
 import io.helidon.common.types.Annotation;
@@ -33,6 +34,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Model of a prototype/builder option.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionInfoBlueprint extends Annotated {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionProviderBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionProviderBlueprint.java
@@ -24,6 +24,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Definition of an option that is a provider (i.e. loaded through registry or service loader).
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionProviderBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionSingularBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/OptionSingularBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package io.helidon.builder.codegen;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Definition of a singular option.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface OptionSingularBlueprint {
 

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeConfiguredBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeConfiguredBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ import java.util.Optional;
 
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 
 /**
  * Configuration information for a prototype.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface PrototypeConfiguredBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeConstantBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeConstantBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,13 @@ import java.util.function.Consumer;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.ContentBuilder;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * Custom constant definition. This constant will be code generated on the prototype interface.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface PrototypeConstantBlueprint {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeInfoBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/PrototypeInfoBlueprint.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.classmodel.Javadoc;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotated;
 import io.helidon.common.types.TypeInfo;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Information about the prototype we are going to build.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface PrototypeInfoBlueprint extends Annotated {
     /**

--- a/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/RuntimeTypeInfoBlueprint.java
+++ b/builder/tests/builder-codegen/src/main/java/io/helidon/builder/codegen/RuntimeTypeInfoBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ package io.helidon.builder.codegen;
 import java.util.Optional;
 
 import io.helidon.builder.api.Prototype;
+import io.helidon.common.Api;
 
 /**
  * Configuration specific to a factory method to create a runtime type from a prototype with a builder.
  */
+@Api.Incubating
 @Prototype.Blueprint(detach = true)
 interface RuntimeTypeInfoBlueprint {
     /**

--- a/docs/modules/builder.md
+++ b/docs/modules/builder.md
@@ -380,7 +380,7 @@ Annotations:
 | `Prototype.BuilderMethod`                                  | No       | Annotation to be placed on factory methods that are to be added to builder, first parameter is the `BuilderBase<?, ?>` of the prototype                                                                                       |
 | `Prototype.PrototypeMethod`                                | No       | Annotation to be placed on factory methods that are to be added to prototype, first parameter is the prototype instance                                                                                                       |
 | `Prototype.IncludeDefaultMethods`                          | No       | Add default methods on the blueprint (or a super interface) as option methods, allows list of method names to include (if annotation is present and the list is empty, all default getter methods will be considered options) |
-| `Prototype.Extension`                                      | No       | Allows registering of extensions to enhance the generated type (such as for JSON serialization and deserialization)                                                                                                           |
+| `Prototype.Extension`                                      | No       | Incubating API. Allows registering of extensions to enhance the generated type (such as for JSON serialization and deserialization)                                                                                           |
 <!--@mdc :: -->
 
 Interfaces:


### PR DESCRIPTION
Part of #11500

Annotates the public Builder API as stable, keeps the Builder extension and builder-codegen SPI/model surface incubating, and marks codegen service-provider implementations as internal.

Enables API-stability enforcement during normal compilation of deployed Builder modules and keeps generated codegen model sources synchronized with their blueprints. The Builder guide identifies the extension hook as incubating.
