### PR TITLE
Annotate Codegen APIs with API stability (27.x)

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -25,6 +25,9 @@ This top level module contains the following modules:
 - `compiler` - wrapper around Java compiler that is running within the current VM
 - `helidon-copyright` - Helidon specific implementation of copyright handler, used by Helidon project itself to generate sources
 
+> **Note:** The Codegen SPI and class-model APIs are internal. We plan to redesign this area before exposing it as a
+> supported extension API.
+
 ## Codegen abstraction (module `helidon-codegen`)
 
 Codegen provides types that each code generation implementation can code against, without the need to hard code against

--- a/codegen/class-model/pom.xml
+++ b/codegen/class-model/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -65,5 +66,35 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Annotation.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Annotation.java
@@ -33,7 +33,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Model of the annotation.
  */
-@Api.Stable
+@Api.Internal
 public final class Annotation extends CommonComponent {
 
     private final List<AnnotationParameter> parameters;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Annotation.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Annotation.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AnnotationProperty;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Model of the annotation.
  */
+@Api.Stable
 public final class Annotation extends CommonComponent {
 
     private final List<AnnotationParameter> parameters;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/AnnotationParameter.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/AnnotationParameter.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AnnotationProperty;
 import io.helidon.common.types.AnnotationProperty.ConstantValue;
 import io.helidon.common.types.ElementKind;
@@ -30,6 +31,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Annotation parameter model.
  */
+@Api.Stable
 public final class AnnotationParameter extends CommonComponent {
 
     private final Set<TypeName> importedTypes;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/AnnotationParameter.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/AnnotationParameter.java
@@ -31,7 +31,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Annotation parameter model.
  */
-@Api.Stable
+@Api.Internal
 public final class AnnotationParameter extends CommonComponent {
 
     private final Set<TypeName> importedTypes;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassBase.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassBase.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -37,6 +38,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Abstract class type model. Contains common logic for all class related models.
  */
+@Api.Stable
 public abstract class ClassBase extends AnnotatedComponent {
 
     private final boolean isFinal;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassBase.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassBase.java
@@ -38,7 +38,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Abstract class type model. Contains common logic for all class related models.
  */
-@Api.Stable
+@Api.Internal
 public abstract class ClassBase extends AnnotatedComponent {
 
     private final boolean isFinal;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModel.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModel.java
@@ -44,7 +44,7 @@ import io.helidon.common.types.TypeName;
  *     {@link Builder#addField(Field)} to add record components, as non-static fields are not supported in records</li>
  * </ul>
  */
-@Api.Stable
+@Api.Internal
 public final class ClassModel extends ClassBase {
 
     /**

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModel.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModel.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -43,6 +44,7 @@ import io.helidon.common.types.TypeName;
  *     {@link Builder#addField(Field)} to add record components, as non-static fields are not supported in records</li>
  * </ul>
  */
+@Api.Stable
 public final class ClassModel extends ClassBase {
 
     /**

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModelException.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModelException.java
@@ -20,7 +20,7 @@ import io.helidon.common.Api;
 /**
  * Exception message which corresponds to the error in class model creation.
  */
-@Api.Stable
+@Api.Internal
 public class ClassModelException extends RuntimeException {
 
     ClassModelException(String message) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModelException.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ClassModelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package io.helidon.codegen.classmodel;
 
+import io.helidon.common.Api;
+
 /**
  * Exception message which corresponds to the error in class model creation.
  */
+@Api.Stable
 public class ClassModelException extends RuntimeException {
 
     ClassModelException(String message) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Constructor.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Constructor.java
@@ -24,7 +24,7 @@ import io.helidon.common.types.ElementKind;
 /**
  * Constructor model.
  */
-@Api.Stable
+@Api.Internal
 public final class Constructor extends Executable {
 
     private Constructor(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Constructor.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Constructor.java
@@ -17,12 +17,14 @@ package io.helidon.codegen.classmodel;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 
 /**
  * Constructor model.
  */
+@Api.Stable
 public final class Constructor extends Executable {
 
     private Constructor(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
@@ -33,7 +33,7 @@ import io.helidon.common.types.TypedElementInfo;
  * @see io.helidon.codegen.classmodel.Constructor
  * @see io.helidon.codegen.classmodel.Field
  */
-@Api.Stable
+@Api.Internal
 public interface ContentBuilder<T extends ContentBuilder<T>> {
     /**
      * Set new content.

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/ContentBuilder.java
@@ -19,6 +19,7 @@ package io.helidon.codegen.classmodel;
 import java.util.List;
 import java.util.Objects;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ResolvedType;
 import io.helidon.common.types.TypeName;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypedElementInfo;
  * @see io.helidon.codegen.classmodel.Constructor
  * @see io.helidon.codegen.classmodel.Field
  */
+@Api.Stable
 public interface ContentBuilder<T extends ContentBuilder<T>> {
     /**
      * Set new content.

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/EnumConstant.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/EnumConstant.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -28,6 +29,7 @@ import io.helidon.common.types.TypeNames;
 /**
  * Field model representation.
  */
+@Api.Stable
 public final class EnumConstant extends AnnotatedComponent {
     private final Content content;
 

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/EnumConstant.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/EnumConstant.java
@@ -29,7 +29,7 @@ import io.helidon.common.types.TypeNames;
 /**
  * Field model representation.
  */
-@Api.Stable
+@Api.Internal
 public final class EnumConstant extends AnnotatedComponent {
     private final Content content;
 

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Executable.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Executable.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Executable base, used by method and constructor.
  */
+@Api.Stable
 public abstract class Executable extends AnnotatedComponent {
 
     private final Content content;
@@ -310,4 +312,3 @@ public abstract class Executable extends AnnotatedComponent {
     }
 
 }
-

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Executable.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Executable.java
@@ -33,7 +33,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Executable base, used by method and constructor.
  */
-@Api.Stable
+@Api.Internal
 public abstract class Executable extends AnnotatedComponent {
 
     private final Content content;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -28,6 +29,7 @@ import io.helidon.common.types.TypeNames;
 /**
  * Field model representation.
  */
+@Api.Stable
 public final class Field extends AnnotatedComponent {
 
     private final Content defaultValue;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Field.java
@@ -29,7 +29,7 @@ import io.helidon.common.types.TypeNames;
 /**
  * Field model representation.
  */
-@Api.Stable
+@Api.Internal
 public final class Field extends AnnotatedComponent {
 
     private final Content defaultValue;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/InnerClass.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/InnerClass.java
@@ -20,7 +20,7 @@ import io.helidon.common.Api;
 /**
  * Inner class model.
  */
-@Api.Stable
+@Api.Internal
 public final class InnerClass extends ClassBase {
 
     //Collected directly specified imports when building this class

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/InnerClass.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/InnerClass.java
@@ -15,9 +15,12 @@
  */
 package io.helidon.codegen.classmodel;
 
+import io.helidon.common.Api;
+
 /**
  * Inner class model.
  */
+@Api.Stable
 public final class InnerClass extends ClassBase {
 
     //Collected directly specified imports when building this class

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.ElementKind;
 
 /**
@@ -40,6 +41,7 @@ import io.helidon.common.types.ElementKind;
  *     <li>everything else</li>
  * </ul>
  */
+@Api.Stable
 public final class Javadoc extends ModelComponent {
 
     private final List<String> content;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Javadoc.java
@@ -41,7 +41,7 @@ import io.helidon.common.types.ElementKind;
  *     <li>everything else</li>
  * </ul>
  */
-@Api.Stable
+@Api.Internal
 public final class Javadoc extends ModelComponent {
 
     private final List<String> content;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Method.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Method.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.Modifier;
@@ -34,6 +35,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Model of the method which should be created in the specific type.
  */
+@Api.Stable
 public final class Method extends Executable {
 
     private final Map<String, TypeArgument> declaredTokens;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Method.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Method.java
@@ -35,7 +35,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Model of the method which should be created in the specific type.
  */
-@Api.Stable
+@Api.Internal
 public final class Method extends Executable {
 
     private final Map<String, TypeArgument> declaredTokens;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
@@ -20,12 +20,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 
 /**
  * Method parameter model.
  */
+@Api.Stable
 public final class Parameter extends AnnotatedComponent {
 
     private final boolean vararg;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Parameter.java
@@ -27,7 +27,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Method parameter model.
  */
-@Api.Stable
+@Api.Internal
 public final class Parameter extends AnnotatedComponent {
 
     private final boolean vararg;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Returns.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Returns.java
@@ -18,12 +18,14 @@ package io.helidon.codegen.classmodel;
 import java.util.List;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 
 /**
  * Objects which describes return type configuration.
  */
+@Api.Stable
 public final class Returns extends DescribableComponent {
 
     private Returns(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Returns.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Returns.java
@@ -25,7 +25,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Objects which describes return type configuration.
  */
-@Api.Stable
+@Api.Internal
 public final class Returns extends DescribableComponent {
 
     private Returns(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Throws.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Throws.java
@@ -25,7 +25,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Objects which describes exception throws configuration.
  */
-@Api.Stable
+@Api.Internal
 public class Throws extends DescribableComponent {
 
     private Throws(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Throws.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/Throws.java
@@ -18,12 +18,14 @@ package io.helidon.codegen.classmodel;
 import java.util.List;
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
 
 /**
  * Objects which describes exception throws configuration.
  */
+@Api.Stable
 public class Throws extends DescribableComponent {
 
     private Throws(Builder builder) {

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
@@ -30,7 +30,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Generic type argument model.
  */
-@Api.Stable
+@Api.Internal
 public final class TypeArgument extends Type implements TypeName {
 
     private final TypeName token;

--- a/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
+++ b/codegen/class-model/src/main/java/io/helidon/codegen/classmodel/TypeArgument.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeName;
@@ -29,6 +30,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Generic type argument model.
  */
+@Api.Stable
 public final class TypeArgument extends Type implements TypeName {
 
     private final TypeName token;

--- a/codegen/class-model/src/main/java/module-info.java
+++ b/codegen/class-model/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
  * The class model code generator.
  */
 module io.helidon.codegen.classmodel {
+    requires static io.helidon.common;
     requires transitive io.helidon.common.types;
 
     exports io.helidon.codegen.classmodel;

--- a/codegen/codegen/pom.xml
+++ b/codegen/codegen/pom.xml
@@ -63,4 +63,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/Codegen.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import io.helidon.codegen.classmodel.ClassModel;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ModuleTypeInfo;
@@ -42,6 +43,7 @@ import io.helidon.common.types.TypeName;
  * This type loads {@link io.helidon.codegen.spi.CodegenExtensionProvider extension providers}, and invokes
  * each {@link io.helidon.codegen.spi.CodegenExtension} with appropriate types and annotations.
  */
+@Api.Stable
 public class Codegen {
     private static final List<CodegenExtensionProvider> EXTENSIONS =
             HelidonServiceLoader.create(ServiceLoader.load(CodegenExtensionProvider.class,

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContext.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import io.helidon.codegen.spi.AnnotationMapper;
 import io.helidon.codegen.spi.ElementMapper;
 import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -31,6 +32,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Code processing and generation context.
  */
+@Api.Stable
 public interface CodegenContext {
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContext.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContext.java
@@ -107,6 +107,7 @@ public interface CodegenContext {
      *
      * @return list of mapper
      */
+    @Api.Internal
     List<ElementMapper> elementMappers();
 
     /**
@@ -115,6 +116,7 @@ public interface CodegenContext {
      *
      * @return list of mapper
      */
+    @Api.Internal
     List<TypeMapper> typeMappers();
 
     /**
@@ -123,6 +125,7 @@ public interface CodegenContext {
      *
      * @return list of mapper
      */
+    @Api.Internal
     List<AnnotationMapper> annotationMappers();
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContextBase.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContextBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.helidon.codegen.spi.ElementMapper;
 import io.helidon.codegen.spi.ElementMapperProvider;
 import io.helidon.codegen.spi.TypeMapper;
 import io.helidon.codegen.spi.TypeMapperProvider;
+import io.helidon.common.Api;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.types.ElementSignature;
 import io.helidon.common.types.TypeInfo;
@@ -39,6 +40,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Base of codegen context implementation taking care of the common parts of the API.
  */
+@Api.Internal
 public abstract class CodegenContextBase implements CodegenContext {
     // class -> method name -> element signature
     private final Map<TypeName, Map<String, ElementSignatures>> uniqueNames = new HashMap<>();

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContextDelegate.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenContextDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import io.helidon.codegen.spi.AnnotationMapper;
 import io.helidon.codegen.spi.ElementMapper;
 import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -31,6 +32,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Base of codegen context implementation that delegates common parts of the API to an existing instance.
  */
+@Api.Internal
 public abstract class CodegenContextDelegate implements CodegenContext {
     private final CodegenContext delegate;
 

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenEvent.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.Errors;
  *
  * @see #builder()
  */
+@Api.Stable
 public interface CodegenEvent extends CodegenEventBlueprint {
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenEventBlueprint.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenEventBlueprint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,13 @@ package io.helidon.codegen;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
+
 /**
  * An event happening during code gen. This is not a fast solution, it is only to be used when processing code, where
  * we can have a bit of an overhead!
  */
+@Api.Stable
 interface CodegenEventBlueprint {
     /**
      * Level can be used directly (command line tools), mapped to Maven level (maven plugins),

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenException.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenException.java
@@ -19,10 +19,13 @@ package io.helidon.codegen;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.Api;
+
 /**
  * An exception for any code processing and generation tools.
  * This exception can hold {@link #originatingElement()} that may be used to provide more information to the user.
  */
+@Api.Stable
 public class CodegenException extends RuntimeException {
     /**
      * Originating element, depends on which codegen implementation is used.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,14 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * An abstraction for writing out source files and resource files.
  * Always attempts to create a new file and replace its content (as it is impossible to update files in annotation processing).
  */
+@Api.Stable
 public interface CodegenFiler {
     /**
      * Write a source file from its {@link io.helidon.codegen.classmodel.ClassModel}.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenFiler.java
@@ -42,6 +42,7 @@ public interface CodegenFiler {
      *                            (you can use {@link io.helidon.common.types.TypeInfo#originatingElementValue()})
      * @return written path, we expect to always run on local file system
      */
+    @Api.Internal
     Path writeSourceFile(ClassModel classModel, Object... originatingElements);
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenLogger.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenLogger.java
@@ -18,9 +18,12 @@ package io.helidon.codegen;
 
 import java.util.List;
 
+import io.helidon.common.Api;
+
 /**
  * An abstraction for logging code processing and generation events.
  */
+@Api.Stable
 public interface CodegenLogger {
     /**
      * Create a new logger backed by {@link java.lang.System.Logger}.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenOptions.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 
 /**
  * Configuration options.
  */
+@Api.Stable
 public interface CodegenOptions {
     /**
      * Tag to define custom module name.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenScope.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.codegen;
 
+import io.helidon.common.Api;
+
 import static io.helidon.codegen.CodegenUtil.capitalize;
 
 /**
@@ -23,6 +25,7 @@ import static io.helidon.codegen.CodegenUtil.capitalize;
  *
  * @param name name of the scope, use empty string for production scope, see {@link #PRODUCTION}, use lower case names
  */
+@Api.Stable
 public record CodegenScope(String name) {
     /**
      * Production scope.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenUtil.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenUtil.java
@@ -18,12 +18,14 @@ package io.helidon.codegen;
 
 import java.util.Locale;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
 
 /**
  * Tools for generating code.
  */
+@Api.Stable
 public final class CodegenUtil {
     private CodegenUtil() {
     }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/CodegenValidator.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/CodegenValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.codegen;
 import java.net.URI;
 import java.time.Duration;
 
+import io.helidon.common.Api;
 import io.helidon.common.Size;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypedElementInfo;
@@ -26,6 +27,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Validation utilities.
  */
+@Api.Stable
 public final class CodegenValidator {
     private CodegenValidator() {
     }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ElementInfoPredicates.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ElementInfoPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.codegen;
 import java.util.List;
 import java.util.function.Predicate;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.Modifier;
@@ -32,6 +33,7 @@ import io.helidon.common.types.TypedElementInfo;
  * @see io.helidon.common.types.TypedElementInfo
  * @see io.helidon.common.types.TypeInfo#elementInfo()
  */
+@Api.Stable
 public final class ElementInfoPredicates {
     /**
      * A predicate that accepts all.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/FilerResource.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/FilerResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package io.helidon.codegen;
 
+import io.helidon.common.Api;
+
 /**
  * A resource from output (such as {@code target/META-INF/helidon}) that can have existing
  * values, and may be replaced with a new value.
  */
+@Api.Stable
 public interface FilerResource {
     /**
      * Existing bytes of the resource. Returns empty array, if the resource does not exist or is empty.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/FilerTextResource.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/FilerTextResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,13 @@ package io.helidon.codegen;
 
 import java.util.List;
 
+import io.helidon.common.Api;
+
 /**
  * A resource from output (such as {@code target/META-INF/helidon}) that can have existing
  * values, and may be replaced with a new value.
  */
+@Api.Stable
 public interface FilerTextResource {
     /**
      * Existing lines of the resource. Returns an empty list if the resource does not exist.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/IndentType.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/IndentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package io.helidon.codegen;
 
+import io.helidon.common.Api;
+
 /**
  * Indentation kind.
  */
+@Api.Stable
 public enum IndentType {
     /**
      * Use spaces to indent generated source code.
@@ -44,4 +47,3 @@ public enum IndentType {
         return character;
     }
 }
-

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ManifestResource.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ManifestResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ package io.helidon.codegen;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.helidon.common.Api;
 import io.helidon.metadata.MetadataConstants;
 
 /**
  * Support for Helidon manifest file, that lists all manifest resources on the classpath.
  */
+@Api.Stable
 public class ManifestResource {
     private final FilerTextResource manifestResource;
     private final List<String> locations;

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfo.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import io.helidon.common.Api;
 import io.helidon.common.Errors;
 import io.helidon.common.types.TypeName;
 
@@ -33,6 +34,7 @@ import io.helidon.common.types.TypeName;
  *
  * @see #builder()
  */
+@Api.Stable
 public interface ModuleInfo {
     /**
      * The default module name (i.e., "unnamed").

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfoRequires.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfoRequires.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.helidon.codegen;
 
+import io.helidon.common.Api;
+
 /**
  * A requires definition of a module-info.java.
  *
@@ -23,5 +25,6 @@ package io.helidon.codegen;
  * @param isTransitive whether the requires is defined as {@code transitive}
  * @param isStatic whether the requires is defined as {@code static}
  */
+@Api.Stable
 public record ModuleInfoRequires(String module, boolean isTransitive, boolean isStatic) {
 }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfoSourceParser.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/ModuleInfoSourceParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,13 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * Support for parsing module-info.java sources.
  */
+@Api.Stable
 public final class ModuleInfoSourceParser {
     private static final String PROVIDES = "provides";
     private static final String OPENS = "opens";

--- a/codegen/codegen/src/main/java/io/helidon/codegen/Option.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import io.helidon.common.Api;
 import io.helidon.common.GenericType;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.GenericType;
  *
  * @param <T> option type, as options are always loaded from String, the type has to map from a String or list of strings
  */
+@Api.Stable
 public interface Option<T> {
     /**
      * Create a new String option.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
@@ -98,6 +98,7 @@ public interface RoundContext {
      * @param mainTrigger         a type that caused this, may be the processor itself, if not bound to any type
      * @param originatingElements possible originating elements  (such as Element in APT, or ClassInfo in classpath scanning)
      */
+    @Api.Internal
     void addGeneratedType(TypeName type, ClassModel.Builder newClass, TypeName mainTrigger, Object... originatingElements);
 
     /**
@@ -111,6 +112,7 @@ public interface RoundContext {
      * @param type type of the generated type
      * @return class model of the new type if any
      */
+    @Api.Internal
     Optional<ClassModel.Builder> generatedType(TypeName type);
 
     /**

--- a/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/RoundContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import io.helidon.codegen.classmodel.ClassModel;
+import io.helidon.common.Api;
 import io.helidon.common.types.ModuleTypeInfo;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
@@ -31,6 +32,7 @@ import io.helidon.common.types.TypedElementInfo;
  * Context of a single round of code generation.
  * For example the first round may generate types, that require additional code generation.
  */
+@Api.Stable
 public interface RoundContext {
     /**
      * Annotations available in this round, the collection contains only annotations valid for the extension being invoked.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeHierarchy.java
@@ -43,6 +43,7 @@ import static io.helidon.common.types.TypeNames.INHERITED;
 /**
  * Utilities for type hierarchy.
  */
+@Api.Stable
 public final class TypeHierarchy {
     private TypeHierarchy() {
     }

--- a/codegen/codegen/src/main/java/io/helidon/codegen/TypeInfoFactoryBase.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/TypeInfoFactoryBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.Set;
 import io.helidon.codegen.spi.AnnotationMapper;
 import io.helidon.codegen.spi.ElementMapper;
 import io.helidon.codegen.spi.TypeMapper;
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
@@ -38,6 +39,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Common code for type info factories.
  */
+@Api.Internal
 public abstract class TypeInfoFactoryBase {
     private static final Set<TypeName> IGNORED_ANNOTATIONS = Set.of(TypeName.create(SuppressWarnings.class),
                                                                     TypeName.create(Override.class),

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package io.helidon.codegen.spi;
 import java.util.Collection;
 
 import io.helidon.codegen.CodegenContext;
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
 
 /**
  * Maps annotation from a single annotation instance to zero or more annotation instances.
  */
+@Api.Stable
 public interface AnnotationMapper {
     /**
      * Check if the annotation is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapper.java
@@ -26,7 +26,7 @@ import io.helidon.common.types.ElementKind;
 /**
  * Maps annotation from a single annotation instance to zero or more annotation instances.
  */
-@Api.Stable
+@Api.Internal
 public interface AnnotationMapper {
     /**
      * Check if the annotation is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 package io.helidon.codegen.spi;
 
 import io.helidon.codegen.CodegenOptions;
+import io.helidon.common.Api;
 
 /**
  * {@link java.util.ServiceLoader} provider interface for annotation mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#annotationMappers()}.
  */
+@Api.Stable
 public interface AnnotationMapperProvider extends CodegenProvider {
     /**
      * Create an annotation mapper based on provided options.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/AnnotationMapperProvider.java
@@ -23,7 +23,7 @@ import io.helidon.common.Api;
  * {@link java.util.ServiceLoader} provider interface for annotation mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#annotationMappers()}.
  */
-@Api.Stable
+@Api.Internal
 public interface AnnotationMapperProvider extends CodegenProvider {
     /**
      * Create an annotation mapper based on provided options.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtension.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package io.helidon.codegen.spi;
 
 import io.helidon.codegen.RoundContext;
+import io.helidon.common.Api;
 
 /**
  * Code processing and generation extension.
  */
+@Api.Stable
 public interface CodegenExtension {
     /**
      * Process a round of code analysis and generation.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtension.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtension.java
@@ -22,7 +22,7 @@ import io.helidon.common.Api;
 /**
  * Code processing and generation extension.
  */
-@Api.Stable
+@Api.Internal
 public interface CodegenExtension {
     /**
      * Process a round of code analysis and generation.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtensionProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.codegen.spi;
 
 import io.helidon.codegen.CodegenContext;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -24,6 +25,7 @@ import io.helidon.common.types.TypeName;
  * Each implementation will be called with types that match its declared {@link #supportedAnnotations()} and
  * {@link #supportedAnnotationPackages()}.
  */
+@Api.Stable
 public interface CodegenExtensionProvider extends CodegenProvider {
     /**
      * Create a new instance of the extension provider.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtensionProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenExtensionProvider.java
@@ -25,7 +25,7 @@ import io.helidon.common.types.TypeName;
  * Each implementation will be called with types that match its declared {@link #supportedAnnotations()} and
  * {@link #supportedAnnotationPackages()}.
  */
-@Api.Stable
+@Api.Internal
 public interface CodegenExtensionProvider extends CodegenProvider {
     /**
      * Create a new instance of the extension provider.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.codegen.spi;
 import java.util.Set;
 
 import io.helidon.codegen.Option;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
@@ -30,6 +31,7 @@ import io.helidon.common.types.TypeName;
  * @see io.helidon.codegen.spi.ElementMapperProvider
  * @see io.helidon.codegen.spi.TypeMapperProvider
  */
+@Api.Stable
 public interface CodegenProvider {
     /**
      * Configuration options that are supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CodegenProvider.java
@@ -31,7 +31,7 @@ import io.helidon.common.types.TypeName;
  * @see io.helidon.codegen.spi.ElementMapperProvider
  * @see io.helidon.codegen.spi.TypeMapperProvider
  */
-@Api.Stable
+@Api.Internal
 public interface CodegenProvider {
     /**
      * Configuration options that are supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CopyrightProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CopyrightProvider.java
@@ -22,7 +22,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Extension point to customize copyright headers for generated types.
  */
-@Api.Stable
+@Api.Internal
 public interface CopyrightProvider {
     /**
      * Create a copyright header, including comment begin/end, or line comments.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/CopyrightProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/CopyrightProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 
 package io.helidon.codegen.spi;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 /**
  * Extension point to customize copyright headers for generated types.
  */
+@Api.Stable
 public interface CopyrightProvider {
     /**
      * Create a copyright header, including comment begin/end, or line comments.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapper.java
@@ -25,7 +25,7 @@ import io.helidon.common.types.TypedElementInfo;
 /**
  * Maps (or removes) elements.
  */
-@Api.Stable
+@Api.Internal
 public interface ElementMapper {
     /**
      * Check if the element is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ package io.helidon.codegen.spi;
 import java.util.Optional;
 
 import io.helidon.codegen.CodegenContext;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypedElementInfo;
 
 /**
  * Maps (or removes) elements.
  */
+@Api.Stable
 public interface ElementMapper {
     /**
      * Check if the element is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapperProvider.java
@@ -24,7 +24,7 @@ import io.helidon.common.Api;
  * {@link java.util.ServiceLoader} provider interface for element mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#elementMappers()}.
  */
-@Api.Stable
+@Api.Internal
 public interface ElementMapperProvider extends CodegenProvider {
     /**
      * Create an element mapper based on provided options.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/ElementMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 package io.helidon.codegen.spi;
 
 import io.helidon.codegen.CodegenOptions;
+import io.helidon.common.Api;
 
 
 /**
  * {@link java.util.ServiceLoader} provider interface for element mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#elementMappers()}.
  */
+@Api.Stable
 public interface ElementMapperProvider extends CodegenProvider {
     /**
      * Create an element mapper based on provided options.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/GeneratedAnnotationProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/GeneratedAnnotationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package io.helidon.codegen.spi;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.TypeName;
 
 /**
  * Service provider interface to provide customization of generated annotation.
  */
+@Api.Stable
 public interface GeneratedAnnotationProvider {
     /**
      * Create a generated annotation.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/GeneratedAnnotationProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/GeneratedAnnotationProvider.java
@@ -23,7 +23,7 @@ import io.helidon.common.types.TypeName;
 /**
  * Service provider interface to provide customization of generated annotation.
  */
-@Api.Stable
+@Api.Internal
 public interface GeneratedAnnotationProvider {
     /**
      * Create a generated annotation.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapper.java
@@ -27,7 +27,7 @@ import io.helidon.common.types.TypeInfo;
  * This mapper can be used to handle complex changes to a definition of a type, such as combining
  * multiple annotations into a single one.
  */
-@Api.Stable
+@Api.Internal
 public interface TypeMapper {
     /**
      * Check if the type is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapper.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.codegen.spi;
 import java.util.Optional;
 
 import io.helidon.codegen.CodegenContext;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeInfo;
 
 /**
@@ -26,6 +27,7 @@ import io.helidon.common.types.TypeInfo;
  * This mapper can be used to handle complex changes to a definition of a type, such as combining
  * multiple annotations into a single one.
  */
+@Api.Stable
 public interface TypeMapper {
     /**
      * Check if the type is supported.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapperProvider.java
@@ -23,7 +23,7 @@ import io.helidon.common.Api;
  * {@link java.util.ServiceLoader} provider interface for type mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#typeMappers()}.
  */
-@Api.Stable
+@Api.Internal
 public interface TypeMapperProvider extends CodegenProvider {
     /**
      * Create a type mapper based on provided options.

--- a/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapperProvider.java
+++ b/codegen/codegen/src/main/java/io/helidon/codegen/spi/TypeMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 package io.helidon.codegen.spi;
 
 import io.helidon.codegen.CodegenOptions;
+import io.helidon.common.Api;
 
 /**
  * {@link java.util.ServiceLoader} provider interface for type mapping.
  * This provider is used to load all mappers accessible through {@link io.helidon.codegen.CodegenContext#typeMappers()}.
  */
+@Api.Stable
 public interface TypeMapperProvider extends CodegenProvider {
     /**
      * Create a type mapper based on provided options.

--- a/codegen/compiler/pom.xml
+++ b/codegen/compiler/pom.xml
@@ -62,7 +62,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <annotationProcessorPaths>
+                    <annotationProcessorPaths combine.children="append">
                         <path>
                             <groupId>io.helidon.codegen</groupId>
                             <artifactId>helidon-codegen-apt</artifactId>
@@ -80,6 +80,20 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
@@ -94,6 +108,11 @@
                     <dependency>
                         <groupId>io.helidon.codegen</groupId>
                         <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
                         <version>${helidon.version}</version>
                     </dependency>
                 </dependencies>

--- a/codegen/compiler/src/main/java/io/helidon/codegen/compiler/Compiler.java
+++ b/codegen/compiler/src/main/java/io/helidon/codegen/compiler/Compiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ package io.helidon.codegen.compiler;
 import java.nio.file.Path;
 
 import io.helidon.codegen.CodegenException;
+import io.helidon.common.Api;
 
 /**
  * A javac based compiler for in-process compilation.
  */
+@Api.Internal
 public final class Compiler {
     private Compiler() {
     }

--- a/codegen/compiler/src/main/java/io/helidon/codegen/compiler/CompilerOptionsBlueprint.java
+++ b/codegen/compiler/src/main/java/io/helidon/codegen/compiler/CompilerOptionsBlueprint.java
@@ -23,10 +23,12 @@ import java.util.Optional;
 import io.helidon.builder.api.Option;
 import io.helidon.builder.api.Prototype;
 import io.helidon.codegen.CodegenLogger;
+import io.helidon.common.Api;
 
 /**
  * Provides configuration to the javac compiler.
  */
+@Api.Internal
 @Prototype.Blueprint
 interface CompilerOptionsBlueprint {
 

--- a/codegen/compiler/src/main/java/module-info.java
+++ b/codegen/compiler/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/helidon-copyright/pom.xml
+++ b/codegen/helidon-copyright/pom.xml
@@ -47,4 +47,34 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/codegen/helidon-copyright/src/main/java/io/helidon/codegen/helidon/copyright/HelidonCopyrightProvider.java
+++ b/codegen/helidon-copyright/src/main/java/io/helidon/codegen/helidon/copyright/HelidonCopyrightProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package io.helidon.codegen.helidon.copyright;
 import java.time.LocalDate;
 
 import io.helidon.codegen.spi.CopyrightProvider;
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.types.TypeName;
 
 /**
  * Java {@link java.util.ServiceLoader} provider implementation that generates copyright as used by the Helidon project.
  */
+@Api.Internal
 @Weight(100)
 public class HelidonCopyrightProvider implements CopyrightProvider {
     private static final String COPYRIGHT_TEMPLATE = """

--- a/codegen/helidon-copyright/src/main/java/module-info.java
+++ b/codegen/helidon-copyright/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/codegen/scan/pom.xml
+++ b/codegen/scan/pom.xml
@@ -34,6 +34,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-types</artifactId>
         </dependency>
         <dependency>
@@ -55,5 +60,35 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.helidon.codegen</groupId>
+                                    <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                                    <version>${helidon.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-api-stability-enforcer</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanContext.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 package io.helidon.codegen.scan;
 
 import io.helidon.codegen.CodegenContext;
+import io.helidon.common.Api;
 
 import io.github.classgraph.ScanResult;
 
 /**
  * Classpath scanning code generation context.
  */
+@Api.Internal
 public interface ScanContext extends CodegenContext {
     /**
      * Scan result that should have types from the whole classpath.

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanModuleInfo.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanModuleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import io.helidon.codegen.ModuleInfo;
 import io.helidon.codegen.ModuleInfoRequires;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import io.github.classgraph.ModuleRef;
@@ -30,6 +31,7 @@ import io.github.classgraph.ModuleRef;
 /**
  * Module info created from classpath scanning.
  */
+@Api.Internal
 public final class ScanModuleInfo {
     private ScanModuleInfo() {
     }

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeFactory.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.codegen.scan;
 
 import java.util.Objects;
 
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import io.github.classgraph.ClassInfo;
@@ -26,6 +27,7 @@ import io.github.classgraph.HierarchicalTypeSignature;
 /**
  * Factory for types based on classpath scanning.
  */
+@Api.Internal
 public final class ScanTypeFactory {
     private ScanTypeFactory() {
     }

--- a/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeInfoFactory.java
+++ b/codegen/scan/src/main/java/io/helidon/codegen/scan/ScanTypeInfoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.ElementInfoPredicates;
 import io.helidon.codegen.TypeInfoFactoryBase;
+import io.helidon.common.Api;
 import io.helidon.common.types.AccessModifier;
 import io.helidon.common.types.Annotation;
 import io.helidon.common.types.ElementKind;
@@ -53,6 +54,7 @@ import static java.util.function.Predicate.not;
 /**
  * Factory to analyze processed types and to provide {@link io.helidon.common.types.TypeInfo} for them.
  */
+@Api.Internal
 public final class ScanTypeInfoFactory extends TypeInfoFactoryBase {
     // we expect that annotations themselves are not code generated, and can be cached
     private static final Map<TypeName, List<Annotation>> META_ANNOTATION_CACHE = new ConcurrentHashMap<>();

--- a/codegen/scan/src/main/java/module-info.java
+++ b/codegen/scan/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
  * Implementation of codegen utilities for classpath scanning.
  */
 module io.helidon.codegen.scan {
+    requires static io.helidon.common;
     requires transitive io.helidon.common.types;
     requires transitive io.helidon.codegen;
     requires transitive io.github.classgraph;


### PR DESCRIPTION
Part of #11500

Annotates public Codegen APIs with Stable or Internal status and enables API-stability enforcement during normal compilation of the applicable deployed Codegen modules.

Marks the Codegen SPI and class-model APIs as Internal while this area is redesigned. Stable Codegen entry points explicitly lower the members that expose these internal types. The API-stability enforcer remains dependency-free as a bootstrap exception, and existing compiler annotation processors are preserved.
