### PR TITLE
Avoid service-factory activation and registry-shutdown lock inversion (27.x)

### DIFF
--- a/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/GaugeHandler.java
+++ b/declarative/codegen/src/main/java/io/helidon/declarative/codegen/metrics/GaugeHandler.java
@@ -103,10 +103,8 @@ class GaugeHandler {
                 .name("preDestroy")
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE);
 
-        preDestroy.addContentLine("var meters = meterRegistrySupplier.get();");
-
         for (int i = 0; i < gaugeCount; i++) {
-            preDestroy.addContent("meters.remove(this.gauge_")
+            preDestroy.addContent("meterRegistry.remove(this.gauge_")
                     .addContent(String.valueOf(i))
                     .addContentLine(");");
         }
@@ -121,7 +119,8 @@ class GaugeHandler {
                 .name("postConstruct")
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE);
 
-        postConstruct.addContentLine("var meters = meterRegistrySupplier.get();")
+        postConstruct.addContentLine("this.meterRegistry = meterRegistrySupplier.get();")
+                .addContentLine("var meters = this.meterRegistry;")
                 .addContentLine("var metricsFactory = meters.metricsFactory();")
                 .addContentLine();
 
@@ -190,6 +189,12 @@ class GaugeHandler {
                         .isFinal(true)
                         .name("meterRegistrySupplier")
                         .type(meterRegistrySupplierType));
+
+        // PreDestroy must not perform service lookups, so retain the meter registry resolved during PostConstruct.
+        classModel.addField(meterRegistry -> meterRegistry
+                .accessModifier(AccessModifier.PRIVATE)
+                .type(METER_REGISTRY)
+                .name("meterRegistry"));
 
         for (int i = 0; i < gaugesCount; i++) {
             final int index = i;

--- a/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/metrics/MetricsRegistryFactoryCodegenTest.java
+++ b/declarative/tests/codegen/src/test/java/io/helidon/declarative/codegen/metrics/MetricsRegistryFactoryCodegenTest.java
@@ -101,6 +101,9 @@ class MetricsRegistryFactoryCodegenTest {
         assertThat(timed, containsString("var metricsFactory = meterRegistry.metricsFactory();"));
         assertThat(timed, not(containsString("MetricsFactory metricsFactory")));
         assertThat(gauge, containsString("var metricsFactory = meters.metricsFactory();"));
+        assertThat(gauge, containsString("this.meterRegistry = meterRegistrySupplier.get();"));
+        assertThat(gauge, containsString("meterRegistry.remove(this.gauge_0);"));
+        assertThat(gauge, not(containsString("void preDestroy() {\n        var meters = meterRegistrySupplier.get();")));
         assertThat(gauge, not(containsString("metricsFactorySupplier")));
     }
 }

