### PR TITLE
Support split repositories in Maven Invoker builds (27.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <version.lib.maven.plugin.annotations>3.15.1</version.lib.maven.plugin.annotations>
         <version.lib.maven.plugin.api>3.9.15</version.lib.maven.plugin.api>
         <version.lib.maven.plugin.project>2.2.1</version.lib.maven.plugin.project>
-        <version.lib.groovy>2.5.23</version.lib.groovy>
         <version.lib.nimbus.jose.jwt>10.4</version.lib.nimbus.jose.jwt>
         <!--
         !Version statement! - end
@@ -626,13 +625,6 @@
                             <goal>install</goal>
                         </goals>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy</artifactId>
-                            <version>${version.lib.groovy}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>
@@ -894,6 +886,31 @@
             <modules>
                 <module>tests</module>
             </modules>
+        </profile>
+        <profile>
+            <id>invoker-split-repository</id>
+            <activation>
+                <property>
+                    <name>aether.enhancedLocalRepository.split</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <properties>
+                                    <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+                                    <aether.enhancedLocalRepository.localPrefix>${aether.enhancedLocalRepository.localPrefix}</aether.enhancedLocalRepository.localPrefix>
+                                </properties>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>javadoc</id>

--- a/service/tests/maven-plugin/pom.xml
+++ b/service/tests/maven-plugin/pom.xml
@@ -116,6 +116,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <extraArtifacts>
+                        <extraArtifact>io.helidon.codegen:helidon-codegen-apt:${project.version}</extraArtifact>
+                        <extraArtifact>io.helidon.codegen:helidon-codegen-helidon-copyright:${project.version}</extraArtifact>
+                    </extraArtifacts>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Resolves #12515

Carry the Maven Invoker split-repository handling from #12516 forward to `main`.

Forward the active split local-repository prefix to nested Invoker builds while leaving ordinary unsplit builds unchanged, and stage the annotation processors required by the Service Maven Plugin fixtures.