--- a/service/registry/pom.xml
+++ b/service/registry/pom.xml
@@ -76,6 +76,16 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -168,6 +168,7 @@ final class Activators {
 
         volatile ActivationPhase currentPhase = ActivationPhase.INIT;
         private boolean deactivationRequested;
+        private boolean postConstructCompleted;
         private boolean activationCleanupPending;
         private ScopedRegistryImpl scopedRegistry;
 
@@ -398,9 +399,9 @@ final class Activators {
             if (!deactivationRequested && (scopedRegistry == null || scopedRegistry.activationAllowed())) {
                 return false;
             }
-            if (currentPhase.eligibleForDeactivation()) {
-                // Activation stopped at a callback boundary. Preserve its phase so queued deactivation can clean up
-                // after the activating thread releases the instance lock, without publishing the instance.
+            if (postConstructCompleted && currentPhase.eligibleForDeactivation()) {
+                // Preserve queued cleanup only after post construct returned normally. Earlier cancellation must not
+                // invoke pre destroy on an instance whose lifecycle initialization is incomplete.
                 activationCleanupPending = true;
             } else {
                 currentPhase = ActivationPhase.DESTROYED;
@@ -468,6 +469,7 @@ final class Activators {
                     return response.build();
                 }
                 postConstruct(response);
+                postConstructCompleted = true;
                 if (activationInterrupted(response)) {
                     return response.build();
                 }

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -168,6 +168,7 @@ final class Activators {
 
         volatile ActivationPhase currentPhase = ActivationPhase.INIT;
         private boolean deactivationRequested;
+        private boolean activationCleanupPending;
         private ScopedRegistryImpl scopedRegistry;
 
         BaseActivator(ServiceProvider<T> provider, DependencyContext dependencyContext) {
@@ -261,9 +262,9 @@ final class Activators {
                 if (phase.ordinal() < ActivationPhase.ACTIVATION_FINISHING.ordinal()) {
                     deactivationRequested = true;
                 }
-                if (phase == ActivationPhase.CONSTRUCTING
+                if (!activationCleanupPending && (phase == ActivationPhase.CONSTRUCTING
                         || phase == ActivationPhase.INJECTING
-                        || phase == ActivationPhase.POST_CONSTRUCTING) {
+                        || phase == ActivationPhase.POST_CONSTRUCTING)) {
                     // A JVM shutdown hook can run while the activating thread waits for shutdown to complete. Taking the
                     // instance lock here would deadlock, so interrupt activation and let the activating thread terminate.
                     var response = ActivationResult.builder()
@@ -397,8 +398,14 @@ final class Activators {
             if (!deactivationRequested && (scopedRegistry == null || scopedRegistry.activationAllowed())) {
                 return false;
             }
-            currentPhase = ActivationPhase.DESTROYED;
-            response.finishingActivationPhase(ActivationPhase.DESTROYED)
+            if (currentPhase.eligibleForDeactivation()) {
+                // Activation stopped at a callback boundary. Preserve its phase so queued deactivation can clean up
+                // after the activating thread releases the instance lock, without publishing the instance.
+                activationCleanupPending = true;
+            } else {
+                currentPhase = ActivationPhase.DESTROYED;
+            }
+            response.finishingActivationPhase(currentPhase)
                     .success(false)
                     .error(new IllegalStateException("Activation interrupted by deactivation request"));
             return true;

--- a/service/registry/src/main/java/io/helidon/service/registry/Activators.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Activators.java
@@ -164,12 +164,19 @@ final class Activators {
         final DependencyContext dependencyContext;
 
         private final ReadWriteLock instanceLock = new ReentrantReadWriteLock();
+        private final ReentrantLock phaseLock = new ReentrantLock();
 
         volatile ActivationPhase currentPhase = ActivationPhase.INIT;
+        private boolean deactivationRequested;
+        private ScopedRegistryImpl scopedRegistry;
 
         BaseActivator(ServiceProvider<T> provider, DependencyContext dependencyContext) {
             this.provider = provider;
             this.dependencyContext = dependencyContext;
+        }
+
+        void scopedRegistry(ScopedRegistryImpl scopedRegistry) {
+            this.scopedRegistry = scopedRegistry;
         }
 
         // three states
@@ -248,25 +255,32 @@ final class Activators {
 
         @Override
         public ActivationResult deactivate() {
-            if (currentPhase == ActivationPhase.CONSTRUCTING
-                    || currentPhase == ActivationPhase.INJECTING
-                    || currentPhase == ActivationPhase.POST_CONSTRUCTING) {
-                // shutdown/deactivation was called as part of (while) activating this instance
-                // we must resolve this gracefully (as the next lock would end up in a deadlock)
+            phaseLock.lock();
+            try {
+                ActivationPhase phase = currentPhase;
+                if (phase.ordinal() < ActivationPhase.ACTIVATION_FINISHING.ordinal()) {
+                    deactivationRequested = true;
+                }
+                if (phase == ActivationPhase.CONSTRUCTING
+                        || phase == ActivationPhase.INJECTING
+                        || phase == ActivationPhase.POST_CONSTRUCTING) {
+                    // A JVM shutdown hook can run while the activating thread waits for shutdown to complete. Taking the
+                    // instance lock here would deadlock, so interrupt activation and let the activating thread terminate.
+                    var response = ActivationResult.builder()
+                            .success(false)
+                            .startingActivationPhase(phase)
+                            .finishingActivationPhase(ActivationPhase.DESTROYED)
+                            .targetActivationPhase(ActivationPhase.DESTROYED)
+                            .error(new IllegalStateException("Deactivation request received while constructing an instance"))
+                            .build();
 
-                var response = ActivationResult.builder()
-                        .success(false)
-                        .startingActivationPhase(currentPhase)
-                        .finishingActivationPhase(ActivationPhase.DESTROYED)
-                        .targetActivationPhase(ActivationPhase.DESTROYED)
-                        .error(new IllegalStateException("Deactivation request received while constructing an instance"))
-                        .build();
+                    currentPhase = ActivationPhase.DESTROYED;
 
-                currentPhase = ActivationPhase.DESTROYED;
-
-                return response;
+                    return response;
+                }
+            } finally {
+                phaseLock.unlock();
             }
-            // probably re-entering the same lock
             instanceLock.writeLock().lock();
             try {
                 ActivationResult.Builder response = ActivationResult.builder()
@@ -354,11 +368,46 @@ final class Activators {
             this.currentPhase = phase;
         }
 
+        private boolean activationStateTransitionStart(ActivationResult.Builder response, ActivationPhase phase) {
+            phaseLock.lock();
+            try {
+                if (activationInterruptedLocked(response)) {
+                    return false;
+                }
+                stateTransitionStart(response, phase);
+                return true;
+            } finally {
+                phaseLock.unlock();
+            }
+        }
+
+        private boolean activationInterrupted(ActivationResult.Builder response) {
+            phaseLock.lock();
+            try {
+                return activationInterruptedLocked(response);
+            } finally {
+                phaseLock.unlock();
+            }
+        }
+
+        private boolean activationInterruptedLocked(ActivationResult.Builder response) {
+            if (currentPhase == ActivationPhase.ACTIVE) {
+                return false;
+            }
+            if (!deactivationRequested && (scopedRegistry == null || scopedRegistry.activationAllowed())) {
+                return false;
+            }
+            currentPhase = ActivationPhase.DESTROYED;
+            response.finishingActivationPhase(ActivationPhase.DESTROYED)
+                    .success(false)
+                    .error(new IllegalStateException("Activation interrupted by deactivation request"));
+            return true;
+        }
+
         private ActivationResult doActivate(ActivationRequest request) {
             ActivationPhase initialPhase = this.currentPhase;
             ActivationPhase startingPhase = request.startingPhase().orElse(initialPhase);
             ActivationPhase targetPhase = request.targetPhase();
-            this.currentPhase = startingPhase;
             ActivationPhase finishingPhase = startingPhase;
 
             ActivationResult.Builder response = ActivationResult.builder()
@@ -367,46 +416,74 @@ final class Activators {
                     .targetActivationPhase(targetPhase)
                     .success(true);
 
+            if (!activationStateTransitionStart(response, startingPhase)) {
+                return response.build();
+            }
+
             if (targetPhase.ordinal() > ActivationPhase.ACTIVATION_STARTING.ordinal()
                     && initialPhase == ActivationPhase.INIT) {
                 if (ActivationPhase.INIT == startingPhase
                         || ActivationPhase.ACTIVATION_STARTING == startingPhase
                         || ActivationPhase.DESTROYED == startingPhase) {
-                    stateTransitionStart(response, ActivationPhase.ACTIVATION_STARTING);
+                    if (!activationStateTransitionStart(response, ActivationPhase.ACTIVATION_STARTING)) {
+                        return response.build();
+                    }
                 }
             }
 
             finishingPhase = response.finishingActivationPhase().orElse(finishingPhase);
             if (response.targetActivationPhase().ordinal() >= ActivationPhase.CONSTRUCTING.ordinal()) {
-                stateTransitionStart(response, ActivationPhase.CONSTRUCTING);
+                if (!activationStateTransitionStart(response, ActivationPhase.CONSTRUCTING)) {
+                    return response.build();
+                }
                 construct(response);
+                if (activationInterrupted(response)) {
+                    return response.build();
+                }
             }
 
             finishingPhase = response.finishingActivationPhase().orElse(finishingPhase);
             if (response.targetActivationPhase().ordinal() >= ActivationPhase.INJECTING.ordinal()
                     && (ActivationPhase.CONSTRUCTING == finishingPhase)) {
-                stateTransitionStart(response, ActivationPhase.INJECTING);
+                if (!activationStateTransitionStart(response, ActivationPhase.INJECTING)) {
+                    return response.build();
+                }
                 inject(response);
+                if (activationInterrupted(response)) {
+                    return response.build();
+                }
             }
 
             finishingPhase = response.finishingActivationPhase().orElse(finishingPhase);
             if (response.targetActivationPhase().ordinal() >= ActivationPhase.POST_CONSTRUCTING.ordinal()
                     && (ActivationPhase.INJECTING == finishingPhase)) {
-                stateTransitionStart(response, ActivationPhase.POST_CONSTRUCTING);
+                if (!activationStateTransitionStart(response, ActivationPhase.POST_CONSTRUCTING)) {
+                    return response.build();
+                }
                 postConstruct(response);
+                if (activationInterrupted(response)) {
+                    return response.build();
+                }
             }
             finishingPhase = response.finishingActivationPhase().orElse(finishingPhase);
             if (response.targetActivationPhase().ordinal() >= ActivationPhase.ACTIVATION_FINISHING.ordinal()
                     && (ActivationPhase.POST_CONSTRUCTING == finishingPhase)) {
-                stateTransitionStart(response, ActivationPhase.ACTIVATION_FINISHING);
+                if (!activationStateTransitionStart(response, ActivationPhase.ACTIVATION_FINISHING)) {
+                    return response.build();
+                }
                 finishActivation(response);
             }
             finishingPhase = response.finishingActivationPhase().orElse(finishingPhase);
             if (response.targetActivationPhase().ordinal() >= ActivationPhase.ACTIVE.ordinal()
                     && (ActivationPhase.ACTIVATION_FINISHING == finishingPhase)) {
-                stateTransitionStart(response, ActivationPhase.ACTIVE);
+                if (!activationStateTransitionStart(response, ActivationPhase.ACTIVE)) {
+                    return response.build();
+                }
             }
 
+            if (activationInterrupted(response)) {
+                return response.build();
+            }
             if (startingPhase.ordinal() < ActivationPhase.CONSTRUCTING.ordinal()
                     && currentPhase.ordinal() >= ActivationPhase.CONSTRUCTING.ordinal()) {
                 setTargetInstances();

--- a/service/registry/src/main/java/io/helidon/service/registry/Scope.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ package io.helidon.service.registry;
 public interface Scope extends AutoCloseable {
     /**
      * Stop the scope, and destroy all service instances created within it.
+     * <p>
+     * This method must not be invoked concurrently on the same scope instance.
      */
     @Override
     void close();

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistry.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ public interface ScopedRegistry {
     void activate();
 
     /**
-     * Deactivate this registry instance. This method will deactivate all active instances
+     * Deactivate this registry instance. This method will deactivate all active instances.
+     * <p>
+     * This method must not be invoked concurrently on the same registry instance.
      *
      * @throws io.helidon.service.registry.ServiceRegistryException in case one or more services failed to deactivate
      */

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -44,6 +44,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
 
     private final TypeName scope;
     private final String id;
+    private volatile boolean activationAllowed;
     private RegistryState state = RegistryState.INACTIVE;
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -62,7 +63,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
             Object value = entry.getValue();
             Activator<?> fixedService;
 
-            fixedService = Activators.createActive(provider, value);
+            fixedService = scopedActivator(Activators.createActive(provider, value));
 
             activators.put(key, fixedService);
         }
@@ -76,6 +77,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
         try {
             serviceProvidersLock.writeLock().lock();
             state = RegistryState.ACTIVE;
+            activationAllowed = true;
         } finally {
             serviceProvidersLock.writeLock().unlock();
         }
@@ -90,6 +92,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
                 return;
             }
 
+            activationAllowed = false;
             state = RegistryState.DEACTIVATING;
             // Include INIT activators that may already have been handed to a lookup before this snapshot.
             toShutdown = activators.values()
@@ -165,7 +168,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
             serviceProvidersLock.writeLock().lock();
             checkActive();
             return (Activator<T>) activators.computeIfAbsent(descriptor,
-                                                             desc -> activatorSupplier.get());
+                                                             _ -> scopedActivator(activatorSupplier.get()));
         } finally {
             serviceProvidersLock.writeLock().unlock();
         }
@@ -197,6 +200,17 @@ class ScopedRegistryImpl implements ScopedRegistry {
         if (state != RegistryState.ACTIVE) {
             throw new ScopeNotActiveException("Injection scope " + scope.fqName() + "[" + id + "] is not active.", scope);
         }
+    }
+
+    private Activator<?> scopedActivator(Activator<?> activator) {
+        if (activator instanceof Activators.BaseActivator<?> baseActivator) {
+            baseActivator.scopedRegistry(this);
+        }
+        return activator;
+    }
+
+    boolean activationAllowed() {
+        return activationAllowed;
     }
 
     private boolean availableForActiveLookup(Activator<?> activator) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -91,9 +91,10 @@ class ScopedRegistryImpl implements ScopedRegistry {
             }
 
             state = RegistryState.DEACTIVATING;
+            // Include INIT activators that may already have been handed to a lookup before this snapshot.
             toShutdown = activators.values()
                     .stream()
-                    .filter(it -> it.phase().eligibleForDeactivation())
+                    .filter(it -> it.phase() != ActivationPhase.DESTROYED)
                     .sorted(shutdownComparator())
                     .toList();
         } finally {
@@ -151,7 +152,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
         try {
             serviceProvidersLock.readLock().lock();
             Activator<?> activator = activators.get(descriptor);
-            if (activator != null && state != RegistryState.INACTIVE) {
+            if (activator != null && availableForLookup(activator)) {
                 return (Activator<T>) activator;
             }
             checkActive();
@@ -175,7 +176,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
         try {
             serviceProvidersLock.readLock().lock();
             Activator<?> activator = activators.get(descriptor);
-            if (activator != null && state != RegistryState.INACTIVE) {
+            if (activator != null && availableForLookup(activator)) {
                 return Optional.of((Activator<T>) activator);
             }
             checkActive();
@@ -196,6 +197,11 @@ class ScopedRegistryImpl implements ScopedRegistry {
         if (state != RegistryState.ACTIVE) {
             throw new ScopeNotActiveException("Injection scope " + scope.fqName() + "[" + id + "] is not active.", scope);
         }
+    }
+
+    private boolean availableForLookup(Activator<?> activator) {
+        return state == RegistryState.ACTIVE
+                || (state == RegistryState.DEACTIVATING && activator.phase() == ActivationPhase.ACTIVE);
     }
 
     private enum RegistryState {

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -189,6 +189,10 @@ class ScopedRegistryImpl implements ScopedRegistry {
         }
     }
 
+    boolean activationAllowed() {
+        return activationAllowed;
+    }
+
     private static Comparator<? super Activator<?>> shutdownComparator() {
         return Comparator
                 .<Activator<?>>comparingDouble(it -> it.descriptor().runLevel().orElse(Service.RunLevel.NORMAL))
@@ -207,10 +211,6 @@ class ScopedRegistryImpl implements ScopedRegistry {
             baseActivator.scopedRegistry(this);
         }
         return activator;
-    }
-
-    boolean activationAllowed() {
-        return activationAllowed;
     }
 
     private boolean availableForActiveLookup(Activator<?> activator) {

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -151,11 +151,11 @@ class ScopedRegistryImpl implements ScopedRegistry {
     public <T> Activator<T> activator(ServiceInfo descriptor, Supplier<Activator<T>> activatorSupplier) {
         try {
             serviceProvidersLock.readLock().lock();
+            checkActive();
             Activator<?> activator = activators.get(descriptor);
-            if (activator != null && availableForLookup(activator)) {
+            if (activator != null) {
                 return (Activator<T>) activator;
             }
-            checkActive();
         } finally {
             serviceProvidersLock.readLock().unlock();
         }
@@ -176,7 +176,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
         try {
             serviceProvidersLock.readLock().lock();
             Activator<?> activator = activators.get(descriptor);
-            if (activator != null && availableForLookup(activator)) {
+            if (activator != null && availableForActiveLookup(activator)) {
                 return Optional.of((Activator<T>) activator);
             }
             checkActive();
@@ -199,7 +199,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
         }
     }
 
-    private boolean availableForLookup(Activator<?> activator) {
+    private boolean availableForActiveLookup(Activator<?> activator) {
         return state == RegistryState.ACTIVE
                 || (state == RegistryState.DEACTIVATING && activator.phase() == ActivationPhase.ACTIVE);
     }

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -44,7 +44,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
 
     private final TypeName scope;
     private final String id;
-    private boolean active = false;
+    private RegistryState state = RegistryState.INACTIVE;
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     ScopedRegistryImpl(CoreServiceRegistry registry,
@@ -73,7 +73,7 @@ class ScopedRegistryImpl implements ScopedRegistry {
      * at the time the scope is active and instances can be created within it.
      */
     public void activate() {
-        active = true;
+        state = RegistryState.ACTIVE;
     }
 
     @Override
@@ -81,11 +81,11 @@ class ScopedRegistryImpl implements ScopedRegistry {
         List<Activator<?>> toShutdown;
         try {
             serviceProvidersLock.writeLock().lock();
-            if (!active) {
+            if (state != RegistryState.ACTIVE) {
                 return;
             }
 
-            active = false;
+            state = RegistryState.DEACTIVATING;
             toShutdown = activators.values()
                     .stream()
                     .filter(it -> it.phase().eligibleForDeactivation())
@@ -95,31 +95,40 @@ class ScopedRegistryImpl implements ScopedRegistry {
             serviceProvidersLock.writeLock().unlock();
         }
 
-        // Deactivation may invoke user lifecycle code and wait for activator instance locks. The scope must already be
-        // inactive, and its lock must not be held while that code runs.
+        // Deactivation may invoke user lifecycle code and wait for activator instance locks. The scope must already
+        // reject new activators, and its lock must not be held while that code runs.
         List<Throwable> exceptions = new ArrayList<>();
 
-        for (Activator<?> managedService : toShutdown) {
-            try {
-                ActivationResult activationResult = managedService.deactivate();
-                if (activationResult.failure() && LOGGER.isLoggable(Level.DEBUG)) {
-                    if (activationResult.error().isPresent()) {
-                        LOGGER.log(Level.DEBUG,
-                                   "[" + id + "] Failed to deactivate " + managedService.description(),
-                                   activationResult.error().get());
-                        exceptions.add(activationResult.error().get());
-                    } else {
-                        LOGGER.log(Level.DEBUG,
-                                   "[" + id + "] Failed to deactivate " + managedService.description());
-                        exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description()
-                                                                            + ", no exception received."));
+        try {
+            for (Activator<?> managedService : toShutdown) {
+                try {
+                    ActivationResult activationResult = managedService.deactivate();
+                    if (activationResult.failure() && LOGGER.isLoggable(Level.DEBUG)) {
+                        if (activationResult.error().isPresent()) {
+                            LOGGER.log(Level.DEBUG,
+                                       "[" + id + "] Failed to deactivate " + managedService.description(),
+                                       activationResult.error().get());
+                            exceptions.add(activationResult.error().get());
+                        } else {
+                            LOGGER.log(Level.DEBUG,
+                                       "[" + id + "] Failed to deactivate " + managedService.description());
+                            exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description()
+                                                                                + ", no exception received."));
+                        }
                     }
+                } catch (Exception e) {
+                    if (LOGGER.isLoggable(Level.DEBUG)) {
+                        LOGGER.log(Level.DEBUG, "[" + id + "] Failed to deactivate service provider: " + managedService, e);
+                    }
+                    exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description(), e));
                 }
-            } catch (Exception e) {
-                if (LOGGER.isLoggable(Level.DEBUG)) {
-                    LOGGER.log(Level.DEBUG, "[" + id + "] Failed to deactivate service provider: " + managedService, e);
-                }
-                exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description(), e));
+            }
+        } finally {
+            try {
+                serviceProvidersLock.writeLock().lock();
+                state = RegistryState.INACTIVE;
+            } finally {
+                serviceProvidersLock.writeLock().unlock();
             }
         }
 
@@ -136,11 +145,11 @@ class ScopedRegistryImpl implements ScopedRegistry {
     public <T> Activator<T> activator(ServiceInfo descriptor, Supplier<Activator<T>> activatorSupplier) {
         try {
             serviceProvidersLock.readLock().lock();
-            checkActive();
             Activator<?> activator = activators.get(descriptor);
-            if (activator != null) {
+            if (activator != null && state != RegistryState.INACTIVE) {
                 return (Activator<T>) activator;
             }
+            checkActive();
         } finally {
             serviceProvidersLock.readLock().unlock();
         }
@@ -160,8 +169,12 @@ class ScopedRegistryImpl implements ScopedRegistry {
     <T> Optional<Activator<T>> existingActivator(ServiceInfo descriptor) {
         try {
             serviceProvidersLock.readLock().lock();
+            Activator<?> activator = activators.get(descriptor);
+            if (activator != null && state != RegistryState.INACTIVE) {
+                return Optional.of((Activator<T>) activator);
+            }
             checkActive();
-            return Optional.ofNullable((Activator<T>) activators.get(descriptor));
+            return Optional.empty();
         } finally {
             serviceProvidersLock.readLock().unlock();
         }
@@ -175,8 +188,14 @@ class ScopedRegistryImpl implements ScopedRegistry {
     }
 
     private void checkActive() {
-        if (!active) {
+        if (state != RegistryState.ACTIVE) {
             throw new ScopeNotActiveException("Injection scope " + scope.fqName() + "[" + id + "] is not active.", scope);
         }
+    }
+
+    private enum RegistryState {
+        ACTIVE,
+        DEACTIVATING,
+        INACTIVE
     }
 }

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -78,55 +78,57 @@ class ScopedRegistryImpl implements ScopedRegistry {
 
     @Override
     public void deactivate() {
+        List<Activator<?>> toShutdown;
         try {
             serviceProvidersLock.writeLock().lock();
             if (!active) {
                 return;
             }
 
-            List<Activator<?>> toShutdown = activators.values()
+            active = false;
+            toShutdown = activators.values()
                     .stream()
                     .filter(it -> it.phase().eligibleForDeactivation())
                     .sorted(shutdownComparator())
                     .toList();
-
-            List<Throwable> exceptions = new ArrayList<>();
-
-            for (Activator<?> managedService : toShutdown) {
-                try {
-                    ActivationResult activationResult = managedService.deactivate();
-                    if (activationResult.failure() && LOGGER.isLoggable(Level.DEBUG)) {
-                        if (activationResult.error().isPresent()) {
-                            LOGGER.log(Level.DEBUG,
-                                       "[" + id + "] Failed to deactivate " + managedService.description(),
-                                       activationResult.error().get());
-                            exceptions.add(activationResult.error().get());
-                        } else {
-                            LOGGER.log(Level.DEBUG,
-                                       "[" + id + "] Failed to deactivate " + managedService.description());
-                            exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description()
-                                                                                + ", no exception received."));
-                        }
-                    }
-                } catch (Exception e) {
-                    if (LOGGER.isLoggable(Level.DEBUG)) {
-                        LOGGER.log(Level.DEBUG, "[" + id + "] Failed to deactivate service provider: " + managedService, e);
-                    }
-                    exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description(), e));
-                }
-            }
-
-            active = false;
-
-            if (exceptions.isEmpty()) {
-                return;
-            }
-            ServiceRegistryException failure = new ServiceRegistryException("Deactivation failed");
-            exceptions.forEach(failure::addSuppressed);
-            throw failure;
         } finally {
             serviceProvidersLock.writeLock().unlock();
         }
+
+        // Deactivation may invoke user lifecycle code and wait for activator instance locks. The scope must already be
+        // inactive, and its lock must not be held while that code runs.
+        List<Throwable> exceptions = new ArrayList<>();
+
+        for (Activator<?> managedService : toShutdown) {
+            try {
+                ActivationResult activationResult = managedService.deactivate();
+                if (activationResult.failure() && LOGGER.isLoggable(Level.DEBUG)) {
+                    if (activationResult.error().isPresent()) {
+                        LOGGER.log(Level.DEBUG,
+                                   "[" + id + "] Failed to deactivate " + managedService.description(),
+                                   activationResult.error().get());
+                        exceptions.add(activationResult.error().get());
+                    } else {
+                        LOGGER.log(Level.DEBUG,
+                                   "[" + id + "] Failed to deactivate " + managedService.description());
+                        exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description()
+                                                                            + ", no exception received."));
+                    }
+                }
+            } catch (Exception e) {
+                if (LOGGER.isLoggable(Level.DEBUG)) {
+                    LOGGER.log(Level.DEBUG, "[" + id + "] Failed to deactivate service provider: " + managedService, e);
+                }
+                exceptions.add(new ServiceRegistryException("Failed to deactivate " + managedService.description(), e));
+            }
+        }
+
+        if (exceptions.isEmpty()) {
+            return;
+        }
+        ServiceRegistryException failure = new ServiceRegistryException("Deactivation failed");
+        exceptions.forEach(failure::addSuppressed);
+        throw failure;
     }
 
     @SuppressWarnings("unchecked")

--- a/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/ScopedRegistryImpl.java
@@ -73,7 +73,12 @@ class ScopedRegistryImpl implements ScopedRegistry {
      * at the time the scope is active and instances can be created within it.
      */
     public void activate() {
-        state = RegistryState.ACTIVE;
+        try {
+            serviceProvidersLock.writeLock().lock();
+            state = RegistryState.ACTIVE;
+        } finally {
+            serviceProvidersLock.writeLock().unlock();
+        }
     }
 
     @Override

--- a/service/registry/src/main/java/io/helidon/service/registry/Service.java
+++ b/service/registry/src/main/java/io/helidon/service/registry/Service.java
@@ -688,6 +688,8 @@ public final class Service {
 
         /**
          * De-activate the given scope.
+         * <p>
+         * This method must not be invoked concurrently for the same scope instance.
          *
          * @param scope scope to de-activate
          */

--- a/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
+++ b/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
@@ -28,6 +28,7 @@ import io.helidon.common.types.TypeName;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,7 +59,7 @@ class ScopedRegistryImplTest {
         TestActivator blocker = TestActivator.active(BLOCKING_DESCRIPTOR,
                                                       deactivationStarted,
                                                       continueDeactivation);
-        TestActivator pending = TestActivator.init(PENDING_DESCRIPTOR);
+        LifecycleActivator pending = new LifecycleActivator(PENDING_DESCRIPTOR);
         registry.activator(blocker.descriptor(), () -> blocker);
         registry.activator(pending.descriptor(), () -> pending);
 
@@ -77,6 +78,11 @@ class ScopedRegistryImplTest {
         try {
             assertThat("shutdown started", deactivationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
             assertThat("pending activator phase", pending.phase(), is(ActivationPhase.INIT));
+            ActivationResult activationResult = pending.activate(ActivationRequest.builder()
+                                                                          .targetPhase(ActivationPhase.ACTIVE)
+                                                                          .build());
+            assertThat("activation interrupted", activationResult.failure(), is(true));
+            assertThat("target instances not published", pending.targetInstancesSet(), is(false));
             assertThrows(ScopeNotActiveException.class,
                          () -> registry.activator(pending.descriptor(), () -> pending));
             assertThrows(ScopeNotActiveException.class,
@@ -92,6 +98,87 @@ class ScopedRegistryImplTest {
         assertThat("shutdown completed", shutdownThread.isAlive(), is(false));
         assertThat("shutdown failure", shutdownFailure.get(), nullValue());
         assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    @Test
+    void inProgressInitActivatorIsDestroyedDuringShutdown() throws InterruptedException {
+        CountDownLatch activationStarted = new CountDownLatch(1);
+        CountDownLatch continueActivation = new CountDownLatch(1);
+        CountDownLatch deactivationStarted = new CountDownLatch(1);
+        CountDownLatch deactivationCompleted = new CountDownLatch(1);
+        ScopedRegistryImpl registry = registry();
+        BlockingActivationActivator pending = new BlockingActivationActivator(PENDING_DESCRIPTOR,
+                                                                                activationStarted,
+                                                                                continueActivation,
+                                                                                deactivationStarted);
+        registry.activator(pending.descriptor(), () -> pending);
+
+        AtomicReference<ActivationResult> activationResult = new AtomicReference<>();
+        AtomicReference<Throwable> activationFailure = new AtomicReference<>();
+        Thread activationThread = Thread.ofVirtual()
+                .name("service-activation")
+                .unstarted(() -> {
+                    try {
+                        activationResult.set(pending.activate(ActivationRequest.builder()
+                                                                        .targetPhase(ActivationPhase.ACTIVE)
+                                                                        .build()));
+                    } catch (Throwable t) {
+                        activationFailure.set(t);
+                    }
+                });
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        Thread shutdownThread = Thread.ofVirtual()
+                .name("scoped-registry-shutdown")
+                .unstarted(() -> {
+                    try {
+                        registry.deactivate();
+                    } catch (Throwable t) {
+                        shutdownFailure.set(t);
+                    } finally {
+                        deactivationCompleted.countDown();
+                    }
+                });
+
+        activationThread.start();
+        try {
+            assertThat("activation started", activationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            assertThat("activator phase", pending.phase(), is(ActivationPhase.POST_CONSTRUCTING));
+            shutdownThread.start();
+            assertThat("deactivation started", deactivationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            assertThat("shutdown completed during activation",
+                       deactivationCompleted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                       is(true));
+            assertThat("activator phase during shutdown", pending.phase(), is(ActivationPhase.DESTROYED));
+        } finally {
+            continueActivation.countDown();
+            activationThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            shutdownThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        }
+
+        assertThat("activation completed", activationThread.isAlive(), is(false));
+        assertThat("shutdown completed", shutdownThread.isAlive(), is(false));
+        assertThat("activation failure", activationFailure.get(), nullValue());
+        assertThat("activation result", activationResult.get(), notNullValue());
+        assertThat("activation interrupted", activationResult.get().failure(), is(true));
+        assertThat("shutdown failure", shutdownFailure.get(), nullValue());
+        assertThat("target instances not published", pending.targetInstancesSet(), is(false));
+        assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    @Test
+    void activeActivatorIsPreDestroyedDuringShutdown() {
+        ScopedRegistryImpl registry = registry();
+        LifecycleActivator activator = new LifecycleActivator(PENDING_DESCRIPTOR);
+        registry.activator(activator.descriptor(), () -> activator);
+        ActivationResult activationResult = activator.activate(ActivationRequest.builder()
+                                                                       .targetPhase(ActivationPhase.ACTIVE)
+                                                                       .build());
+
+        registry.deactivate();
+
+        assertThat("activation succeeded", activationResult.failure(), is(false));
+        assertThat("pre destroy invocations", activator.preDestroyInvocations(), is(1));
+        assertThat(activator.phase(), is(ActivationPhase.DESTROYED));
     }
 
     private static ScopedRegistryImpl registry() {
@@ -125,6 +212,102 @@ class ScopedRegistryImplTest {
         @Override
         public Optional<Double> runLevel() {
             return Optional.of(runLevel);
+        }
+    }
+
+    private static final class BlockingActivationActivator extends Activators.BaseActivator<Object> {
+        private final ServiceDescriptor<Object> descriptor;
+        private final CountDownLatch activationStarted;
+        private final CountDownLatch continueActivation;
+        private final CountDownLatch deactivationStarted;
+        private boolean targetInstancesSet;
+
+        private BlockingActivationActivator(ServiceDescriptor<Object> descriptor,
+                                             CountDownLatch activationStarted,
+                                             CountDownLatch continueActivation,
+                                             CountDownLatch deactivationStarted) {
+            super(null, null);
+            this.descriptor = descriptor;
+            this.activationStarted = activationStarted;
+            this.continueActivation = continueActivation;
+            this.deactivationStarted = deactivationStarted;
+        }
+
+        @Override
+        public ServiceDescriptor<Object> descriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public ActivationResult deactivate() {
+            deactivationStarted.countDown();
+            return super.deactivate();
+        }
+
+        @Override
+        public String description() {
+            return descriptor.serviceType().fqName() + ":" + phase();
+        }
+
+        @Override
+        void postConstruct(ActivationResult.Builder response) {
+            activationStarted.countDown();
+            try {
+                if (!continueActivation.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Timed out waiting to continue activation");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+        }
+
+        @Override
+        void setTargetInstances() {
+            targetInstancesSet = true;
+        }
+
+        private boolean targetInstancesSet() {
+            return targetInstancesSet;
+        }
+    }
+
+    private static final class LifecycleActivator extends Activators.BaseActivator<Object> {
+        private final ServiceDescriptor<Object> descriptor;
+        private int preDestroyInvocations;
+        private boolean targetInstancesSet;
+
+        private LifecycleActivator(ServiceDescriptor<Object> descriptor) {
+            super(null, null);
+            this.descriptor = descriptor;
+        }
+
+        @Override
+        public ServiceDescriptor<Object> descriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public String description() {
+            return descriptor.serviceType().fqName() + ":" + phase();
+        }
+
+        @Override
+        void preDestroy(ActivationResult.Builder response) {
+            preDestroyInvocations++;
+        }
+
+        @Override
+        void setTargetInstances() {
+            targetInstancesSet = true;
+        }
+
+        private int preDestroyInvocations() {
+            return preDestroyInvocations;
+        }
+
+        private boolean targetInstancesSet() {
+            return targetInstancesSet;
         }
     }
 

--- a/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
+++ b/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
@@ -162,6 +162,80 @@ class ScopedRegistryImplTest {
         assertThat("activation interrupted", activationResult.get().failure(), is(true));
         assertThat("shutdown failure", shutdownFailure.get(), nullValue());
         assertThat("target instances not published", pending.targetInstancesSet(), is(false));
+        assertThat("pre destroy skipped for interrupted callback", pending.preDestroyInvocations(), is(0));
+        assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    @Test
+    void completedPostConstructIsPreDestroyedDuringShutdown() throws InterruptedException {
+        CountDownLatch activationStarted = new CountDownLatch(1);
+        CountDownLatch continueActivation = new CountDownLatch(1);
+        CountDownLatch deactivationStarted = new CountDownLatch(1);
+        CountDownLatch continueDeactivation = new CountDownLatch(1);
+        CountDownLatch pendingDeactivationStarted = new CountDownLatch(1);
+        ScopedRegistryImpl registry = registry();
+        TestActivator blocker = TestActivator.active(BLOCKING_DESCRIPTOR,
+                                                      deactivationStarted,
+                                                      continueDeactivation);
+        BlockingActivationActivator pending = new BlockingActivationActivator(PENDING_DESCRIPTOR,
+                                                                                activationStarted,
+                                                                                continueActivation,
+                                                                                pendingDeactivationStarted);
+        registry.activator(blocker.descriptor(), () -> blocker);
+        registry.activator(pending.descriptor(), () -> pending);
+
+        AtomicReference<ActivationResult> activationResult = new AtomicReference<>();
+        AtomicReference<Throwable> activationFailure = new AtomicReference<>();
+        Thread activationThread = Thread.ofVirtual()
+                .name("service-activation")
+                .unstarted(() -> {
+                    try {
+                        activationResult.set(pending.activate(ActivationRequest.builder()
+                                                                        .targetPhase(ActivationPhase.ACTIVE)
+                                                                        .build()));
+                    } catch (Throwable t) {
+                        activationFailure.set(t);
+                    }
+                });
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        Thread shutdownThread = Thread.ofVirtual()
+                .name("scoped-registry-shutdown")
+                .unstarted(() -> {
+                    try {
+                        registry.deactivate();
+                    } catch (Throwable t) {
+                        shutdownFailure.set(t);
+                    }
+                });
+
+        activationThread.start();
+        try {
+            assertThat("activation started", activationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            shutdownThread.start();
+            assertThat("higher run-level deactivation started",
+                       deactivationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                       is(true));
+            continueActivation.countDown();
+            activationThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            assertThat("activation completed before pending deactivation", activationThread.isAlive(), is(false));
+            assertThat("pending deactivation not started", pendingDeactivationStarted.getCount(), is(1L));
+            assertThat("pre destroy waits for pending deactivation", pending.preDestroyInvocations(), is(0));
+        } finally {
+            continueActivation.countDown();
+            continueDeactivation.countDown();
+            activationThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+            shutdownThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        }
+
+        assertThat("activation completed", activationThread.isAlive(), is(false));
+        assertThat("shutdown completed", shutdownThread.isAlive(), is(false));
+        assertThat("activation failure", activationFailure.get(), nullValue());
+        assertThat("activation result", activationResult.get(), notNullValue());
+        assertThat("activation interrupted", activationResult.get().failure(), is(true));
+        assertThat("shutdown failure", shutdownFailure.get(), nullValue());
+        assertThat("target instances not published", pending.targetInstancesSet(), is(false));
+        assertThat("pending deactivation started", pendingDeactivationStarted.getCount(), is(0L));
+        assertThat("pre destroy invocations", pending.preDestroyInvocations(), is(1));
         assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
     }
 
@@ -220,6 +294,7 @@ class ScopedRegistryImplTest {
         private final CountDownLatch activationStarted;
         private final CountDownLatch continueActivation;
         private final CountDownLatch deactivationStarted;
+        private int preDestroyInvocations;
         private boolean targetInstancesSet;
 
         private BlockingActivationActivator(ServiceDescriptor<Object> descriptor,
@@ -263,8 +338,17 @@ class ScopedRegistryImplTest {
         }
 
         @Override
+        void preDestroy(ActivationResult.Builder response) {
+            preDestroyInvocations++;
+        }
+
+        @Override
         void setTargetInstances() {
             targetInstancesSet = true;
+        }
+
+        private int preDestroyInvocations() {
+            return preDestroyInvocations;
         }
 
         private boolean targetInstancesSet() {

--- a/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
+++ b/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -79,7 +80,10 @@ class ScopedRegistryImplTest {
             assertThrows(ScopeNotActiveException.class,
                          () -> registry.activator(pending.descriptor(), () -> pending));
             assertThrows(ScopeNotActiveException.class,
+                         () -> registry.activator(blocker.descriptor(), () -> blocker));
+            assertThrows(ScopeNotActiveException.class,
                          () -> registry.existingActivator(pending.descriptor()));
+            assertThat(registry.existingActivator(blocker.descriptor()).orElseThrow(), sameInstance(blocker));
         } finally {
             continueDeactivation.countDown();
             shutdownThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));

--- a/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
+++ b/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
@@ -108,9 +108,10 @@ class ScopedRegistryImplTest {
         CountDownLatch deactivationCompleted = new CountDownLatch(1);
         ScopedRegistryImpl registry = registry();
         BlockingActivationActivator pending = new BlockingActivationActivator(PENDING_DESCRIPTOR,
-                                                                                activationStarted,
-                                                                                continueActivation,
-                                                                                deactivationStarted);
+                                                                                 activationStarted,
+                                                                                 continueActivation,
+                                                                                 deactivationStarted,
+                                                                                 ActivationPhase.POST_CONSTRUCTING);
         registry.activator(pending.descriptor(), () -> pending);
 
         AtomicReference<ActivationResult> activationResult = new AtomicReference<>();
@@ -167,7 +168,39 @@ class ScopedRegistryImplTest {
     }
 
     @Test
+    void completedConstructionIsNotPreDestroyedDuringShutdown() throws InterruptedException {
+        completedCallbackIsDeactivatedDuringShutdown(ActivationPhase.CONSTRUCTING, 0);
+    }
+
+    @Test
+    void completedInjectionIsNotPreDestroyedDuringShutdown() throws InterruptedException {
+        completedCallbackIsDeactivatedDuringShutdown(ActivationPhase.INJECTING, 0);
+    }
+
+    @Test
     void completedPostConstructIsPreDestroyedDuringShutdown() throws InterruptedException {
+        completedCallbackIsDeactivatedDuringShutdown(ActivationPhase.POST_CONSTRUCTING, 1);
+    }
+
+    @Test
+    void activeActivatorIsPreDestroyedDuringShutdown() {
+        ScopedRegistryImpl registry = registry();
+        LifecycleActivator activator = new LifecycleActivator(PENDING_DESCRIPTOR);
+        registry.activator(activator.descriptor(), () -> activator);
+        ActivationResult activationResult = activator.activate(ActivationRequest.builder()
+                                                                       .targetPhase(ActivationPhase.ACTIVE)
+                                                                       .build());
+
+        registry.deactivate();
+
+        assertThat("activation succeeded", activationResult.failure(), is(false));
+        assertThat("pre destroy invocations", activator.preDestroyInvocations(), is(1));
+        assertThat(activator.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    private static void completedCallbackIsDeactivatedDuringShutdown(ActivationPhase blockedPhase,
+                                                                     int expectedLifecycleInvocations)
+            throws InterruptedException {
         CountDownLatch activationStarted = new CountDownLatch(1);
         CountDownLatch continueActivation = new CountDownLatch(1);
         CountDownLatch deactivationStarted = new CountDownLatch(1);
@@ -178,9 +211,10 @@ class ScopedRegistryImplTest {
                                                       deactivationStarted,
                                                       continueDeactivation);
         BlockingActivationActivator pending = new BlockingActivationActivator(PENDING_DESCRIPTOR,
-                                                                                activationStarted,
-                                                                                continueActivation,
-                                                                                pendingDeactivationStarted);
+                                                                                 activationStarted,
+                                                                                 continueActivation,
+                                                                                 pendingDeactivationStarted,
+                                                                                 blockedPhase);
         registry.activator(blocker.descriptor(), () -> blocker);
         registry.activator(pending.descriptor(), () -> pending);
 
@@ -211,6 +245,7 @@ class ScopedRegistryImplTest {
         activationThread.start();
         try {
             assertThat("activation started", activationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            assertThat("blocked callback phase", pending.phase(), is(blockedPhase));
             shutdownThread.start();
             assertThat("higher run-level deactivation started",
                        deactivationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
@@ -235,24 +270,9 @@ class ScopedRegistryImplTest {
         assertThat("shutdown failure", shutdownFailure.get(), nullValue());
         assertThat("target instances not published", pending.targetInstancesSet(), is(false));
         assertThat("pending deactivation started", pendingDeactivationStarted.getCount(), is(0L));
-        assertThat("pre destroy invocations", pending.preDestroyInvocations(), is(1));
+        assertThat("post construct invocations", pending.postConstructInvocations(), is(expectedLifecycleInvocations));
+        assertThat("pre destroy invocations", pending.preDestroyInvocations(), is(expectedLifecycleInvocations));
         assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
-    }
-
-    @Test
-    void activeActivatorIsPreDestroyedDuringShutdown() {
-        ScopedRegistryImpl registry = registry();
-        LifecycleActivator activator = new LifecycleActivator(PENDING_DESCRIPTOR);
-        registry.activator(activator.descriptor(), () -> activator);
-        ActivationResult activationResult = activator.activate(ActivationRequest.builder()
-                                                                       .targetPhase(ActivationPhase.ACTIVE)
-                                                                       .build());
-
-        registry.deactivate();
-
-        assertThat("activation succeeded", activationResult.failure(), is(false));
-        assertThat("pre destroy invocations", activator.preDestroyInvocations(), is(1));
-        assertThat(activator.phase(), is(ActivationPhase.DESTROYED));
     }
 
     private static ScopedRegistryImpl registry() {
@@ -294,18 +314,22 @@ class ScopedRegistryImplTest {
         private final CountDownLatch activationStarted;
         private final CountDownLatch continueActivation;
         private final CountDownLatch deactivationStarted;
+        private final ActivationPhase blockedPhase;
+        private int postConstructInvocations;
         private int preDestroyInvocations;
         private boolean targetInstancesSet;
 
         private BlockingActivationActivator(ServiceDescriptor<Object> descriptor,
                                              CountDownLatch activationStarted,
                                              CountDownLatch continueActivation,
-                                             CountDownLatch deactivationStarted) {
+                                             CountDownLatch deactivationStarted,
+                                             ActivationPhase blockedPhase) {
             super(null, null);
             this.descriptor = descriptor;
             this.activationStarted = activationStarted;
             this.continueActivation = continueActivation;
             this.deactivationStarted = deactivationStarted;
+            this.blockedPhase = blockedPhase;
         }
 
         @Override
@@ -325,16 +349,19 @@ class ScopedRegistryImplTest {
         }
 
         @Override
+        void construct(ActivationResult.Builder response) {
+            awaitCallback(ActivationPhase.CONSTRUCTING);
+        }
+
+        @Override
+        void inject(ActivationResult.Builder response) {
+            awaitCallback(ActivationPhase.INJECTING);
+        }
+
+        @Override
         void postConstruct(ActivationResult.Builder response) {
-            activationStarted.countDown();
-            try {
-                if (!continueActivation.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                    throw new AssertionError("Timed out waiting to continue activation");
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new AssertionError(e);
-            }
+            awaitCallback(ActivationPhase.POST_CONSTRUCTING);
+            postConstructInvocations++;
         }
 
         @Override
@@ -353,6 +380,25 @@ class ScopedRegistryImplTest {
 
         private boolean targetInstancesSet() {
             return targetInstancesSet;
+        }
+
+        private int postConstructInvocations() {
+            return postConstructInvocations;
+        }
+
+        private void awaitCallback(ActivationPhase phase) {
+            if (phase != blockedPhase) {
+                return;
+            }
+            activationStarted.countDown();
+            try {
+                if (!continueActivation.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Timed out waiting to continue activation");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
         }
     }
 

--- a/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
+++ b/service/registry/src/test/java/io/helidon/service/registry/ScopedRegistryImplTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.registry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScopedRegistryImplTest {
+    private static final long TIMEOUT_SECONDS = 5;
+    private static final ServiceDescriptor<Object> BLOCKING_DESCRIPTOR = new TestDescriptor("Blocking", 1);
+    private static final ServiceDescriptor<Object> PENDING_DESCRIPTOR = new TestDescriptor("Pending", 0);
+
+    @Test
+    void handedOutInitActivatorIsTerminalAfterShutdown() {
+        ScopedRegistryImpl registry = registry();
+        TestActivator pending = TestActivator.init(PENDING_DESCRIPTOR);
+        Activator<Object> handedOut = registry.activator(pending.descriptor(), () -> pending);
+
+        registry.deactivate();
+        handedOut.instances(Lookup.EMPTY);
+
+        assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    @Test
+    void initActivatorIsUnavailableDuringShutdown() throws InterruptedException {
+        CountDownLatch deactivationStarted = new CountDownLatch(1);
+        CountDownLatch continueDeactivation = new CountDownLatch(1);
+        ScopedRegistryImpl registry = registry();
+        TestActivator blocker = TestActivator.active(BLOCKING_DESCRIPTOR,
+                                                      deactivationStarted,
+                                                      continueDeactivation);
+        TestActivator pending = TestActivator.init(PENDING_DESCRIPTOR);
+        registry.activator(blocker.descriptor(), () -> blocker);
+        registry.activator(pending.descriptor(), () -> pending);
+
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+        Thread shutdownThread = Thread.ofVirtual()
+                .name("scoped-registry-shutdown")
+                .unstarted(() -> {
+                    try {
+                        registry.deactivate();
+                    } catch (Throwable t) {
+                        shutdownFailure.set(t);
+                    }
+                });
+
+        shutdownThread.start();
+        try {
+            assertThat("shutdown started", deactivationStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            assertThat("pending activator phase", pending.phase(), is(ActivationPhase.INIT));
+            assertThrows(ScopeNotActiveException.class,
+                         () -> registry.activator(pending.descriptor(), () -> pending));
+            assertThrows(ScopeNotActiveException.class,
+                         () -> registry.existingActivator(pending.descriptor()));
+        } finally {
+            continueDeactivation.countDown();
+            shutdownThread.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        }
+
+        assertThat("shutdown completed", shutdownThread.isAlive(), is(false));
+        assertThat("shutdown failure", shutdownFailure.get(), nullValue());
+        assertThat(pending.phase(), is(ActivationPhase.DESTROYED));
+    }
+
+    private static ScopedRegistryImpl registry() {
+        ScopedRegistryImpl registry = new ScopedRegistryImpl(null,
+                                                             Service.Singleton.TYPE,
+                                                             "test",
+                                                             Map.of());
+        registry.activate();
+        return registry;
+    }
+
+    private static final class TestDescriptor implements ServiceDescriptor<Object> {
+        private final TypeName typeName;
+        private final double runLevel;
+
+        private TestDescriptor(String typeName, double runLevel) {
+            this.typeName = TypeName.create(typeName);
+            this.runLevel = runLevel;
+        }
+
+        @Override
+        public TypeName serviceType() {
+            return typeName;
+        }
+
+        @Override
+        public TypeName descriptorType() {
+            return typeName;
+        }
+
+        @Override
+        public Optional<Double> runLevel() {
+            return Optional.of(runLevel);
+        }
+    }
+
+    private static final class TestActivator implements Activator<Object> {
+        private final ServiceDescriptor<Object> descriptor;
+        private final CountDownLatch deactivationStarted;
+        private final CountDownLatch continueDeactivation;
+
+        private volatile ActivationPhase phase;
+
+        private TestActivator(ServiceDescriptor<Object> descriptor,
+                              ActivationPhase phase,
+                              CountDownLatch deactivationStarted,
+                              CountDownLatch continueDeactivation) {
+            this.descriptor = descriptor;
+            this.phase = phase;
+            this.deactivationStarted = deactivationStarted;
+            this.continueDeactivation = continueDeactivation;
+        }
+
+        static TestActivator init(ServiceDescriptor<Object> descriptor) {
+            return new TestActivator(descriptor, ActivationPhase.INIT, null, null);
+        }
+
+        static TestActivator active(ServiceDescriptor<Object> descriptor,
+                                    CountDownLatch deactivationStarted,
+                                    CountDownLatch continueDeactivation) {
+            return new TestActivator(descriptor,
+                                     ActivationPhase.ACTIVE,
+                                     deactivationStarted,
+                                     continueDeactivation);
+        }
+
+        @Override
+        public ServiceDescriptor<Object> descriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public Optional<List<Service.QualifiedInstance<Object>>> instances(Lookup lookup) {
+            if (phase != ActivationPhase.DESTROYED) {
+                phase = ActivationPhase.ACTIVE;
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public ActivationResult activate(ActivationRequest activationRequest) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ActivationResult deactivate() {
+            ActivationPhase startingPhase = phase;
+            if (deactivationStarted != null) {
+                deactivationStarted.countDown();
+                try {
+                    if (!continueDeactivation.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to continue deactivation");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            phase = ActivationPhase.DESTROYED;
+            return ActivationResult.builder()
+                    .success(true)
+                    .startingActivationPhase(startingPhase)
+                    .targetActivationPhase(ActivationPhase.DESTROYED)
+                    .finishingActivationPhase(ActivationPhase.DESTROYED)
+                    .build();
+        }
+
+        @Override
+        public ActivationPhase phase() {
+            return phase;
+        }
+
+        @Override
+        public String description() {
+            return descriptor.serviceType().fqName() + ":" + phase;
+        }
+    }
+}

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
@@ -26,12 +26,14 @@ import io.helidon.service.registry.Service;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.ScopeNotActiveException;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ShutdownLockingTest {
     private static final long TIMEOUT_SECONDS = 5;
@@ -49,6 +51,7 @@ class ShutdownLockingTest {
                 .discoverServices(false)
                 .discoverServicesFromServiceLoader(false)
                 .addServiceDescriptor(ShutdownLockingTest_LookupServicesFactory__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(ShutdownLockingTest_NotYetActive__ServiceDescriptor.INSTANCE)
                 .addServiceDescriptor(ShutdownLockingTest_ShutdownSignal__ServiceDescriptor.INSTANCE)
                 .build();
         ServiceRegistryManager manager = ServiceRegistryManager.create(config);
@@ -116,11 +119,14 @@ class ShutdownLockingTest {
                 throw new AssertionError(e);
             }
 
-            assertThat("registry inactive during shutdown",
-                       registry.firstActive(ServiceRegistry.class).isEmpty(),
-                       is(true));
+            registry.firstActive(ServiceRegistry.class);
+            assertThrows(ScopeNotActiveException.class, () -> registry.get(NotYetActive.class));
             return List.of(Service.QualifiedInstance.create(new FactoryProduct() { }, Set.of()));
         }
+    }
+
+    @Service.Singleton
+    static class NotYetActive {
     }
 
     @Service.Singleton

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -43,6 +44,7 @@ class ShutdownLockingTest {
         CountDownLatch factoryEntered = new CountDownLatch(1);
         CountDownLatch continueFactory = new CountDownLatch(1);
         CountDownLatch shutdownStarted = new CountDownLatch(1);
+        CountDownLatch factoryLookupCompleted = new CountDownLatch(1);
         CountDownLatch completed = new CountDownLatch(2);
         AtomicReference<Throwable> lookupFailure = new AtomicReference<>();
         AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
@@ -51,13 +53,19 @@ class ShutdownLockingTest {
                 .discoverServices(false)
                 .discoverServicesFromServiceLoader(false)
                 .addServiceDescriptor(ShutdownLockingTest_LookupServicesFactory__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(ShutdownLockingTest_ExistingService__ServiceDescriptor.INSTANCE)
                 .addServiceDescriptor(ShutdownLockingTest_NotYetActive__ServiceDescriptor.INSTANCE)
                 .addServiceDescriptor(ShutdownLockingTest_ShutdownSignal__ServiceDescriptor.INSTANCE)
                 .build();
         ServiceRegistryManager manager = ServiceRegistryManager.create(config);
         ServiceRegistry registry = manager.registry();
-        LookupServicesFactory.prepare(registry, factoryEntered, continueFactory);
-        ShutdownSignal.prepare(shutdownStarted);
+        ExistingService existingService = registry.get(ExistingService.class);
+        LookupServicesFactory.prepare(registry,
+                                      existingService,
+                                      factoryEntered,
+                                      continueFactory,
+                                      factoryLookupCompleted);
+        ShutdownSignal.prepare(shutdownStarted, factoryLookupCompleted);
         registry.get(ShutdownSignal.class);
 
         Thread lookupThread = Thread.ofVirtual()
@@ -98,15 +106,21 @@ class ShutdownLockingTest {
     @Service.Singleton
     static class LookupServicesFactory implements Service.ServicesFactory<FactoryProduct> {
         private static volatile ServiceRegistry registry;
+        private static volatile ExistingService existingService;
         private static volatile CountDownLatch factoryEntered;
         private static volatile CountDownLatch continueFactory;
+        private static volatile CountDownLatch factoryLookupCompleted;
 
         static void prepare(ServiceRegistry registry,
+                            ExistingService existingService,
                             CountDownLatch factoryEntered,
-                            CountDownLatch continueFactory) {
+                            CountDownLatch continueFactory,
+                            CountDownLatch factoryLookupCompleted) {
             LookupServicesFactory.registry = registry;
+            LookupServicesFactory.existingService = existingService;
             LookupServicesFactory.factoryEntered = factoryEntered;
             LookupServicesFactory.continueFactory = continueFactory;
+            LookupServicesFactory.factoryLookupCompleted = factoryLookupCompleted;
         }
 
         @Override
@@ -119,10 +133,21 @@ class ShutdownLockingTest {
                 throw new AssertionError(e);
             }
 
-            registry.firstActive(ServiceRegistry.class);
-            assertThrows(ScopeNotActiveException.class, () -> registry.get(NotYetActive.class));
+            try {
+                assertThat("existing service available during shutdown",
+                           registry.firstActive(ExistingService.class).orElseThrow(),
+                           sameInstance(existingService));
+                assertThrows(ScopeNotActiveException.class, () -> registry.get(NotYetActive.class));
+            } finally {
+                factoryLookupCompleted.countDown();
+            }
             return List.of(Service.QualifiedInstance.create(new FactoryProduct() { }, Set.of()));
         }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.NORMAL - 1)
+    static class ExistingService {
     }
 
     @Service.Singleton
@@ -133,14 +158,24 @@ class ShutdownLockingTest {
     @Service.RunLevel(Service.RunLevel.NORMAL + 1)
     static class ShutdownSignal {
         private static volatile CountDownLatch shutdownStarted = new CountDownLatch(0);
+        private static volatile CountDownLatch factoryLookupCompleted = new CountDownLatch(0);
 
-        static void prepare(CountDownLatch shutdownStarted) {
+        static void prepare(CountDownLatch shutdownStarted, CountDownLatch factoryLookupCompleted) {
             ShutdownSignal.shutdownStarted = shutdownStarted;
+            ShutdownSignal.factoryLookupCompleted = factoryLookupCompleted;
         }
 
         @Service.PreDestroy
         void signalShutdown() {
             shutdownStarted.countDown();
+            try {
+                assertThat("factory lookup completed during shutdown",
+                           factoryLookupCompleted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                           is(true));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
         }
     }
 }

--- a/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
+++ b/service/tests/registry/src/test/java/io/helidon/service/test/registry/ShutdownLockingTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.service.test.registry;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ShutdownLockingTest {
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @Test
+    void factoryLookupDoesNotDeadlockWithShutdown() throws InterruptedException {
+        CountDownLatch factoryEntered = new CountDownLatch(1);
+        CountDownLatch continueFactory = new CountDownLatch(1);
+        CountDownLatch shutdownStarted = new CountDownLatch(1);
+        CountDownLatch completed = new CountDownLatch(2);
+        AtomicReference<Throwable> lookupFailure = new AtomicReference<>();
+        AtomicReference<Throwable> shutdownFailure = new AtomicReference<>();
+
+        ServiceRegistryConfig config = ServiceRegistryConfig.builder()
+                .discoverServices(false)
+                .discoverServicesFromServiceLoader(false)
+                .addServiceDescriptor(ShutdownLockingTest_LookupServicesFactory__ServiceDescriptor.INSTANCE)
+                .addServiceDescriptor(ShutdownLockingTest_ShutdownSignal__ServiceDescriptor.INSTANCE)
+                .build();
+        ServiceRegistryManager manager = ServiceRegistryManager.create(config);
+        ServiceRegistry registry = manager.registry();
+        LookupServicesFactory.prepare(registry, factoryEntered, continueFactory);
+        ShutdownSignal.prepare(shutdownStarted);
+        registry.get(ShutdownSignal.class);
+
+        Thread lookupThread = Thread.ofVirtual()
+                .name("service-factory-lookup")
+                .unstarted(() -> run(lookupFailure, completed, () -> registry.get(FactoryProduct.class)));
+        Thread shutdownThread = Thread.ofVirtual()
+                .name("service-registry-shutdown")
+                .unstarted(() -> run(shutdownFailure, completed, manager::shutdown));
+
+        lookupThread.start();
+        assertThat("factory lookup started", factoryEntered.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+        shutdownThread.start();
+        assertThat("shutdown started deactivating services",
+                   shutdownStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                   is(true));
+        continueFactory.countDown();
+
+        assertThat("factory lookup and registry shutdown completed",
+                   completed.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                   is(true));
+        assertThat("factory lookup failure", lookupFailure.get(), nullValue());
+        assertThat("registry shutdown failure", shutdownFailure.get(), nullValue());
+    }
+
+    private static void run(AtomicReference<Throwable> failure, CountDownLatch completed, Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable t) {
+            failure.set(t);
+        } finally {
+            completed.countDown();
+        }
+    }
+
+    interface FactoryProduct {
+    }
+
+    @Service.Singleton
+    static class LookupServicesFactory implements Service.ServicesFactory<FactoryProduct> {
+        private static volatile ServiceRegistry registry;
+        private static volatile CountDownLatch factoryEntered;
+        private static volatile CountDownLatch continueFactory;
+
+        static void prepare(ServiceRegistry registry,
+                            CountDownLatch factoryEntered,
+                            CountDownLatch continueFactory) {
+            LookupServicesFactory.registry = registry;
+            LookupServicesFactory.factoryEntered = factoryEntered;
+            LookupServicesFactory.continueFactory = continueFactory;
+        }
+
+        @Override
+        public List<Service.QualifiedInstance<FactoryProduct>> services() {
+            factoryEntered.countDown();
+            try {
+                assertThat("factory released", continueFactory.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+
+            assertThat("registry inactive during shutdown",
+                       registry.firstActive(ServiceRegistry.class).isEmpty(),
+                       is(true));
+            return List.of(Service.QualifiedInstance.create(new FactoryProduct() { }, Set.of()));
+        }
+    }
+
+    @Service.Singleton
+    @Service.RunLevel(Service.RunLevel.NORMAL + 1)
+    static class ShutdownSignal {
+        private static volatile CountDownLatch shutdownStarted = new CountDownLatch(0);
+
+        static void prepare(CountDownLatch shutdownStarted) {
+            ShutdownSignal.shutdownStarted = shutdownStarted;
+        }
+
+        @Service.PreDestroy
+        void signalShutdown() {
+            shutdownStarted.countDown();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #12471

Snapshot services under the scoped-registry lock, then release it before lifecycle callbacks. Preserve access to already-created services during shutdown, reject new activation, synchronize scope activation with shutdown state, document the deactivation concurrency constraint, and cover the lock inversion deterministically.