### PR TITLE
Fix HTTP parsing and redirect handling (4.x)

### DIFF
--- a/http/http/src/main/java/io/helidon/http/Header.java
+++ b/http/http/src/main/java/io/helidon/http/Header.java
@@ -118,9 +118,15 @@ public interface Header extends Value<String> {
     boolean changing();
 
     /**
-     * Cached bytes of a single valued header's value.
+     * Bytes of a single-valued header value.
+     * <p>
+     * Each character in the value is mapped to the byte with the same numeric value using
+     * {@link java.nio.charset.StandardCharsets#ISO_8859_1}. Characters from {@code U+0080} through
+     * {@code U+00FF} therefore represent opaque HTTP field-value octets; they are not interpreted
+     * as UTF-8 or as ISO-8859-1 text.
      *
      * @return value bytes
+     * @throws IllegalArgumentException if the value contains a character above {@code U+00FF}
      */
     default byte[] valueBytes() {
         return encodeValue(get());
@@ -143,9 +149,13 @@ public interface Header extends Value<String> {
     }
 
     /**
-     * Check validity of header name and values.
+     * Check validity of the header name and values.
+     * <p>
+     * The name must be a non-empty HTTP token. Values may contain opaque octets represented by
+     * characters from {@code U+0080} through {@code U+00FF}; characters above {@code U+00FF}
+     * cannot be represented in an HTTP field value and are rejected.
      *
-     * @throws IllegalArgumentException in case the HeaderValue is not valid
+     * @throws IllegalArgumentException if the header name or a value is not valid
      */
     default void validate() throws IllegalArgumentException {
         String name = name();

--- a/http/http/src/main/java/io/helidon/http/Header.java
+++ b/http/http/src/main/java/io/helidon/http/Header.java
@@ -123,7 +123,7 @@ public interface Header extends Value<String> {
      * @return value bytes
      */
     default byte[] valueBytes() {
-        return get().getBytes(StandardCharsets.US_ASCII);
+        return encodeValue(get());
     }
 
     /**
@@ -137,7 +137,7 @@ public interface Header extends Value<String> {
             writeHeader(buffer, nameBytes, valueBytes());
         } else {
             for (String value : allValues()) {
-                writeHeader(buffer, nameBytes, value.getBytes(StandardCharsets.US_ASCII));
+                writeHeader(buffer, nameBytes, encodeValue(value));
             }
         }
     }
@@ -168,16 +168,25 @@ public interface Header extends Value<String> {
         }
     }
 
+    private static byte[] encodeValue(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0xff) {
+                throw new IllegalArgumentException("Header value contains a character above 0xff");
+            }
+        }
+        return value.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
     private static int validateValue(String name, String value, int position) {
         int length = value.length();
         for (int i = 0; i < length; i++) {
             char vChar = value.charAt(i);
             if (position == 0) {
-                if (vChar < '!' || vChar == '\u007f') {
+                if (vChar < '!' || vChar == '\u007f' || vChar > '\u00ff') {
                     throw new IllegalArgumentException("First character of the header value is invalid"
                                                                + " for header '" + name + "'");
                 }
-            } else if (vChar < ' ' && vChar != '\t' || vChar == '\u007f') {
+            } else if (vChar < ' ' && vChar != '\t' || vChar == '\u007f' || vChar > '\u00ff') {
                 throw new IllegalArgumentException("Character at position " + (position + 1)
                                                            + " of the header value is invalid"
                                                            + " for header '" + name + "'");

--- a/http/http/src/main/java/io/helidon/http/HeaderValues.java
+++ b/http/http/src/main/java/io/helidon/http/HeaderValues.java
@@ -165,7 +165,7 @@ public final class HeaderValues {
     public static Header createCached(HeaderName name, String value) {
         return new HeaderValueCached(name, false,
                                      false,
-                                     value.getBytes(StandardCharsets.US_ASCII),
+                                     encodeValue(value),
                                      value);
     }
 
@@ -397,7 +397,7 @@ public final class HeaderValues {
      * @return a new header
      */
     public static Header createCached(HeaderName name, boolean changing, boolean sensitive, String value) {
-        return new HeaderValueCached(name, changing, sensitive, value.getBytes(StandardCharsets.UTF_8), value);
+        return new HeaderValueCached(name, changing, sensitive, encodeValue(value), value);
     }
 
     /**
@@ -437,5 +437,14 @@ public final class HeaderValues {
      */
     public static Header create(HeaderName name, boolean changing, boolean sensitive, long value) {
         return create(name, changing, sensitive, String.valueOf(value));
+    }
+
+    private static byte[] encodeValue(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0xff) {
+                throw new IllegalArgumentException("Header value contains a character above 0xff");
+            }
+        }
+        return value.getBytes(StandardCharsets.ISO_8859_1);
     }
 }

--- a/http/http/src/main/java/io/helidon/http/Http1HeadersParser.java
+++ b/http/http/src/main/java/io/helidon/http/Http1HeadersParser.java
@@ -85,7 +85,7 @@ public final class Http1HeadersParser {
                 headerValue = connectionHeaderValue(reader, eol);
             } else {
                 // we do not need the string until somebody asks for this header (unless validation is on)
-                LazyString value = reader.readLazyString(StandardCharsets.US_ASCII, eol);
+                LazyString value = reader.readLazyString(StandardCharsets.ISO_8859_1, eol);
                 headerValue = HeaderValues.create(header, value);
             }
             reader.skip(2);
@@ -115,7 +115,8 @@ public final class Http1HeadersParser {
             return HeaderValues.CONNECTION_CLOSE;
         }
         // some other (unexpected) combination
-        return HeaderValues.create(HeaderNames.CONNECTION, new LazyString(bytes, 0, bytes.length, StandardCharsets.US_ASCII));
+        return HeaderValues.create(HeaderNames.CONNECTION,
+                                   new LazyString(bytes, 0, bytes.length, StandardCharsets.ISO_8859_1));
     }
 
     private static boolean isKeepAlive(byte[] buffer) {

--- a/http/http/src/main/java/io/helidon/http/HttpMediaType.java
+++ b/http/http/src/main/java/io/helidon/http/HttpMediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package io.helidon.http;
 
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -158,11 +160,13 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
      *         parameter set to the supplied value.
      */
     default HttpMediaType withCharset(String charset) {
-        return builder()
+        Builder builder = builder()
                 .mediaType(mediaType())
-                .parameters(parameters())
-                .charset(charset)
-                .build();
+                .parameters(parameters());
+        if (charset != null && !charset.isEmpty()) {
+            builder.charset(charset);
+        }
+        return builder.build();
     }
 
     /**
@@ -247,7 +251,7 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
          * @return updated builder instance
          */
         public Builder addParameter(String parameter, String value) {
-            parameters.put(parameter.toLowerCase(), value);
+            parameters.put(parameter.toLowerCase(Locale.ROOT), value);
             return this;
         }
 
@@ -259,7 +263,7 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
          */
         public Builder parameters(Map<String, String> parameters) {
             this.parameters.clear();
-            parameters.forEach((key, value) -> this.parameters.put(key.toLowerCase(), value));
+            parameters.forEach((key, value) -> this.parameters.put(key.toLowerCase(Locale.ROOT), value));
 
             return this;
         }
@@ -284,8 +288,27 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
         }
 
         private static HttpMediaType parse(String mediaTypeString, ParserMode parserMode) {
-            // text/plain; charset=UTF-8
+            Objects.requireNonNull(mediaTypeString);
+            Objects.requireNonNull(parserMode);
+            if (mediaTypeString.indexOf(';') == -1) {
+                MediaType mediaType = MediaTypes.create(mediaTypeString, parserMode);
+                if (parserMode == ParserMode.STRICT) {
+                    HttpToken.validate(mediaType.type());
+                    HttpToken.validate(mediaType.subtype());
+                }
+                return builder().mediaType(mediaType).build();
+            }
+            try {
+                return new StrictParser(mediaTypeString).parse();
+            } catch (IllegalArgumentException e) {
+                if (parserMode == ParserMode.STRICT) {
+                    throw e;
+                }
+            }
+            return parseRelaxed(mediaTypeString);
+        }
 
+        private static HttpMediaType parseRelaxed(String mediaTypeString) {
             Builder b = builder();
             int index = mediaTypeString.indexOf(';');
             if (index != -1) {
@@ -310,9 +333,151 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
                     }
                 }
             } else {
-                b.mediaType(MediaTypes.create(mediaTypeString, parserMode));
+                b.mediaType(MediaTypes.create(mediaTypeString, ParserMode.RELAXED));
             }
             return b.build();
+        }
+
+        private static final class StrictParser {
+            private final String value;
+            private int index;
+
+            private StrictParser(String value) {
+                this.value = value;
+            }
+
+            private static boolean isOptionalWhitespace(char ch) {
+                return ch == ' ' || ch == '\t';
+            }
+
+            private static boolean isQuotedText(char ch) {
+                return ch == '\t'
+                        || ch == ' '
+                        || ch == 0x21
+                        || ch >= 0x23 && ch <= 0x5b
+                        || ch >= 0x5d && ch <= 0x7e
+                        || ch >= 0x80 && ch <= 0xff;
+            }
+
+            private static boolean isQuotedPairCharacter(char ch) {
+                return ch == '\t'
+                        || ch == ' '
+                        || ch >= 0x21 && ch <= 0x7e
+                        || ch >= 0x80 && ch <= 0xff;
+            }
+
+            private static IllegalArgumentException invalid(String message) {
+                return new IllegalArgumentException("Invalid media type: " + message);
+            }
+
+            private HttpMediaType parse() {
+                if (value.indexOf('/') < 1) {
+                    throw new IllegalArgumentException("Cannot parse media type: " + value);
+                }
+                Builder builder = builder();
+                String type = parseUntil('/');
+                require('/');
+                String subtype = parseSubtype();
+                builder.mediaType(MediaTypes.create(type, subtype));
+
+                while (!atEnd()) {
+                    skipOptionalWhitespace();
+                    if (atEnd()) {
+                        throw invalid("Expected ';'");
+                    }
+                    require(';');
+                    skipOptionalWhitespace();
+                    if (atEnd() || current() == ';') {
+                        continue;
+                    }
+
+                    String parameterName = parseUntil('=');
+                    require('=');
+                    if (atEnd()) {
+                        throw invalid("Expected parameter value");
+                    }
+                    String parameterValue = current() == '"' ? parseQuotedString() : parseParameterToken();
+                    builder.addParameter(parameterName, parameterValue);
+                }
+                return builder.build();
+            }
+
+            private String parseSubtype() {
+                int start = index;
+                while (!atEnd() && current() != ';' && !isOptionalWhitespace(current())) {
+                    index++;
+                }
+                return validateToken(start);
+            }
+
+            private String parseParameterToken() {
+                int start = index;
+                while (!atEnd() && current() != ';' && !isOptionalWhitespace(current())) {
+                    index++;
+                }
+                return validateToken(start);
+            }
+
+            private String parseUntil(char delimiter) {
+                int start = index;
+                while (!atEnd() && current() != delimiter) {
+                    index++;
+                }
+                return validateToken(start);
+            }
+
+            private String validateToken(int start) {
+                String token = value.substring(start, index);
+                HttpToken.validate(token);
+                return token;
+            }
+
+            private String parseQuotedString() {
+                index++;
+                StringBuilder result = new StringBuilder();
+                while (!atEnd()) {
+                    char ch = current();
+                    index++;
+                    if (ch == '"') {
+                        return result.toString();
+                    }
+                    if (ch == '\\') {
+                        if (atEnd()) {
+                            throw invalid("Incomplete quoted-pair");
+                        }
+                        ch = current();
+                        index++;
+                        if (!isQuotedPairCharacter(ch)) {
+                            throw invalid("Invalid quoted-pair character");
+                        }
+                    } else if (!isQuotedText(ch)) {
+                        throw invalid("Invalid quoted-string character");
+                    }
+                    result.append(ch);
+                }
+                throw invalid("Unterminated quoted-string");
+            }
+
+            private void skipOptionalWhitespace() {
+                while (!atEnd() && isOptionalWhitespace(current())) {
+                    index++;
+                }
+            }
+
+            private void require(char expected) {
+                if (atEnd() || current() != expected) {
+                    throw invalid("Expected '" + expected + "'");
+                }
+                index++;
+            }
+
+            private boolean atEnd() {
+                return index == value.length();
+            }
+
+            private char current() {
+                return value.charAt(index);
+            }
         }
     }
 }

--- a/http/http/src/main/java/io/helidon/http/HttpMediaTypeImpl.java
+++ b/http/http/src/main/java/io/helidon/http/HttpMediaTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,10 +109,11 @@ final class HttpMediaTypeImpl implements HttpMediaType {
     public String text() {
         StringBuilder result = new StringBuilder(mediaType.text());
         for (Map.Entry<String, String> param : parameters.entrySet()) {
+            HttpToken.validate(param.getKey());
             result.append("; ")
                     .append(param.getKey())
-                    .append('=')
-                    .append(param.getValue());
+                    .append('=');
+            appendParameterValue(result, param.getValue());
         }
         return result.toString();
     }
@@ -136,6 +137,35 @@ final class HttpMediaTypeImpl implements HttpMediaType {
     @Override
     public String toString() {
         return text();
+    }
+
+    private static void appendParameterValue(StringBuilder target, String value) {
+        Objects.requireNonNull(value);
+        if (HttpToken.isValid(value)) {
+            target.append(value);
+            return;
+        }
+
+        target.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '"' || ch == '\\') {
+                target.append('\\');
+            } else if (!isQuotedText(ch)) {
+                throw new IllegalArgumentException("Invalid media type parameter value");
+            }
+            target.append(ch);
+        }
+        target.append('"');
+    }
+
+    private static boolean isQuotedText(char ch) {
+        return ch == '\t'
+                || ch == ' '
+                || ch == 0x21
+                || ch >= 0x23 && ch <= 0x5b
+                || ch >= 0x5d && ch <= 0x7e
+                || ch >= 0x80 && ch <= 0xff;
     }
 
     private boolean subtypeMismatch(MediaType other) {

--- a/http/http/src/main/java/io/helidon/http/HttpToken.java
+++ b/http/http/src/main/java/io/helidon/http/HttpToken.java
@@ -16,25 +16,33 @@
 
 package io.helidon.http;
 
+import java.util.Objects;
+
 /**
  * HTTP Token utility.
- * Token is defined by the HTTP specification and must not contain a set of characters.
+ * A token is defined by the HTTP specification as one or more ASCII {@code tchar} characters.
  */
 public final class HttpToken {
     private HttpToken() {
     }
 
     /**
-     * Validate if this is a good HTTP token.
+     * Validate an HTTP token.
      *
      * @param token token to validate
      * @throws IllegalArgumentException in case the token is not valid
      */
     public static void validate(String token) throws IllegalArgumentException {
-        char[] chars = token.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char aChar = chars[i];
-            if (aChar > 254) {
+        Objects.requireNonNull(token);
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("Token must not be empty");
+        }
+        if (isValid(token)) {
+            return;
+        }
+        for (int i = 0; i < token.length(); i++) {
+            char aChar = token.charAt(i);
+            if (aChar > 127) {
                 throw new IllegalArgumentException("Token contains non-ASCII character at position "
                                                            + hex(i));
             }
@@ -46,16 +54,34 @@ public final class HttpToken {
                 throw new IllegalArgumentException("Token contains whitespace character at position "
                                                            + hex(i));
             }
-            switch (aChar) {
-            case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}' -> {
+            if (!isValidCharacter(aChar)) {
                 throw new IllegalArgumentException("Token contains illegal character at position "
                                                            + hex(i));
             }
-            default -> {
-                // this is a valid character
-            }
+        }
+    }
+
+    static boolean isValid(String token) {
+        Objects.requireNonNull(token);
+        if (token.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < token.length(); i++) {
+            if (!isValidCharacter(token.charAt(i))) {
+                return false;
             }
         }
+        return true;
+    }
+
+    private static boolean isValidCharacter(char character) {
+        return character >= '0' && character <= '9'
+                || character >= 'A' && character <= 'Z'
+                || character >= 'a' && character <= 'z'
+                || switch (character) {
+                    case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' -> true;
+                    default -> false;
+                };
     }
 
     private static String hex(int i) {

--- a/http/http/src/test/java/io/helidon/http/HeaderValuesTest.java
+++ b/http/http/src/test/java/io/helidon/http/HeaderValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.http;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 
@@ -41,5 +42,25 @@ class HeaderValuesTest {
         assertThat(connectionClose.name().toLowerCase(Locale.ROOT), is("connection"));
         assertThat(connectionClose.headerName(), is(HeaderNames.CONNECTION));
         assertThat(connectionClose.get(), is("close"));
+    }
+
+    @Test
+    void testLatin1ValueBytes() {
+        String value = "\u0080value\u00ff";
+        byte[] expected = value.getBytes(StandardCharsets.ISO_8859_1);
+
+        assertThat(HeaderValues.create("Name", value).valueBytes(), is(expected));
+        assertThat(HeaderValues.createCached("Name", value).valueBytes(), is(expected));
+        assertThat(HeaderValues.createCached(HeaderNames.create("Name"), true, true, value).valueBytes(), is(expected));
+    }
+
+    @Test
+    void testRejectsNonLatin1ValueBytes() {
+        String value = "invalid\u0100value";
+
+        assertThrows(IllegalArgumentException.class, () -> HeaderValues.create("Name", value).valueBytes());
+        assertThrows(IllegalArgumentException.class, () -> HeaderValues.createCached("Name", value));
+        assertThrows(IllegalArgumentException.class,
+                     () -> HeaderValues.createCached(HeaderNames.create("Name"), true, true, value));
     }
 }

--- a/http/http/src/test/java/io/helidon/http/Http1HeadersParserTest.java
+++ b/http/http/src/test/java/io/helidon/http/Http1HeadersParserTest.java
@@ -19,6 +19,7 @@ package io.helidon.http;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 
 import org.junit.jupiter.api.Assertions;
@@ -66,6 +67,23 @@ class Http1HeadersParserTest {
 
         assertThat(headers.values(HeaderNames.TRANSFER_ENCODING), hasItems("gzip", "chunked"));
         assertThat(headers.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED), is(true));
+    }
+
+    @Test
+    void testObsTextRoundTrip() {
+        String first = "\u0080first\u00ff";
+        String second = "\u00ffsecond\u0080";
+
+        assertHeaderRoundTrip(HeaderValues.create("X-Obs-Single", first), true);
+        assertHeaderRoundTrip(HeaderValues.createCached("X-Obs-Cached", first), true);
+        assertHeaderRoundTrip(HeaderValues.create("X-Obs-Multiple", first, second), true);
+        assertHeaderRoundTrip(HeaderValues.create(HeaderNames.CONNECTION, "custom-" + first), false);
+    }
+
+    @Test
+    void testRemoteUserHeaderPreservesOctets() {
+        assertParsedHeaderValue(new byte[] {'B', 'j', (byte) 0xf8, 'r', 'n'}, "Bj\u00f8rn");
+        assertParsedHeaderValue(new byte[] {'B', 'j', (byte) 0xc3, (byte) 0xb8, 'r', 'n'}, "Bj\u00c3\u00b8rn");
     }
 
     @Test
@@ -143,6 +161,32 @@ class Http1HeadersParserTest {
         DataReader reader =
                 DataReader.create(() -> (headerName + ":" + headerValue + "\r\n" + "\r\n").getBytes(StandardCharsets.US_ASCII));
         return Http1HeadersParser.readHeaders(reader, 1024, validate);
+    }
+
+    private static void assertHeaderRoundTrip(Header header, boolean validate) {
+        BufferData buffer = BufferData.growing(128);
+        header.writeHttp1Header(buffer);
+        buffer.write('\r');
+        buffer.write('\n');
+        byte[] bytes = buffer.readBytes();
+
+        WritableHeaders<?> parsed = Http1HeadersParser.readHeaders(DataReader.create(() -> bytes), 1024, validate);
+
+        assertThat(parsed.get(header.headerName()).allValues(), is(header.allValues()));
+    }
+
+    private static void assertParsedHeaderValue(byte[] valueBytes, String expectedValue) {
+        BufferData buffer = BufferData.growing(128);
+        buffer.writeAscii("ofs_remote_user: ");
+        buffer.write(valueBytes);
+        buffer.writeAscii("\r\n\r\n");
+        byte[] headerBytes = buffer.readBytes();
+
+        WritableHeaders<?> parsed = Http1HeadersParser.readHeaders(DataReader.create(() -> headerBytes), 1024, true);
+        String parsedValue = parsed.get(HeaderNames.create("ofs_remote_user")).get();
+
+        assertThat(parsedValue, is(expectedValue));
+        assertThat(parsedValue.getBytes(StandardCharsets.ISO_8859_1), is(valueBytes));
     }
 
     private static WritableHeaders<?> headers(String rawHeaders) {

--- a/http/http/src/test/java/io/helidon/http/HttpTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTest.java
@@ -96,6 +96,8 @@ class HttpTest {
                 arguments("Valid-Header-Name", "H\u001ceaderValue1", false),
                 arguments("Valid-Header-Name", "HeaderValue1, Header\u007fValue", false),
                 arguments("Valid-Header-Name", "HeaderValue1\u001f, HeaderValue2", false),
+                arguments("Valid-Header-Name", "\u0100HeaderValue", false),
+                arguments("Valid-Header-Name", "Header\u0100Value", false),
                 arguments("Header\u001aName", "Valid-Header-Value", false),
                 arguments("Header\u000EName", "Valid-Header-Value", false),
                 arguments("HeaderName\r\n", "Valid-Header-Value", false),

--- a/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
@@ -19,8 +19,10 @@ package io.helidon.http;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpTokenTest {
@@ -34,5 +36,33 @@ class HttpTokenTest {
         assertThat(message, containsString("Token contains whitespace character at position 6"));
         assertThat(message, not(containsString("secret")));
         assertThat(message, not(containsString("73 65 63 72 65 74")));
+    }
+
+    @Test
+    void testValidTokens() {
+        assertValid("*");
+        assertValid("gzip");
+        assertValid("x-gzip_1");
+        assertValid("!#$%&'*+-.^_`|~");
+    }
+
+    @Test
+    void testInvalidTokens() {
+        assertInvalid("");
+        assertInvalid("g zip");
+        assertInvalid("gzip;level=1");
+        assertInvalid("x/gzip");
+        assertInvalid("\u00e9");
+        assertInvalid("\u0100");
+    }
+
+    private static void assertValid(String token) {
+        assertThat(HttpToken.isValid(token), is(true));
+        assertDoesNotThrow(() -> HttpToken.validate(token));
+    }
+
+    private static void assertInvalid(String token) {
+        assertThat(HttpToken.isValid(token), is(false));
+        assertThrows(IllegalArgumentException.class, () -> HttpToken.validate(token));
     }
 }

--- a/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpTokenTest {
@@ -58,7 +57,7 @@ class HttpTokenTest {
 
     private static void assertValid(String token) {
         assertThat(HttpToken.isValid(token), is(true));
-        assertDoesNotThrow(() -> HttpToken.validate(token));
+        HttpToken.validate(token);
     }
 
     private static void assertInvalid(String token) {

--- a/http/http/src/test/java/io/helidon/http/MediaTypeTest.java
+++ b/http/http/src/test/java/io/helidon/http/MediaTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.http;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -67,6 +68,17 @@ class MediaTypeTest {
     }
 
     @Test
+    void nullOrEmptyCharsetDoesNotUpdateParameter() {
+        HttpMediaType withCharset = HttpMediaType.create("text/plain; charset=utf-8");
+        HttpMediaType withoutCharset = HttpMediaType.create("text/plain");
+
+        assertThat(withCharset.withCharset((String) null).charset(), is(Optional.of("utf-8")));
+        assertThat(withCharset.withCharset("").charset(), is(Optional.of("utf-8")));
+        assertThat(withoutCharset.withCharset((String) null).charset(), is(Optional.empty()));
+        assertThat(withoutCharset.withCharset("").charset(), is(Optional.empty()));
+    }
+
+    @Test
     void parseParameters() {
         HttpMediaType mediaType = HttpMediaType.create("unknown-type/unknown-subtype; option1=value1; option2=value2");
 
@@ -83,8 +95,86 @@ class MediaTypeTest {
 
     @Test
     void parseEmptyParameterValue() {
-        assertThat(HttpMediaType.create("type/subtype; o1=").parameters(), is(Map.of()));
-        assertThat(HttpMediaType.create("type/subtype; o1=; o2=v2").parameters(), is(Map.of("o2", "v2")));
+        assertThrows(IllegalArgumentException.class, () -> HttpMediaType.create("type/subtype; o1="));
+        assertThrows(IllegalArgumentException.class, () -> HttpMediaType.create("type/subtype; o1=; o2=v2"));
+
+        assertThat(HttpMediaType.create("type/subtype; o1=", ParserMode.RELAXED).parameters(), is(Map.of()));
+        assertThat(HttpMediaType.create("type/subtype; o1=; o2=v2", ParserMode.RELAXED).parameters(),
+                   is(Map.of("o2", "v2")));
+    }
+
+    @Test
+    void parseQuotedParameterValue() {
+        HttpMediaType mediaType = HttpMediaType.create("text/plain; profile=\"a;b\\\"c\\\\d\"; empty=\"\"");
+
+        assertThat(mediaType.parameters(), is(Map.of("profile", "a;b\"c\\d", "empty", "")));
+        assertThat(mediaType.text(), is("text/plain; empty=\"\"; profile=\"a;b\\\"c\\\\d\""));
+    }
+
+    @Test
+    void parseQuotedParameterValueInRelaxedMode() {
+        HttpMediaType mediaType = HttpMediaType.create("text/plain; profile=\"a;b\"", ParserMode.RELAXED);
+
+        assertThat(mediaType.parameters(), is(Map.of("profile", "a;b")));
+    }
+
+    @Test
+    void parseQuotedPairCharacters() {
+        HttpMediaType escaped = HttpMediaType.create("text/plain; value=\"a\\~\\" + (char) 0x80 + "\"");
+        HttpMediaType unescaped = HttpMediaType.create("text/plain; value=\"a" + (char) 0x80 + "\"");
+
+        assertThat(escaped.parameters(), is(Map.of("value", "a~" + (char) 0x80)));
+        assertThat(unescaped.parameters(), is(Map.of("value", "a" + (char) 0x80)));
+    }
+
+    @Test
+    void parseOptionalWhitespaceAndEmptyParameters() {
+        HttpMediaType mediaType = HttpMediaType.create("text/plain\t; ; Charset=\"utf-8\";;format=flowed;");
+
+        assertThat(mediaType.parameters(), is(Map.of("charset", "utf-8", "format", "flowed")));
+        assertThat(mediaType.text(), is("text/plain; charset=utf-8; format=flowed"));
+    }
+
+    @Test
+    void rejectInvalidMediaTypes() {
+        List<String> invalidMediaTypes = List.of("",
+                                                 "text",
+                                                 "/plain",
+                                                 "text/",
+                                                 "text//plain",
+                                                 " text/plain",
+                                                 "text/plain ",
+                                                 "text /plain",
+                                                 "text/ plain",
+                                                 "text/plain, application/json",
+                                                 "text/plain; =value",
+                                                 "text/plain; name =value",
+                                                 "text/plain; name= value",
+                                                 "text/plain; name=",
+                                                 "text/plain; name=;",
+                                                 "text/plain; name=one two",
+                                                 "text/plain; name=\"unterminated",
+                                                 "text/plain; name=\"value\"x",
+                                                 "text/plain; name=\"bad" + (char) 0 + "value\"",
+                                                 "text/plain; name=\"bad" + (char) 0x7f + "value\"",
+                                                 "text/plain; name=\"bad" + (char) 0x100 + "value\"",
+                                                 "text/plain; name=\"bad\\" + (char) 0 + "value\"",
+                                                 "text/plain; name=\"bad\\" + (char) 0x7f + "value\"");
+
+        invalidMediaTypes.forEach(value -> assertThrows(IllegalArgumentException.class,
+                                                        () -> HttpMediaType.create(value),
+                                                        value));
+    }
+
+    @Test
+    void serializeParameterValuesUsingRfc9110Syntax() {
+        HttpMediaType mediaType = HttpMediaType.builder()
+                .mediaType(MediaTypes.TEXT_PLAIN)
+                .addParameter("token", "value")
+                .addParameter("quoted", "a b;c\"d\\e")
+                .build();
+
+        assertThat(mediaType.text(), is("text/plain; quoted=\"a b;c\\\"d\\\\e\"; token=value"));
     }
 
     @Test
@@ -140,10 +230,15 @@ class MediaTypeTest {
     // Calling create method with "text" argument shall throw IllegalArgumentException in strict mode.
     @Test
     void parseInvalidTextInStrictMode() {
-        assertThrows(IllegalArgumentException.class, () -> {
-                         HttpMediaType.create("text");
-                     },
-                     "Cannot parse media type: text");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                           () -> HttpMediaType.create("text"));
+
+        assertThat(exception.getMessage(), is("Cannot parse media type: text"));
+    }
+
+    @Test
+    void rejectNullParserMode() {
+        assertThrows(NullPointerException.class, () -> HttpMediaType.create("text/plain", null));
     }
 
     // Calling create method with "text" argument shall return "text/plain" in relaxed mode.

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -18,6 +18,7 @@ package io.helidon.http.http2;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
+import io.helidon.http.HttpToken;
 import io.helidon.http.LogFormatter;
 import io.helidon.http.Method;
 import io.helidon.http.ServerRequestHeaders;
@@ -433,6 +435,10 @@ public class Http2Headers {
      * @param growingBuffer buffer to write to
      */
     public void write(DynamicTable table, Http2HuffmanEncoder huffman, BufferData growingBuffer) {
+        // A rejected header block is not sent to the peer, so validate the complete block before changing the
+        // connection-scoped HPACK table.
+        validateEncoding();
+
         // first write pseudoheaders
         if (pseudoHeaders.hasStatus()) {
             StaticHeader indexed = null;
@@ -616,10 +622,13 @@ public class Http2Headers {
                 // read from bytes
                 String name;
                 try {
-                    name = readString(huffman, data);
+                    name = readString(huffman, data, StandardCharsets.US_ASCII);
                 } catch (IllegalArgumentException e) {
                     throw new Http2Exception(Http2ErrorCode.PROTOCOL,
                                              "Received a header with non ASCII character(s)");
+                }
+                if (name.isEmpty()) {
+                    throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received an empty header name");
                 }
                 if (!(name.toLowerCase(Locale.ROOT).equals(name))) {
                     throw new Http2Exception(Http2ErrorCode.PROTOCOL,
@@ -631,6 +640,11 @@ public class Http2Headers {
                                              "Received invalid pseudo-header field "
                                                      + "(or explicit value instead of indexed): "
                                                      + LogFormatter.escape(name));
+                }
+                try {
+                    HttpToken.validate(name);
+                } catch (IllegalArgumentException e) {
+                    throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received an invalid header name", e);
                 }
                 headerName = HeaderNames.create(name);
             } else {
@@ -649,7 +663,7 @@ public class Http2Headers {
 
             if (approach.hasValue) {
                 // read from bytes
-                value = readString(huffman, data);
+                value = readString(huffman, data, StandardCharsets.ISO_8859_1);
             } else {
                 value = record.value();
                 if (value == null) {
@@ -696,7 +710,7 @@ public class Http2Headers {
         }
     }
 
-    private static String readString(Http2HuffmanDecoder huffman, BufferData data) {
+    private static String readString(Http2HuffmanDecoder huffman, BufferData data, Charset charset) {
         if (data.available() < 1) {
             throw new Http2Exception(Http2ErrorCode.COMPRESSION, "No data available to read header");
         }
@@ -746,9 +760,9 @@ public class Http2Headers {
         }
 
         if (isHuffman) {
-            return huffman.decodeString(data, length);
+            return huffman.decodeString(data, length, charset);
         } else {
-            return data.readString(length);
+            return data.readString(length, charset);
         }
     }
 
@@ -822,49 +836,64 @@ public class Http2Headers {
                              String value,
                              boolean shouldIndex,
                              boolean neverIndex) {
-        IndexedHeaderRecord record = table.find(name, value);
+        int index = table.findIndex(name, value);
         HeaderApproach approach;
 
-        if (record == null) {
+        if (index == 0) {
             // neither name nor value exists in an index
             if (shouldIndex) {
                 table.add(name, value);
             }
-            approach = new HeaderApproach(shouldIndex,
-                                          neverIndex,
-                                          true,
-                                          true,
-                                          0);
+            approach = new HeaderApproach(shouldIndex, neverIndex, true, true, 0);
+        } else if (index > 0) {
+            // this is the exact same name and value
+            approach = new HeaderApproach(false, neverIndex, false, false, index);
         } else {
-            // at least name is available in index, maybe even value
-            if (value.equals(record.value())) {
-                // this is the exact same name and value
-                approach = new HeaderApproach(false,
-                                              neverIndex,
-                                              false,
-                                              false,
-                                              record.index());
-            } else {
-                // same name
-                if (shouldIndex) {
-                    table.add(name, value);
-                }
-                // in both cases, we use index to record name
-                approach = new HeaderApproach(shouldIndex,
-                                              neverIndex,
-                                              false,
-                                              true,
-                                              record.index());
+            // same name
+            if (shouldIndex) {
+                table.add(name, value);
             }
+            // in both cases, we use index to record name
+            approach = new HeaderApproach(shouldIndex, neverIndex, false, true, -index);
         }
 
         approach.write(huffman, buffer, name, value);
     }
 
+    private void validateEncoding() {
+        if (pseudoHeaders.hasStatus()) {
+            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.status().codeText());
+        }
+        if (pseudoHeaders.hasMethod()) {
+            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.method().text());
+        }
+        if (pseudoHeaders.hasScheme()) {
+            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.scheme());
+        }
+        if (pseudoHeaders.hasPath()) {
+            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.path());
+        }
+        if (pseudoHeaders.hasAuthority()) {
+            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.authority());
+        }
+
+        for (Header header : headers) {
+            HeaderName headerName = header.headerName();
+            String lowerCaseName = headerName.lowerCase();
+            if (headerName.index() < 0 || lowerCaseName.isEmpty() || lowerCaseName.charAt(0) == ':') {
+                HttpToken.validate(lowerCaseName);
+            }
+            if (header.valueCount() == 1) {
+                Http2HuffmanEncoder.validateLatin1(header.get());
+            } else {
+                header.allValues().forEach(Http2HuffmanEncoder::validateLatin1);
+            }
+        }
+    }
+
     private void writeHeader(BufferData buffer,
                              StaticHeader header) {
-        new HeaderApproach(false, false, false, false, header.index)
-                .write(buffer);
+        buffer.writeHpackInt(header.index, 0b10000000, 7);
     }
 
     enum StaticHeader implements IndexedHeaderRecord {
@@ -1148,10 +1177,6 @@ public class Http2Headers {
             }
         }
 
-        public boolean nameFromIndex() {
-            return !hasName;
-        }
-
         public void write(Http2HuffmanEncoder huffman, BufferData buffer, HeaderName headerName, String value) {
             /*
              0   1   2   3   4   5   6   7
@@ -1164,37 +1189,36 @@ public class Http2Headers {
            +-------------------------------+
              */
             // write flags + index beginning
-            boolean hasValue = hasValue();
-
-            if (neverIndex()) {
-                if (hasName()) {
+            boolean writeValue = hasValue;
+            if (neverIndex) {
+                if (hasName) {
                     // never indexed, custom name and value
                     buffer.writeInt8(0b00010000);
                 } else {
                     // indexed name
-                    if (!hasValue) {
+                    if (!writeValue) {
                         // this is garbage, cannot "never index" a header that is already indexed
                         if (LOGGER.isLoggable(DEBUG)) {
                             LOGGER.log(DEBUG, "Never index on field with indexed value: "
                                     + LogFormatter.escape(headerName.defaultCase()));
                         }
 
-                        hasValue = true;
+                        writeValue = true;
                     }
                     buffer.writeHpackInt(number, 0b00010000, 4);
                 }
-            } else if (addToIndex()) {
+            } else if (addToIndex) {
                 if (hasName) {
                     // index, custom name and value
                     buffer.writeInt8(0b01000000);
                 } else {
                     // index and name from index
-                    if (!hasValue) {
+                    if (!writeValue) {
                         if (LOGGER.isLoggable(DEBUG)) {
                             LOGGER.log(DEBUG, "Index on field with indexed value: "
                                     + LogFormatter.escape(headerName.defaultCase()));
                         }
-                        hasValue = true;
+                        writeValue = true;
                     }
                     buffer.writeHpackInt(number, 0b01000000, 6);
                 }
@@ -1205,7 +1229,7 @@ public class Http2Headers {
                     buffer.write(0);
                 } else {
                     // indexed name
-                    if (hasValue) {
+                    if (writeValue) {
                         // indexed name, custom value
                         buffer.writeHpackInt(number, 0, 4);
                     } else {
@@ -1218,7 +1242,7 @@ public class Http2Headers {
             if (hasName) {
                 String name = headerName.lowerCase();
                 if (name.length() > 3) {
-                    huffman.encode(buffer, name);
+                    huffman.encodeValidated(buffer, name);
                 } else {
                     byte[] nameBytes = name.getBytes(StandardCharsets.US_ASCII);
                     buffer.writeHpackInt(nameBytes.length, 0, 7);
@@ -1226,11 +1250,11 @@ public class Http2Headers {
                 }
 
             }
-            if (hasValue) {
+            if (writeValue) {
                 if (value.length() > 3) {
-                    huffman.encode(buffer, value);
+                    huffman.encodeValidated(buffer, value);
                 } else {
-                    byte[] valueBytes = value.getBytes(StandardCharsets.US_ASCII);
+                    byte[] valueBytes = Http2HuffmanEncoder.encodeLatin1(value);
                     buffer.writeHpackInt(valueBytes.length, 0, 7);
                     buffer.write(valueBytes);
                 }
@@ -1238,26 +1262,6 @@ public class Http2Headers {
             }
         }
 
-        public boolean hasValue() {
-            return hasValue;
-        }
-
-        public boolean neverIndex() {
-            return neverIndex;
-        }
-
-        public boolean hasName() {
-            return hasName;
-        }
-
-        public boolean addToIndex() {
-            return addToIndex;
-        }
-
-        // write fully indexed value
-        void write(BufferData buffer) {
-            buffer.writeHpackInt(number, 0b10000000, 7);
-        }
     }
 
     /**
@@ -1323,7 +1327,7 @@ public class Http2Headers {
 
         int add(HeaderName headerName, String headerValue) {
             String name = headerName.lowerCase();
-            int size = name.length() + headerValue.getBytes(StandardCharsets.US_ASCII).length + 32;
+            int size = name.length() + headerValue.length() + 32;
 
             if (currentTableSize + size <= maxTableSize) {
                 // fast path
@@ -1356,31 +1360,32 @@ public class Http2Headers {
             return currentTableSize;
         }
 
-        private IndexedHeaderRecord find(HeaderName headerName, String headerValue) {
+        private int findIndex(HeaderName headerName, String headerValue) {
             StaticHeader staticHeader = StaticHeader.find(headerName, headerValue);
-            IndexedHeaderRecord candidate = null;
+            int candidate = 0;
 
             if (staticHeader != null) {
                 if (staticHeader.name.equals(headerName)
                         && staticHeader.hasValue
                         && staticHeader.value().equals(headerValue)) {
-                    return staticHeader;
+                    return staticHeader.index();
                 }
-                candidate = staticHeader;
+                candidate = staticHeader.index();
             }
             for (int i = 0; i < headers.size(); i++) {
                 DynamicHeader header = headers.get(i);
                 if (header.headerName.equals(headerName)) {
+                    int index = StaticHeader.MAX_INDEX + i + 1;
                     if (header.value().equals(headerValue)) {
-                        return new IndexedHeader(header, StaticHeader.MAX_INDEX + i + 1);
+                        return index;
                     }
-                    if (candidate == null) {
-                        candidate = new IndexedHeader(header, StaticHeader.MAX_INDEX + i + 1);
+                    if (candidate == 0) {
+                        candidate = index;
                     }
                 }
             }
 
-            return candidate;
+            return -candidate;
         }
 
         private void evict() {
@@ -1413,18 +1418,6 @@ public class Http2Headers {
     }
 
     private record DynamicHeader(HeaderName headerName, String value, int size) implements HeaderRecord {
-    }
-
-    private record IndexedHeader(HeaderRecord delegate, int index) implements IndexedHeaderRecord {
-        @Override
-        public HeaderName headerName() {
-            return delegate().headerName();
-        }
-
-        @Override
-        public String value() {
-            return delegate.value();
-        }
     }
 
     private static class PseudoHeaders {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanDecoder.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
  */
 package io.helidon.http.http2;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
 
@@ -74,10 +75,14 @@ public class Http2HuffmanDecoder {
      * @return decoded string
      */
     public String decodeString(BufferData data, int length) {
+        return decodeString(data, length, StandardCharsets.US_ASCII);
+    }
+
+    String decodeString(BufferData data, int length, Charset charset) {
         if (length == 0) {
             return EMPTY_STRING;
         }
-        return decodeBytes(data, length, (bytes, size) -> new String(bytes, 0, size, StandardCharsets.US_ASCII));
+        return decodeBytes(data, length, (bytes, size) -> new String(bytes, 0, size, charset));
     }
 
     private boolean process(byte input) {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@
  */
 package io.helidon.http.http2;
 
+import java.nio.charset.StandardCharsets;
+
 import io.helidon.common.buffers.BufferData;
 
 /**
@@ -57,12 +59,40 @@ public class Http2HuffmanEncoder {
         return new Http2HuffmanEncoder();
     }
 
+    static byte[] encodeLatin1(String value) {
+        return value.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    static void validateLatin1(String value) {
+        int length = value.length();
+        int i = 0;
+        for (; i + 3 < length; i += 4) {
+            int characters = value.charAt(i)
+                    | value.charAt(i + 1)
+                    | value.charAt(i + 2)
+                    | value.charAt(i + 3);
+            if ((characters & 0xff00) != 0) {
+                throw new IllegalArgumentException("Header value contains a character above 0xff");
+            }
+        }
+        for (; i < length; i++) {
+            if (value.charAt(i) > 0xff) {
+                throw new IllegalArgumentException("Header value contains a character above 0xff");
+            }
+        }
+    }
+
     void encode(BufferData buffer, String string) {
+        validateLatin1(string);
+        encodeValidated(buffer, string);
+    }
+
+    void encodeValidated(BufferData buffer, String string) {
         int index = 0;
 
         long current = 0;
         int n = 0;
-        byte[] bytes = new byte[string.length()];
+        byte[] bytes = new byte[encodedLength(string)];
 
         for (int i = 0; i < string.length(); i++) {
             int b = string.charAt(i) & 0xFF;
@@ -89,6 +119,13 @@ public class Http2HuffmanEncoder {
 
         buffer.writeHpackInt(index, HUFFMAN_ENCODED, 7);
         buffer.write(bytes, 0, index);
+    }
 
+    private static int encodedLength(String string) {
+        long bitLength = 0;
+        for (int i = 0; i < string.length(); i++) {
+            bitLength += Http2HuffmanConstants.HUFFMAN_CODE_LENGTHS[string.charAt(i)];
+        }
+        return Math.toIntExact((bitLength + 7) / 8);
     }
 }

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -29,6 +29,8 @@ import io.helidon.http.http2.Http2Headers.DynamicTable;
 import io.helidon.http.http2.Http2Headers.HeaderRecord;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class Http2HeadersTest {
     private static final HeaderName CUSTOM_HEADER_NAME = HeaderNames.create("custom-key");
+    private static final Method CUSTOM_METHOD = Method.create("SEARCH");
 
     @Test
     void testRequestRejectsTransferEncoding() {
@@ -198,6 +201,91 @@ class Http2HeadersTest {
         buffer.read(actual);
 
         assertThat(actual, is(expected));
+    }
+
+    @Test
+    void testLatin1HeaderValueRoundTrip() {
+        assertHeaderValueRoundTrip("\u0080\u00ff");
+        assertHeaderValueRoundTrip("a\u0080\u00ffb");
+    }
+
+    @Test
+    void testRejectsNonLatin1ValueBeforeWritingOrIndexing() {
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        BufferData buffer = BufferData.growing(32);
+        Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create()
+                                                               .add(HeaderNames.CONTENT_TYPE, "text/plain")
+                                                               .add(CUSTOM_HEADER_NAME, "\u0100"))
+                .method(CUSTOM_METHOD)
+                .scheme("https")
+                .path("/");
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> http2Headers.write(dynamicTable, Http2HuffmanEncoder.create(), buffer));
+        assertThat(dynamicTable.currentTableSize(), is(0));
+        assertThat(buffer.available(), is(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"custom-\u0080", ":custom", ":bad\u0100"})
+    void testRejectsInvalidHeaderNameBeforeWritingOrIndexing(String invalidName) {
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        BufferData buffer = BufferData.growing(32);
+        Http2Headers http2Headers = Http2Headers.create(WritableHeaders.create()
+                                                               .add(HeaderNames.CONTENT_TYPE, "text/plain")
+                                                               .add(HeaderNames.create(invalidName), "value"))
+                .method(CUSTOM_METHOD)
+                .scheme("https")
+                .path("/");
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> http2Headers.write(dynamicTable, Http2HuffmanEncoder.create(), buffer));
+        assertThat(dynamicTable.currentTableSize(), is(0));
+        assertThat(buffer.available(), is(0));
+    }
+
+    @Test
+    void testFailedHeaderEncodingDoesNotPoisonNextHeaderBlock() {
+        DynamicTable outboundTable = DynamicTable.create(Http2Settings.create());
+        Http2HuffmanEncoder encoder = Http2HuffmanEncoder.create();
+        Http2Headers rejected = Http2Headers.create(WritableHeaders.create()
+                                                            .add(HeaderNames.HOST, "invalid-\u0100.example")
+                                                            .add(HeaderNames.CONTENT_TYPE, "text/plain"))
+                .method(CUSTOM_METHOD)
+                .scheme("https")
+                .path("/");
+
+        rejected.validateRequest();
+
+        BufferData rejectedBlock = BufferData.growing(64);
+        assertThrows(IllegalArgumentException.class,
+                     () -> rejected.write(outboundTable, encoder, rejectedBlock));
+        assertThat(outboundTable.currentTableSize(), is(0));
+        assertThat(rejectedBlock.available(), is(0));
+
+        BufferData nextBlock = BufferData.growing(64);
+        Http2Headers.create(WritableHeaders.create()
+                                    .add(HeaderNames.HOST, "example.com")
+                                    .add(HeaderNames.CONTENT_TYPE, "text/plain"))
+                .method(CUSTOM_METHOD)
+                .scheme("https")
+                .path("/")
+                .write(outboundTable, encoder, nextBlock);
+
+        DynamicTable inboundTable = DynamicTable.create(Http2Settings.create());
+        Http2Headers decoded = headers(HexFormat.of().formatHex(nextBlock.readBytes()), inboundTable);
+
+        assertThat(decoded.method(), is(CUSTOM_METHOD));
+    }
+
+    @Test
+    void testRejectsNonAsciiLiteralHeaderName() {
+        String hexEncoded = "40 01 80 01 61";
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+
+        Http2Exception exception = assertThrows(Http2Exception.class, () -> headers(hexEncoded, dynamicTable));
+
+        assertThat(exception.code(), is(Http2ErrorCode.PROTOCOL));
     }
 
     @Test
@@ -434,6 +522,19 @@ class Http2HeadersTest {
                                    dynamicTable,
                                    Http2HuffmanDecoder.create(),
                                    new Http2FrameData(header, data));
+    }
+
+    private void assertHeaderValueRoundTrip(String value) {
+        DynamicTable outboundTable = DynamicTable.create(Http2Settings.create());
+        BufferData buffer = BufferData.growing(32);
+        Http2Headers outbound = Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, value));
+        outbound.write(outboundTable, Http2HuffmanEncoder.create(), buffer);
+
+        String encoded = HexFormat.of().formatHex(buffer.readBytes());
+        DynamicTable inboundTable = DynamicTable.create(Http2Settings.create());
+        Headers decoded = headers(encoded, inboundTable).httpHeaders();
+
+        assertThat(decoded.get(CUSTOM_HEADER_NAME).get(), is(value));
     }
 
     private static String requestHeaders(String authority, String... hostValues) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.http2;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.HttpMediaType;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.http.WritableHeaders;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+public class HttpCodecJmhBenchmark {
+    private static final String SIMPLE_CONTENT_TYPE = "application/json";
+    private static final String QUOTED_CONTENT_TYPE = "text/plain; profile=\"a\u0080\u00ff\"";
+    private static final String ASCII_VALUE = "0123456789";
+    private static final String LATIN1_VALUE = "\u008012345678\u00ff";
+    private static final HeaderName CUSTOM_HEADER_NAME = HeaderNames.create("x-jmh-custom-header");
+    private static final HeaderName MULTI_VALUE_HEADER_NAME = HeaderNames.create("x-jmh-multi-value");
+    private static final Method CUSTOM_METHOD = Method.create("SEARCH");
+    private static final HttpMediaType SIMPLE_MEDIA_TYPE = HttpMediaType.create(SIMPLE_CONTENT_TYPE);
+    private static final HttpMediaType QUOTED_MEDIA_TYPE = HttpMediaType.create(QUOTED_CONTENT_TYPE);
+
+    @Benchmark
+    public HttpMediaType parseSimpleContentType() {
+        return HttpMediaType.create(SIMPLE_CONTENT_TYPE);
+    }
+
+    @Benchmark
+    public HttpMediaType parseQuotedContentType() {
+        return HttpMediaType.create(QUOTED_CONTENT_TYPE);
+    }
+
+    @Benchmark
+    public String serializeSimpleContentType() {
+        return SIMPLE_MEDIA_TYPE.text();
+    }
+
+    @Benchmark
+    public String serializeQuotedContentType() {
+        return QUOTED_MEDIA_TYPE.text();
+    }
+
+    @Benchmark
+    public int writeHttp1Ascii(EncodingState state) {
+        state.http1Buffer.clear();
+        state.asciiHeader.writeHttp1Header(state.http1Buffer);
+        return state.http1Buffer.available();
+    }
+
+    @Benchmark
+    public int writeHttp1Latin1(EncodingState state) {
+        state.http1Buffer.clear();
+        state.latin1Header.writeHttp1Header(state.http1Buffer);
+        return state.http1Buffer.available();
+    }
+
+    @Benchmark
+    public int encodeHpackAscii(EncodingState state) {
+        state.hpackBuffer.clear();
+        state.huffmanEncoder.encode(state.hpackBuffer, ASCII_VALUE);
+        return state.hpackBuffer.available();
+    }
+
+    @Benchmark
+    public int encodeHpackLatin1(EncodingState state) {
+        state.hpackBuffer.clear();
+        state.huffmanEncoder.encode(state.hpackBuffer, LATIN1_VALUE);
+        return state.hpackBuffer.available();
+    }
+
+    @Benchmark
+    public int writeHpackRequestAscii(EncodingState state) {
+        return state.requestAscii.write();
+    }
+
+    @Benchmark
+    public int writeHpackRequestLatin1(EncodingState state) {
+        return state.requestLatin1.write();
+    }
+
+    @Benchmark
+    public int writeHpackResponseAscii(EncodingState state) {
+        return state.responseAscii.write();
+    }
+
+    @Benchmark
+    public int writeHpackResponseLatin1(EncodingState state) {
+        return state.responseLatin1.write();
+    }
+
+    private static Http2Headers requestHeaders(String value) {
+        return Http2Headers.create(headers(value))
+                .method(CUSTOM_METHOD)
+                .scheme("https")
+                .path("/search?name=benchmark")
+                .authority("example.com");
+    }
+
+    private static Http2Headers responseHeaders(String value) {
+        return Http2Headers.create(headers(value))
+                .status(Status.OK_200);
+    }
+
+    private static WritableHeaders<?> headers(String value) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.CONTENT_TYPE_JSON);
+        headers.add(HeaderValues.CACHE_NO_CACHE);
+        headers.add(HeaderValues.create(CUSTOM_HEADER_NAME, true, false, value));
+        headers.add(HeaderValues.create(MULTI_VALUE_HEADER_NAME, true, false, value, value));
+        return headers;
+    }
+
+    @State(Scope.Thread)
+    public static class EncodingState {
+        private final Header asciiHeader = HeaderValues.create("X-JMH", ASCII_VALUE);
+        private final Header latin1Header = HeaderValues.create("X-JMH", LATIN1_VALUE);
+        private final BufferData http1Buffer = BufferData.growing(32);
+        private final BufferData hpackBuffer = BufferData.growing(32);
+        private final Http2HuffmanEncoder huffmanEncoder = Http2HuffmanEncoder.create();
+        private final HeaderBlockState requestAscii = new HeaderBlockState(requestHeaders(ASCII_VALUE));
+        private final HeaderBlockState requestLatin1 = new HeaderBlockState(requestHeaders(LATIN1_VALUE));
+        private final HeaderBlockState responseAscii = new HeaderBlockState(responseHeaders(ASCII_VALUE));
+        private final HeaderBlockState responseLatin1 = new HeaderBlockState(responseHeaders(LATIN1_VALUE));
+    }
+
+    private static class HeaderBlockState {
+        private final Http2Headers headers;
+        private final Http2Headers.DynamicTable table = Http2Headers.DynamicTable.create(Http2Settings.create());
+        private final Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+        private final BufferData buffer = BufferData.growing(256);
+
+        private HeaderBlockState(Http2Headers headers) {
+            this.headers = headers;
+            write();
+        }
+
+        private int write() {
+            buffer.clear();
+            headers.write(table, huffman, buffer);
+            return buffer.available();
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webclient.api.ClientRequest;
+import io.helidon.webclient.api.HttpClient;
+import io.helidon.webclient.api.HttpClientResponse;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http2.Http2Client;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.http2.Http2ConnectionSelector;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class HttpRedirectJmhBenchmark {
+    private static final int REQUESTS_PER_INVOCATION = 8;
+    private static final String HOST = "127.0.0.1";
+    private static final String REDIRECT_PATH = "/redirect";
+    private static final String TARGET_PATH = "/target";
+    private static final byte[] REQUEST_ENTITY = "request-entity".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RESPONSE_ENTITY = "ok".getBytes(StandardCharsets.UTF_8);
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1PutOutputStreamRedirect(NetworkState state, Blackhole blackhole) {
+        invokeRedirectOutputStream(state.http1Client, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http2PutOutputStreamRedirect(NetworkState state, Blackhole blackhole) {
+        invokeRedirectOutputStream(state.http2Client, blackhole);
+    }
+
+    private static void configureRouting(HttpRouting.Builder routing) {
+        routing.put(REDIRECT_PATH, HttpRedirectJmhBenchmark::redirect)
+                .put(TARGET_PATH, HttpRedirectJmhBenchmark::handle);
+    }
+
+    private static void redirect(ServerRequest request, ServerResponse response) {
+        request.content().as(byte[].class);
+        response.status(Status.TEMPORARY_REDIRECT_307)
+                .header(HeaderNames.LOCATION, TARGET_PATH)
+                .send();
+    }
+
+    private static void handle(ServerRequest request, ServerResponse response) {
+        request.content().as(byte[].class);
+        response.send(RESPONSE_ENTITY);
+    }
+
+    private static void invokeRedirectOutputStream(HttpClient<?> client, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            ClientRequest<?> request = client.method(Method.PUT)
+                    .uri(REDIRECT_PATH)
+                    .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
+                    .followRedirects(true);
+            try (HttpClientResponse response = request.outputStream(output -> {
+                output.write(REQUEST_ENTITY);
+                output.close();
+            })) {
+                consume(response, blackhole);
+            }
+        }
+    }
+
+    private static void consume(HttpClientResponse response, Blackhole blackhole) {
+        response.entity().consume();
+        int status = response.status().code();
+        if (status != Status.OK_200.code()) {
+            throw new IllegalStateException("Unexpected benchmark response: " + response.status());
+        }
+        blackhole.consume(status);
+    }
+
+    private static void warmUp(HttpClient<?> client) {
+        try (HttpClientResponse response = client.method(Method.PUT)
+                .uri(TARGET_PATH)
+                .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
+                .submit(REQUEST_ENTITY)) {
+            response.entity().consume();
+            if (response.status().code() != Status.OK_200.code()) {
+                throw new IllegalStateException("Could not warm benchmark connection: " + response.status());
+            }
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class NetworkState {
+        private WebServer server;
+        private Http1Client http1Client;
+        private Http2Client http2Client;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            LogConfig.configureRuntime();
+            Http2Config http2Config = Http2Config.builder().build();
+            try {
+                server = WebServer.builder()
+                        .host(HOST)
+                        .addProtocol(http2Config)
+                        .addConnectionSelector(Http2ConnectionSelector.builder()
+                                                       .http2Config(http2Config)
+                                                       .build())
+                        .routing(HttpRedirectJmhBenchmark::configureRouting)
+                        .build()
+                        .start();
+
+                String baseUri = "http://" + HOST + ":" + server.port();
+                http1Client = Http1Client.builder()
+                        .baseUri(baseUri)
+                        .shareConnectionCache(false)
+                        .servicesDiscoverServices(false)
+                        .build();
+                http2Client = Http2Client.builder()
+                        .baseUri(baseUri)
+                        .shareConnectionCache(false)
+                        .servicesDiscoverServices(false)
+                        .protocolConfig(config -> config.priorKnowledge(true))
+                        .build();
+
+                warmUp(http1Client);
+                warmUp(http2Client);
+            } catch (RuntimeException e) {
+                tearDown();
+                throw e;
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            if (http2Client != null) {
+                http2Client.closeResource();
+            }
+            if (http1Client != null) {
+                http1Client.closeResource();
+            }
+            if (server != null) {
+                server.stop();
+            }
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhBenchmark.java
@@ -47,7 +47,9 @@ public class HttpRedirectJmhBenchmark {
     private static final int REQUESTS_PER_INVOCATION = 8;
     private static final String HOST = "127.0.0.1";
     private static final String REDIRECT_PATH = "/redirect";
+    private static final String EARLY_REDIRECT_PATH = "/early-redirect";
     private static final String TARGET_PATH = "/target";
+    private static final String NO_CONTENT_PATH = "/no-content";
     private static final byte[] REQUEST_ENTITY = "request-entity".getBytes(StandardCharsets.UTF_8);
     private static final byte[] RESPONSE_ENTITY = "ok".getBytes(StandardCharsets.UTF_8);
 
@@ -59,13 +61,21 @@ public class HttpRedirectJmhBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
+    public void http1PutOutputStreamEarlyRedirect(NetworkState state, Blackhole blackhole) {
+        invokeEarlyRedirectOutputStream(state.http1Client, blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(REQUESTS_PER_INVOCATION)
     public void http2PutOutputStreamRedirect(NetworkState state, Blackhole blackhole) {
         invokeRedirectOutputStream(state.http2Client, blackhole);
     }
 
     private static void configureRouting(HttpRouting.Builder routing) {
         routing.put(REDIRECT_PATH, HttpRedirectJmhBenchmark::redirect)
-                .put(TARGET_PATH, HttpRedirectJmhBenchmark::handle);
+                .put(EARLY_REDIRECT_PATH, HttpRedirectJmhBenchmark::earlyRedirect)
+                .put(TARGET_PATH, HttpRedirectJmhBenchmark::handle)
+                .get(NO_CONTENT_PATH, HttpRedirectJmhBenchmark::noContent);
     }
 
     private static void redirect(ServerRequest request, ServerResponse response) {
@@ -75,9 +85,19 @@ public class HttpRedirectJmhBenchmark {
                 .send();
     }
 
+    private static void earlyRedirect(ServerRequest request, ServerResponse response) {
+        response.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, NO_CONTENT_PATH)
+                .send();
+    }
+
     private static void handle(ServerRequest request, ServerResponse response) {
         request.content().as(byte[].class);
         response.send(RESPONSE_ENTITY);
+    }
+
+    private static void noContent(ServerRequest request, ServerResponse response) {
+        response.status(Status.NO_CONTENT_204).send();
     }
 
     private static void invokeRedirectOutputStream(HttpClient<?> client, Blackhole blackhole) {
@@ -91,6 +111,26 @@ public class HttpRedirectJmhBenchmark {
                 output.close();
             })) {
                 consume(response, blackhole);
+            }
+        }
+    }
+
+    private static void invokeEarlyRedirectOutputStream(HttpClient<?> client, Blackhole blackhole) {
+        for (int i = 0; i < REQUESTS_PER_INVOCATION; i++) {
+            ClientRequest<?> request = client.method(Method.PUT)
+                    .uri(EARLY_REDIRECT_PATH)
+                    .header(HeaderNames.CONTENT_TYPE, "application/octet-stream")
+                    .followRedirects(true);
+            try (HttpClientResponse response = request.outputStream(output -> {
+                output.write(REQUEST_ENTITY);
+                output.close();
+            })) {
+                response.entity().consume();
+                int status = response.status().code();
+                if (status != Status.NO_CONTENT_204.code()) {
+                    throw new IllegalStateException("Unexpected early-redirect response: " + response.status());
+                }
+                blackhole.consume(status);
             }
         }
     }
@@ -140,6 +180,7 @@ public class HttpRedirectJmhBenchmark {
                 String baseUri = "http://" + HOST + ":" + server.port();
                 http1Client = Http1Client.builder()
                         .baseUri(baseUri)
+                        .sendExpectContinue(true)
                         .shareConnectionCache(false)
                         .servicesDiscoverServices(false)
                         .build();

--- a/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.http.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import io.helidon.http.http2.HttpCodecJmhBenchmark;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class HttpCodecJmhRunnerTest {
+    private static final String METHODS =
+            "(parseSimpleContentType|parseQuotedContentType|serializeSimpleContentType|serializeQuotedContentType|"
+                    + "writeHttp1Ascii|writeHttp1Latin1|"
+                    + "encodeHpackAscii|encodeHpackLatin1|writeHpackRequestAscii|writeHpackRequestLatin1|"
+                    + "writeHpackResponseAscii|writeHpackResponseLatin1)";
+
+    @Test
+    void runExactBenchmarks() throws RunnerException {
+        String result = System.getProperty("http.codec.jmh.result", "target/http-codec-jmh.json");
+        String include = System.getProperty("http.codec.jmh.include",
+                                            exactMethods(HttpCodecJmhBenchmark.class, METHODS));
+
+        Options options = optionsBuilder()
+                .include(include)
+                .result(result)
+                .build();
+        new Runner(options).run();
+    }
+
+    private static ChainedOptionsBuilder optionsBuilder() {
+        ChainedOptionsBuilder builder = new OptionsBuilder()
+                .threads(1)
+                .forks(Integer.getInteger("http.codec.jmh.forks", 3))
+                .warmupIterations(Integer.getInteger("http.codec.jmh.warmupIterations", 3))
+                .warmupTime(TimeValue.milliseconds(Long.getLong("http.codec.jmh.warmupMillis", 500)))
+                .measurementIterations(Integer.getInteger("http.codec.jmh.measurementIterations", 5))
+                .measurementTime(TimeValue.milliseconds(Long.getLong("http.codec.jmh.measurementMillis", 1_000)))
+                .mode(Mode.AverageTime)
+                .timeUnit(TimeUnit.NANOSECONDS)
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .timeout(TimeValue.seconds(Long.getLong("http.codec.jmh.timeoutSeconds", 30)));
+        String jvmArgument = System.getProperty("http.codec.jmh.jvmArgument");
+        if (jvmArgument != null) {
+            builder.jvmArgsAppend(jvmArgument);
+        }
+        return builder;
+    }
+
+    private static String exactMethods(Class<?> benchmarkClass, String methods) {
+        return "^" + Pattern.quote(benchmarkClass.getName()) + "\\." + methods + "$";
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.benchmark.jmh;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class HttpRedirectJmhRunnerTest {
+    private static final String METHODS = "(http1PutOutputStreamRedirect|http2PutOutputStreamRedirect)";
+
+    @Test
+    void runExactBenchmarks() throws RunnerException {
+        String result = System.getProperty("http.redirect.jmh.result", "target/http-redirect-jmh.json");
+        String include = System.getProperty(
+                "http.redirect.jmh.include",
+                "^" + Pattern.quote(HttpRedirectJmhBenchmark.class.getName()) + "\\." + METHODS + "$");
+
+        Options options = new OptionsBuilder()
+                .include(include)
+                .threads(1)
+                .forks(Integer.getInteger("http.redirect.jmh.forks", 3))
+                .warmupIterations(Integer.getInteger("http.redirect.jmh.warmupIterations", 3))
+                .measurementIterations(Integer.getInteger("http.redirect.jmh.measurementIterations", 5))
+                .mode(Mode.SingleShotTime)
+                .timeUnit(TimeUnit.MICROSECONDS)
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .timeout(TimeValue.seconds(Long.getLong("http.redirect.jmh.timeoutSeconds", 30)))
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/webclient/benchmark/jmh/HttpRedirectJmhRunnerTest.java
@@ -30,7 +30,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
 class HttpRedirectJmhRunnerTest {
-    private static final String METHODS = "(http1PutOutputStreamRedirect|http2PutOutputStreamRedirect)";
+    private static final String METHODS = "(http1PutOutputStreamEarlyRedirect|http1PutOutputStreamRedirect"
+            + "|http2PutOutputStreamRedirect)";
 
     @Test
     void runExactBenchmarks() throws RunnerException {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -256,24 +256,27 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
                                           DataReader reader) {
 
         Status responseStatus;
-        try {
-            responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
-        } catch (UncheckedIOException e) {
-            // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
-            // data of this request on the next use of this connection
+        ClientResponseHeaders responseHeaders;
+        do {
             try {
-                connection.closeResource();
-            } catch (Exception ex) {
-                e.addSuppressed(ex);
+                responseStatus = Http1StatusParser.readStatus(reader, protocolConfig.maxStatusLineLength());
+            } catch (UncheckedIOException e) {
+                // if we get a timeout or connection close, we must close the resource (as otherwise we may receive
+                // data of this request on the next use of this connection
+                try {
+                    connection.closeResource();
+                } catch (Exception ex) {
+                    e.addSuppressed(ex);
+                }
+                throw e;
             }
-            throw e;
-        }
 
-        recvListener.status(connection.helidonSocket(), responseStatus);
+            recvListener.status(connection.helidonSocket(), responseStatus);
 
-        ClientResponseHeaders responseHeaders = readHeaders(reader);
+            responseHeaders = readHeaders(reader);
 
-        recvListener.headers(connection.helidonSocket(), responseHeaders);
+            recvListener.headers(connection.helidonSocket(), responseHeaders);
+        } while (originalRequest.outputStreamRedirect() && isPreContinueInterimResponse(responseStatus));
 
         return createServiceResponse(http1Client,
                                      serviceRequest,
@@ -290,6 +293,12 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
 
     Http1ConnectionListener recvListener() {
         return recvListener;
+    }
+
+    private static boolean isPreContinueInterimResponse(Status responseStatus) {
+        return responseStatus.family() == Status.Family.INFORMATIONAL
+                && responseStatus.code() != Status.CONTINUE_100.code()
+                && responseStatus.code() != Status.SWITCHING_PROTOCOLS_101.code();
     }
 
     private static String requestTarget(ClientUri uri) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -316,8 +316,10 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }
-        // Why is NOT_MODIFIED_304 not added here too?
-        if (responseStatus.code() == Status.NO_CONTENT_204.code()) {
+        int statusCode = responseStatus.code();
+        if (statusCode == Status.NO_CONTENT_204_CODE
+                || statusCode == Status.RESET_CONTENT_205_CODE
+                || statusCode == Status.NOT_MODIFIED_304_CODE) {
             return false;
         }
         if ((

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -149,19 +149,30 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
     public WebClientServiceResponse proceed(WebClientServiceRequest serviceRequest) {
         // either use the explicit connection, or obtain one (keep alive or one-off)
         effectiveConnection = connection == null ? obtainConnection(serviceRequest) : connection;
-        effectiveConnection.readTimeout(this.timeout);
+        try {
+            effectiveConnection.readTimeout(this.timeout);
 
-        DataWriter writer = effectiveConnection.writer();
-        DataReader reader = effectiveConnection.reader();
-        ClientUri uri = serviceRequest.uri();
-        ClientRequestHeaders headers = serviceRequest.headers();
+            DataWriter writer = effectiveConnection.writer();
+            DataReader reader = effectiveConnection.reader();
+            ClientUri uri = serviceRequest.uri();
+            ClientRequestHeaders headers = serviceRequest.headers();
 
-        writeBuffer.clear();
-        originalRequest.sanitizeRedirectHeaders(uri, headers);
-        prologue(effectiveConnection, writeBuffer, serviceRequest, uri);
-        headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
+            writeBuffer.clear();
+            originalRequest.sanitizeRedirectHeaders(uri, headers);
+            prologue(effectiveConnection, writeBuffer, serviceRequest, uri);
+            headers.setIfAbsent(HeaderValues.create(HeaderNames.HOST, uri.authority()));
 
-        return doProceed(effectiveConnection, serviceRequest, headers, writer, reader, writeBuffer);
+            return doProceed(effectiveConnection, serviceRequest, headers, writer, reader, writeBuffer);
+        } catch (RuntimeException | Error e) {
+            if (connection == null) {
+                try {
+                    effectiveConnection.closeResource();
+                } catch (Throwable closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+            }
+            throw e;
+        }
     }
 
     abstract WebClientServiceResponse doProceed(ClientConnection connection,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -105,7 +105,7 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();
         AtomicReference<WebClientServiceResponse> response = new AtomicReference<>();
 
-        if (mayHaveEntity(responseStatus, responseHeaders)) {
+        if (mayHaveEntity(serviceRequest.method(), responseStatus, responseHeaders)) {
             // this may be an entity (if content length is set to zero, we know there is no entity)
             builder.inputStream(inputStream(clientConfig,
                                             recvListener,
@@ -312,7 +312,10 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         return requestTarget.substring(0, requestTarget.length() - fragmentLength - 1);
     }
 
-    private static boolean mayHaveEntity(Status responseStatus, ClientResponseHeaders responseHeaders) {
+    private static boolean mayHaveEntity(Method requestMethod, Status responseStatus, ClientResponseHeaders responseHeaders) {
+        if (requestMethod == Method.HEAD) {
+            return false;
+        }
         if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -318,8 +318,13 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
         }
         int statusCode = responseStatus.code();
         if (statusCode == Status.NO_CONTENT_204_CODE
-                || statusCode == Status.RESET_CONTENT_205_CODE
                 || statusCode == Status.NOT_MODIFIED_304_CODE) {
+            return false;
+        }
+        if (statusCode == Status.RESET_CONTENT_205_CODE
+                && !responseHeaders.contains(HeaderNames.CONTENT_LENGTH)
+                && !responseHeaders.contains(HeaderNames.TRANSFER_ENCODING)) {
+            // Preserve header-terminated 205 compatibility, but honor declared framing so it is consumed before reuse.
             return false;
         }
         if ((

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -327,9 +327,9 @@ abstract class Http1CallChainBase implements WebClientService.Chain {
             // Preserve header-terminated 205 compatibility, but honor declared framing so it is consumed before reuse.
             return false;
         }
-        if ((
-                responseHeaders.contains(HeaderNames.UPGRADE)
-                        && !responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED))) {
+        if (statusCode == Status.SWITCHING_PROTOCOLS_101_CODE
+                && responseHeaders.contains(HeaderNames.UPGRADE)
+                && !responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
             // this is an upgrade response and there is no entity
             return false;
         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -504,7 +504,9 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                                                                      connection,
                                                                      reader,
                                                                      responseStatus,
-                                                                     ClientResponseHeaders.create(responseHeaders),
+                                                                     ClientResponseHeaders.create(
+                                                                             responseHeaders,
+                                                                             clientConfig.mediaTypeParserMode()),
                                                                      whenComplete);
                         //we are not sending anything by this OS, we need to interrupt it.
                         throw new OutputStreamInterruptedException();

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -352,14 +352,15 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 return serviceResponse;
             }
 
+            ClientConnection responseConnection = response.connection();
             WebClientServiceResponse result = createServiceResponse(http1Client,
                                                                     request,
-                                                                    response.connection(),
-                                                                    response.connection().reader(),
+                                                                    responseConnection,
+                                                                    responseConnection.reader(),
                                                                     response.status(),
                                                                     response.headers(),
                                                                     whenComplete);
-            response.closeIfNoEntity();
+            response.completeIfNoEntityAfterConnectionTransfer();
             return result;
         }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -158,7 +158,8 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             Http1ClientRequestImpl request = new Http1ClientRequestImpl(cos.lastRequest,
                                                                         sendEntity ? cos.lastRequest.method() : Method.GET,
                                                                         redirectUri,
-                                                                        cos.lastRequest.properties());
+                                                                        cos.lastRequest.properties(),
+                                                                        sendEntity);
             if (sendEntity) {
                 request.maxRedirects(cos.lastRequest.maxRedirects() - numberOfRedirects);
             }
@@ -517,14 +518,14 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (lastStatus == Status.TEMPORARY_REDIRECT_307
-                    || lastStatus == Status.PERMANENT_REDIRECT_308) {
+            if (RedirectionProcessor.keepsMethodAndEntity(lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
                 method = Method.GET;
                 sendEntity = false;
             }
+            connection.closeResource();
             while (numberOfRedirects < originalRequest.maxRedirects()) {
                 numberOfRedirects++;
                 URI newUri = URI.create(redirectedUri);
@@ -535,7 +536,6 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     redirectUri.port(lastUri.port());
                 }
                 lastUri = redirectUri;
-                connection.closeResource();
                 boolean sendEmptyEntity = false;
                 if (sendEntity && !lastRequest.canReplayEntityTo(redirectUri)) {
                     // User code already provided bytes for the original origin; do not replay them across origins.
@@ -547,7 +547,8 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 Http1ClientRequestImpl clientRequest = new Http1ClientRequestImpl(lastRequest,
                                                                                   method,
                                                                                   redirectUri,
-                                                                                  lastRequest.properties());
+                                                                                  lastRequest.properties(),
+                                                                                  sendEntity);
                 clientRequest.followRedirects(false);
                 Http1ClientResponseImpl response;
                 if (sendEntity && !sendEmptyEntity) {
@@ -572,8 +573,7 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                     boolean closeRedirectProbeConnection = sendEntity && !sendEmptyEntity;
                     try {
                         checkRedirectHeaders(response.headers());
-                        if (response.status() != Status.TEMPORARY_REDIRECT_307
-                                && response.status() != Status.PERMANENT_REDIRECT_308) {
+                        if (!RedirectionProcessor.keepsMethodAndEntity(response.status())) {
                             method = Method.GET;
                             sendEntity = false;
                         }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -352,13 +352,15 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                 return serviceResponse;
             }
 
-            return createServiceResponse(http1Client,
-                                         request,
-                                         response.connection(),
-                                         response.connection().reader(),
-                                         response.status(),
-                                         response.headers(),
-                                         whenComplete);
+            WebClientServiceResponse result = createServiceResponse(http1Client,
+                                                                    request,
+                                                                    response.connection(),
+                                                                    response.connection().reader(),
+                                                                    response.status(),
+                                                                    response.headers(),
+                                                                    whenComplete);
+            response.closeIfNoEntity();
+            return result;
         }
 
         boolean closed() {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallOutputStreamChain.java
@@ -589,16 +589,20 @@ class Http1CallOutputStreamChain extends Http1CallChainBase {
                         response.close();
                     }
                 } else {
-                    if (!sendEntity || sendEmptyEntity) {
-                        //OS changed its state to interrupted, that means other usage of this OS will result in NOOP actions.
-                        this.interrupted = true;
-                        this.response = response;
-                        //we are not sending anything by this OS, we need to interrupt it.
-                        throw new OutputStreamInterruptedException();
-                    } else {
+                    if (sendEntity
+                            && !sendEmptyEntity
+                            && response.status().code() == Status.CONTINUE_100.code()) {
                         reader.skip(reader.available());
+                        return;
                     }
-                    return;
+                    if (sendEntity && !sendEmptyEntity) {
+                        response.closeConnectionOnClose();
+                    }
+                    //OS changed its state to interrupted, that means other usage of this OS will result in NOOP actions.
+                    this.interrupted = true;
+                    this.response = response;
+                    //we are not sending anything by this OS, we need to interrupt it.
+                    throw new OutputStreamInterruptedException();
                 }
 
             }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -302,6 +302,7 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         return new Http1ClientResponseImpl(clientConfig(),
                                            http1Client().protocolConfig(),
                                            serviceResponse.status(),
+                                           serviceResponse.serviceRequest().method(),
                                            serviceResponse.serviceRequest().headers(),
                                            serviceResponse.headers(),
                                            responseConnection,

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientRequestImpl.java
@@ -18,12 +18,14 @@ package io.helidon.webclient.http1;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.LogFormatter;
 import io.helidon.http.Method;
@@ -41,6 +43,9 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 
 class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1ClientResponse> implements Http1ClientRequest {
     private static final System.Logger LOGGER = System.getLogger(Http1ClientRequestImpl.class.getName());
+    // RFC 9110, section 8.1: these define the replayed representation data's format and encoding.
+    private static final Set<HeaderName> REPRESENTATION_HEADERS = Set.of(HeaderNames.CONTENT_TYPE,
+                                                                         HeaderNames.CONTENT_ENCODING);
 
     private final Http1ClientImpl http1Client;
     private final FullClientRequest<?> delegate;
@@ -88,7 +93,8 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
     Http1ClientRequestImpl(Http1ClientRequestImpl request,
                            Method method,
                            ClientUri clientUri,
-                           Map<String, String> properties) {
+                           Map<String, String> properties,
+                           boolean preserveEntity) {
         this(request.http1Client,
              null,
              method,
@@ -102,6 +108,9 @@ class Http1ClientRequestImpl extends ClientRequestBase<Http1ClientRequest, Http1
         maxRedirects(request.maxRedirects());
         tls(request.tls());
         outputStreamRedirect(request.outputStreamRedirect());
+        if (preserveEntity) {
+            REPRESENTATION_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
+        }
     }
 
     @Override

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -109,13 +109,16 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                 protocolConfig.validateResponseHeaders()
         ));
 
+        OptionalLong contentLength = responseHeaders.contentLength();
         if (inputStream != null) {
-            OptionalLong contentLength = responseHeaders.contentLength();
             if (contentLength.isPresent()) {
                 this.entityLength = contentLength.getAsLong();
             } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
                 this.entityLength = ENTITY_LENGTH_CHUNKED;
             }
+        } else if (responseStatus.code() == Status.NO_CONTENT_204_CODE
+                && (contentLength.orElse(0) > 0 || responseHeaders.contains(HeaderNames.TRANSFER_ENCODING))) {
+            this.closeConnectionOnClose = true;
         }
 
         if (responseHeaders.contains(HeaderNames.TRAILER)) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -197,6 +197,12 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         closeConnectionOnClose = true;
     }
 
+    void closeIfNoEntity() {
+        if (inputStream == null) {
+            close();
+        }
+    }
+
     /**
      * Attempts to consume an unread entity for the purpose of re-using a cached
      * connection. Only works for length-prefixed responses and when the entity

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -19,6 +19,7 @@ package io.helidon.webclient.http1;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.ServiceLoader;
@@ -30,7 +31,9 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.media.type.ParserMode;
+import io.helidon.common.socket.HelidonSocket;
 import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.ClientResponseTrailers;
@@ -77,6 +80,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private boolean entityRequested;
     private long entityLength;
     private boolean entityFullyRead = false;
+    private boolean closeConnectionOnClose;
 
     Http1ClientResponseImpl(HttpClientConfig clientConfig,
                             Http1ClientProtocolConfig protocolConfig,
@@ -153,7 +157,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                if (headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
+                if (closeConnectionOnClose || headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
                     connection.closeResource();
                 } else {
                     if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {
@@ -186,7 +190,11 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     }
 
     ClientConnection connection() {
-        return connection;
+        return closeConnectionOnClose ? new CloseOnReleaseClientConnection(connection) : connection;
+    }
+
+    void closeConnectionOnClose() {
+        closeConnectionOnClose = true;
     }
 
     /**
@@ -246,5 +254,63 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             return null;
         }
         return bufferData;
+    }
+
+    private record CloseOnReleaseClientConnection(ClientConnection delegate) implements ClientConnection {
+        @Override
+        public DataReader reader() {
+            return delegate.reader();
+        }
+
+        @Override
+        public DataWriter writer() {
+            return delegate.writer();
+        }
+
+        @Override
+        public String channelId() {
+            return delegate.channelId();
+        }
+
+        @Override
+        public HelidonSocket helidonSocket() {
+            return delegate.helidonSocket();
+        }
+
+        @Override
+        public void readTimeout(Duration readTimeout) {
+            delegate.readTimeout(readTimeout);
+        }
+
+        @Override
+        public boolean allowExpectContinue() {
+            return delegate.allowExpectContinue();
+        }
+
+        @Override
+        public void allowExpectContinue(boolean allowExpectContinue) {
+            delegate.allowExpectContinue(allowExpectContinue);
+        }
+
+        @Override
+        public boolean isConnected() {
+            return delegate.isConnected();
+        }
+
+        @Override
+        public ClientConnection connect() {
+            delegate.connect();
+            return this;
+        }
+
+        @Override
+        public void releaseResource() {
+            delegate.closeResource();
+        }
+
+        @Override
+        public void closeResource() {
+            delegate.closeResource();
+        }
     }
 }

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -197,9 +197,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         closeConnectionOnClose = true;
     }
 
-    void closeIfNoEntity() {
-        if (inputStream == null) {
+    void completeIfNoEntityAfterConnectionTransfer() {
+        if (inputStream != null) {
+            return;
+        }
+        if (closeConnectionOnClose || headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
             close();
+        } else if (closed.compareAndSet(false, true)) {
+            whenComplete.complete(null);
         }
     }
 

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -41,6 +41,7 @@ import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
 import io.helidon.http.Http1HeadersParser;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.ReadableEntity;
@@ -64,6 +65,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     private final HttpClientConfig clientConfig;
     private final Http1ClientProtocolConfig protocolConfig;
     private final Status responseStatus;
+    private final boolean headResponse;
     private final ClientRequestHeaders requestHeaders;
     private final ClientResponseHeaders responseHeaders;
     private final InputStream inputStream;
@@ -85,6 +87,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     Http1ClientResponseImpl(HttpClientConfig clientConfig,
                             Http1ClientProtocolConfig protocolConfig,
                             Status responseStatus,
+                            Method requestMethod,
                             ClientRequestHeaders requestHeaders,
                             ClientResponseHeaders responseHeaders,
                             ClientConnection connection,
@@ -95,6 +98,7 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         this.clientConfig = clientConfig;
         this.protocolConfig = protocolConfig;
         this.responseStatus = responseStatus;
+        this.headResponse = requestMethod == Method.HEAD;
         this.requestHeaders = requestHeaders;
         this.responseHeaders = responseHeaders;
         this.connection = connection;
@@ -119,7 +123,8 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         } else if (responseStatus.code() == Status.NO_CONTENT_204_CODE
                 && (contentLength.orElse(0) > 0 || responseHeaders.contains(HeaderNames.TRANSFER_ENCODING))) {
             this.closeConnectionOnClose = true;
-        } else if (responseStatus.code() == Status.RESET_CONTENT_205_CODE
+        } else if (!headResponse
+                && responseStatus.code() == Status.RESET_CONTENT_205_CODE
                 && contentLength.isEmpty()
                 && !responseHeaders.contains(HeaderNames.TRANSFER_ENCODING)) {
             this.closeConnectionOnClose = true;
@@ -150,6 +155,9 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
             if (!this.entityRequested) {
                 throw new IllegalStateException("Trailers requested before reading entity.");
             }
+            if (headResponse) {
+                return ClientResponseTrailers.create();
+            }
             return ClientResponseTrailers.create(this.trailers.get());
         } else {
             return ClientResponseTrailers.create();
@@ -171,9 +179,9 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                         || headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
                     connection.closeResource();
                 } else if (inputStream == null
-                        && responseStatus.code() == Status.NOT_MODIFIED_304_CODE
+                        && (headResponse || responseStatus.code() == Status.NOT_MODIFIED_304_CODE)
                         && connection.reader().available() > 0) {
-                    // A 304 ends at its headers; buffered bytes must not become the next response.
+                    // HEAD and 304 responses end at their headers; buffered bytes must not become the next response.
                     connection.closeResource();
                 } else {
                     if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -166,7 +166,14 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                if (closeConnectionOnClose || headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
+                if (closeConnectionOnClose
+                        || connection instanceof CloseOnReleaseClientConnection
+                        || headers().containsToken(HeaderValues.CONNECTION_CLOSE)) {
+                    connection.closeResource();
+                } else if (inputStream == null
+                        && responseStatus.code() == Status.NOT_MODIFIED_304_CODE
+                        && connection.reader().available() > 0) {
+                    // A 304 ends at its headers; buffered bytes must not become the next response.
                     connection.closeResource();
                 } else {
                     if (entityFullyRead || entityLength == 0 || consumeUnreadEntity()) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -119,6 +119,10 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
         } else if (responseStatus.code() == Status.NO_CONTENT_204_CODE
                 && (contentLength.orElse(0) > 0 || responseHeaders.contains(HeaderNames.TRANSFER_ENCODING))) {
             this.closeConnectionOnClose = true;
+        } else if (responseStatus.code() == Status.RESET_CONTENT_205_CODE
+                && contentLength.isEmpty()
+                && !responseHeaders.contains(HeaderNames.TRANSFER_ENCODING)) {
+            this.closeConnectionOnClose = true;
         }
 
         if (responseHeaders.contains(HeaderNames.TRAILER)) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1ClientResponseImpl.java
@@ -109,11 +109,13 @@ class Http1ClientResponseImpl implements Http1ClientResponse {
                 protocolConfig.validateResponseHeaders()
         ));
 
-        OptionalLong contentLength = responseHeaders.contentLength();
-        if (contentLength.isPresent()) {
-            this.entityLength = contentLength.getAsLong();
-        } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
-            this.entityLength = ENTITY_LENGTH_CHUNKED;
+        if (inputStream != null) {
+            OptionalLong contentLength = responseHeaders.contentLength();
+            if (contentLength.isPresent()) {
+                this.entityLength = contentLength.getAsLong();
+            } else if (responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED)) {
+                this.entityLength = ENTITY_LENGTH_CHUNKED;
+            }
         }
 
         if (responseHeaders.contains(HeaderNames.TRAILER)) {

--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/RedirectionProcessor.java
@@ -37,8 +37,9 @@ class RedirectionProcessor {
     }
 
     static boolean keepsMethodAndEntity(Status status) {
-        return status == Status.TEMPORARY_REDIRECT_307
-                || status == Status.PERMANENT_REDIRECT_308;
+        int statusCode = status.code();
+        return statusCode == Status.TEMPORARY_REDIRECT_307.code()
+                || statusCode == Status.PERMANENT_REDIRECT_308.code();
     }
 
     static void validateEntityRedirect(Http1ClientRequestImpl request,
@@ -103,14 +104,16 @@ class RedirectionProcessor {
                     clientRequest = new Http1ClientRequestImpl(clientRequest,
                                                                clientRequest.method(),
                                                                redirectUri,
-                                                               request.properties());
+                                                               request.properties(),
+                                                               true);
                 } else {
                     //It is possible to change to GET and send no entity with all other redirect codes
                     entityToBeSent = BufferData.EMPTY_BYTES; //We do not want to send entity after this redirect
                     clientRequest = new Http1ClientRequestImpl(clientRequest,
                                                                Method.GET,
                                                                redirectUri,
-                                                               request.properties());
+                                                               request.properties(),
+                                                               false);
                 }
             }
         }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -567,6 +567,26 @@ class Http1ClientTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("notModifiedMetadata")
+    void testMalformedNoContentFramingClosesConnection(Header responseFraming) throws IOException {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection("204 No Content", responseFraming);
+        try {
+            try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/no-content")
+                    .connection(connection)
+                    .request()) {
+                assertThat(response.status(), is(Status.NO_CONTENT_204));
+                assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                assertThat(connection.releaseCount(), is(0));
+                assertThat(connection.closeCount(), is(0));
+            }
+            assertThat(connection.releaseCount(), is(0));
+            assertThat(connection.closeCount(), is(1));
+        } finally {
+            connection.closeResource();
+        }
+    }
+
     @Test
     void testChunkedResetContentDoesNotContaminateConnection() throws Exception {
         try (ChunkedResetContentServer server = ChunkedResetContentServer.start()) {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -456,6 +456,35 @@ class Http1ClientTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"307 Temporary Redirect", "308 Permanent Redirect"})
+    void testTerminalNoContentRedirectClosesIncompleteUploadConnection(String redirectStatus) throws Exception {
+        String requestBody = "redirect-body";
+        try (NoContentRedirectServer redirectTarget = NoContentRedirectServer.start()) {
+            String redirectResponse = "HTTP/1.1 " + redirectStatus + "\r\n"
+                    + "Location: " + redirectTarget.uri() + "\r\n"
+                    + "Content-Length: 0\r\n\r\n";
+            Http1Client redirectClient = Http1Client.builder()
+                    .sendExpectContinue(true)
+                    .build();
+            try {
+                Http1ClientRequest request = redirectClient.put(redirectTarget.redirectUri());
+                request.connection(new FakeHttp1ClientConnection(redirectResponse));
+
+                Http1ClientResponse response = request.outputStream(output -> {
+                    output.write(requestBody.getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                });
+
+                assertThat(response.status(), is(Status.NO_CONTENT_204));
+                assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                assertThat(redirectTarget.awaitConnectionClose(), is(true));
+            } finally {
+                redirectClient.closeResource();
+            }
+        }
+    }
+
     // validates that HEAD is not allowed with entity payload
     @Test
     void testHeadMethod() {
@@ -1369,6 +1398,66 @@ class Http1ClientTest {
                     return line.toString();
                 }
                 line.append((char) next);
+            }
+        }
+    }
+
+    private record NoContentRedirectServer(ServerSocket server,
+                                           CompletableFuture<Boolean> connectionClosed) implements AutoCloseable {
+        private static final byte[] RESPONSE = ("HTTP/1.1 204 No Content\r\n"
+                + "\r\n").getBytes(StandardCharsets.US_ASCII);
+
+        static NoContentRedirectServer start() throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<Boolean> connectionClosed = CompletableFuture.supplyAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    InputStream inputStream = socket.getInputStream();
+                    readHeaders(inputStream);
+                    socket.getOutputStream().write(RESPONSE);
+                    socket.getOutputStream().flush();
+                    return inputStream.read() == -1;
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new NoContentRedirectServer(server, connectionClosed);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort() + "/target";
+        }
+
+        String redirectUri() {
+            return "http://127.0.0.1:" + server.getLocalPort() + "/redirect";
+        }
+
+        boolean awaitConnectionClose() throws Exception {
+            return connectionClosed.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
             }
         }
     }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -567,6 +567,28 @@ class Http1ClientTest {
         }
     }
 
+    @Test
+    void testChunkedResetContentDoesNotContaminateConnection() throws Exception {
+        try (ChunkedResetContentServer server = ChunkedResetContentServer.start()) {
+            Http1Client testClient = Http1Client.builder()
+                    .baseUri(server.uri())
+                    .build();
+            try {
+                try (Http1ClientResponse response = testClient.get("/reset").request()) {
+                    assertThat(response.status(), is(Status.RESET_CONTENT_205));
+                    assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                }
+                try (Http1ClientResponse response = testClient.get("/next").request()) {
+                    assertThat(response.status(), is(Status.OK_200));
+                    assertThat(response.entity().inputStream().readAllBytes(), is("ok".getBytes(StandardCharsets.UTF_8)));
+                }
+                server.awaitCompletion();
+            } finally {
+                testClient.closeResource();
+            }
+        }
+    }
+
     // validates that HEAD is not allowed with entity payload
     @Test
     void testHeadMethod() {
@@ -1550,6 +1572,71 @@ class Http1ClientTest {
 
         boolean awaitConnectionClose() throws Exception {
             return connectionClosed.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
+            }
+        }
+    }
+
+    private record ChunkedResetContentServer(ServerSocket server,
+                                             CompletableFuture<Void> completion) implements AutoCloseable {
+        private static final byte[] RESET_RESPONSE = ("HTTP/1.1 205 Reset Content\r\n"
+                + "Transfer-Encoding: chunked\r\n"
+                + "\r\n"
+                + "0\r\n\r\n").getBytes(StandardCharsets.US_ASCII);
+        private static final byte[] NEXT_RESPONSE = ("HTTP/1.1 200 OK\r\n"
+                + "Content-Length: 2\r\n"
+                + "\r\n"
+                + "ok").getBytes(StandardCharsets.US_ASCII);
+
+        static ChunkedResetContentServer start() throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream();
+                    readHeaders(inputStream);
+                    outputStream.write(RESET_RESPONSE);
+                    outputStream.flush();
+                    readHeaders(inputStream);
+                    outputStream.write(NEXT_RESPONSE);
+                    outputStream.flush();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new ChunkedResetContentServer(server, completion);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort();
+        }
+
+        void awaitCompletion() throws Exception {
+            completion.get(5, TimeUnit.SECONDS);
         }
 
         @Override

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -47,6 +47,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.Bytes;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.common.media.type.ParserMode;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.http.Header;
@@ -404,6 +405,27 @@ class Http1ClientTest {
 
         validateChunkTransfer(response, true, NO_CONTENT_LENGTH, String.join("", requestEntityParts));
         assertThat(response.headers(), hasHeader(REQ_EXPECT_100_HEADER_NAME));
+    }
+
+    @Test
+    void testEarlyResponseUsesConfiguredMediaTypeParserMode() {
+        String earlyResponse = "HTTP/1.1 417 Expectation Failed\r\n"
+                + "Content-Type: text/plain; charset=\r\n"
+                + "Content-Length: 0\r\n\r\n";
+        Http1Client client = Http1Client.builder()
+                .sendExpectContinue(true)
+                .mediaTypeParserMode(ParserMode.RELAXED)
+                .build();
+        Http1ClientRequest request = client.put("http://localhost:" + dummyPort + "/test");
+        request.connection(new FakeHttp1ClientConnection(earlyResponse));
+
+        try (HttpClientResponse response = request.outputStream(output -> {
+            output.write('x');
+            output.close();
+        })) {
+            assertThat(response.status(), is(Status.EXPECTATION_FAILED_417));
+            assertThat(response.headers().contentType().orElseThrow().text(), is("text/plain"));
+        }
     }
 
     // validates that HEAD is not allowed with entity payload
@@ -891,6 +913,7 @@ class Http1ClientTest {
         private final DataReader serverReader;
         private final DataWriter serverWriter;
         private final boolean includeKeepAliveHeader;
+        private final String expectContinueResponse;
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
@@ -902,6 +925,14 @@ class Http1ClientTest {
         }
 
         FakeHttp1ClientConnection(boolean includeKeepAliveHeader) {
+            this(includeKeepAliveHeader, "HTTP/1.1 100 Continue\r\n\r\n");
+        }
+
+        FakeHttp1ClientConnection(String expectContinueResponse) {
+            this(true, expectContinueResponse);
+        }
+
+        private FakeHttp1ClientConnection(boolean includeKeepAliveHeader, String expectContinueResponse) {
             ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
             ArrayBlockingQueue<byte[]> clientToServer = new ArrayBlockingQueue<>(1024);
 
@@ -910,6 +941,7 @@ class Http1ClientTest {
             this.serverReader = reader(clientToServer);
             this.serverWriter = writer(serverToClient);
             this.includeKeepAliveHeader = includeKeepAliveHeader;
+            this.expectContinueResponse = expectContinueResponse;
         }
 
         @Override
@@ -1060,7 +1092,10 @@ class Http1ClientTest {
                     // Send 100-Continue if requested
                     if (reqHeaders.contains(HeaderValues.EXPECT_100)) {
                         serverWriter.write(
-                                BufferData.create("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8)));
+                                BufferData.create(expectContinueResponse.getBytes(StandardCharsets.ISO_8859_1)));
+                        if (!expectContinueResponse.startsWith("HTTP/1.1 100 ")) {
+                            return;
+                        }
                     }
 
                     // Assemble the entity from the chunks

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -547,6 +547,26 @@ class Http1ClientTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("notModifiedMetadata")
+    void testNotModifiedMetadataDoesNotCloseConnection(Header responseMetadata) throws IOException {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection("304 Not Modified", responseMetadata);
+        try {
+            try (Http1ClientResponse response = client.get("http://localhost:" + dummyPort + "/not-modified")
+                    .connection(connection)
+                    .request()) {
+                assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+                assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                assertThat(connection.releaseCount(), is(0));
+                assertThat(connection.closeCount(), is(0));
+            }
+            assertThat(connection.closeCount(), is(0));
+            assertThat(connection.releaseCount(), is(1));
+        } finally {
+            connection.closeResource();
+        }
+    }
+
     // validates that HEAD is not allowed with entity payload
     @Test
     void testHeadMethod() {
@@ -945,6 +965,13 @@ class Http1ClientTest {
         );
     }
 
+    private static Stream<Header> notModifiedMetadata() {
+        return Stream.of(
+                HeaderValues.create(HeaderNames.CONTENT_LENGTH, "123"),
+                HeaderValues.TRANSFER_ENCODING_CHUNKED
+        );
+    }
+
     private static Stream<Arguments> headers() {
         return Stream.of(
                 // Valid headers
@@ -1042,6 +1069,8 @@ class Http1ClientTest {
         private final DataWriter serverWriter;
         private final boolean includeKeepAliveHeader;
         private final String expectContinueResponse;
+        private final String responseStatus;
+        private final Header responseMetadata;
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
@@ -1053,14 +1082,21 @@ class Http1ClientTest {
         }
 
         FakeHttp1ClientConnection(boolean includeKeepAliveHeader) {
-            this(includeKeepAliveHeader, "HTTP/1.1 100 Continue\r\n\r\n");
+            this(includeKeepAliveHeader, "HTTP/1.1 100 Continue\r\n\r\n", "200 OK", null);
         }
 
         FakeHttp1ClientConnection(String expectContinueResponse) {
-            this(true, expectContinueResponse);
+            this(true, expectContinueResponse, "200 OK", null);
         }
 
-        private FakeHttp1ClientConnection(boolean includeKeepAliveHeader, String expectContinueResponse) {
+        FakeHttp1ClientConnection(String responseStatus, Header responseMetadata) {
+            this(true, "HTTP/1.1 100 Continue\r\n\r\n", responseStatus, responseMetadata);
+        }
+
+        private FakeHttp1ClientConnection(boolean includeKeepAliveHeader,
+                                          String expectContinueResponse,
+                                          String responseStatus,
+                                          Header responseMetadata) {
             ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
             ArrayBlockingQueue<byte[]> clientToServer = new ArrayBlockingQueue<>(1024);
 
@@ -1070,6 +1106,8 @@ class Http1ClientTest {
             this.serverWriter = writer(serverToClient);
             this.includeKeepAliveHeader = includeKeepAliveHeader;
             this.expectContinueResponse = expectContinueResponse;
+            this.responseStatus = responseStatus;
+            this.responseMetadata = responseMetadata;
         }
 
         @Override
@@ -1251,6 +1289,9 @@ class Http1ClientTest {
             if (includeKeepAliveHeader) {
                 resHeaders.add(HeaderValues.CONNECTION_KEEP_ALIVE);
             }
+            if (responseMetadata != null) {
+                resHeaders.set(responseMetadata);
+            }
 
             if (reqHeaders != null) {
                 // Send headers that can be validated if Expect-100-Continue, Content_Length, and Chunked request headers exist
@@ -1271,11 +1312,15 @@ class Http1ClientTest {
                 resHeaders.add(HeaderValues.create(header[0], header[1]));
             }
 
-            String responseMessage = !requestFailed ? "HTTP/1.1 200 OK\r\n" : "HTTP/1.1 400 Bad Request\r\n";
+            String responseMessage = !requestFailed ? "HTTP/1.1 " + responseStatus + "\r\n"
+                    : "HTTP/1.1 400 Bad Request\r\n";
             serverWriter.write(BufferData.create(responseMessage.getBytes(StandardCharsets.UTF_8)));
 
             // Send the headers
-            resHeaders.add(HeaderNames.CONTENT_LENGTH, Integer.toString(entitySize));
+            if (!resHeaders.contains(HeaderNames.CONTENT_LENGTH)
+                    && !resHeaders.contains(HeaderNames.TRANSFER_ENCODING)) {
+                resHeaders.add(HeaderNames.CONTENT_LENGTH, Integer.toString(entitySize));
+            }
             BufferData entityBuffer = BufferData.growing(128);
             for (Header header : resHeaders) {
                 header.writeHttp1Header(entityBuffer);

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -476,9 +476,13 @@ class Http1ClientTest {
                     output.close();
                 });
 
-                assertThat(response.status(), is(Status.NO_CONTENT_204));
-                assertThat(response.entity().inputStream().readAllBytes().length, is(0));
-                assertThat(redirectTarget.awaitConnectionClose(), is(true));
+                try {
+                    assertThat(response.status(), is(Status.NO_CONTENT_204));
+                    assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                    assertThat(redirectTarget.awaitConnectionClose(), is(true));
+                } finally {
+                    response.close();
+                }
             } finally {
                 redirectClient.closeResource();
             }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -609,6 +609,29 @@ class Http1ClientTest {
         }
     }
 
+    @Test
+    void testUpgradeRequiredEntityDoesNotContaminateConnection() throws Exception {
+        try (UpgradeRequiredServer server = UpgradeRequiredServer.start()) {
+            Http1Client testClient = Http1Client.builder()
+                    .baseUri(server.uri())
+                    .build();
+            try {
+                try (Http1ClientResponse response = testClient.get("/upgrade").request()) {
+                    assertThat(response.status(), is(Status.UPGRADE_REQUIRED_426));
+                    assertThat(response.entity().inputStream().readAllBytes(),
+                               is("upgrade".getBytes(StandardCharsets.UTF_8)));
+                }
+                try (Http1ClientResponse response = testClient.get("/next").request()) {
+                    assertThat(response.status(), is(Status.OK_200));
+                    assertThat(response.entity().inputStream().readAllBytes(), is("ok".getBytes(StandardCharsets.UTF_8)));
+                }
+                server.awaitCompletion();
+            } finally {
+                testClient.closeResource();
+            }
+        }
+    }
+
     // validates that HEAD is not allowed with entity payload
     @Test
     void testHeadMethod() {
@@ -1650,6 +1673,72 @@ class Http1ClientTest {
                 }
             });
             return new ChunkedResetContentServer(server, completion);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort();
+        }
+
+        void awaitCompletion() throws Exception {
+            completion.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
+            }
+        }
+    }
+
+    private record UpgradeRequiredServer(ServerSocket server,
+                                         CompletableFuture<Void> completion) implements AutoCloseable {
+        private static final byte[] UPGRADE_RESPONSE = ("HTTP/1.1 426 Upgrade Required\r\n"
+                + "Upgrade: h2c\r\n"
+                + "Content-Length: 7\r\n"
+                + "\r\n"
+                + "upgrade").getBytes(StandardCharsets.US_ASCII);
+        private static final byte[] NEXT_RESPONSE = ("HTTP/1.1 200 OK\r\n"
+                + "Content-Length: 2\r\n"
+                + "\r\n"
+                + "ok").getBytes(StandardCharsets.US_ASCII);
+
+        static UpgradeRequiredServer start() throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream();
+                    readHeaders(inputStream);
+                    outputStream.write(UPGRADE_RESPONSE);
+                    outputStream.flush();
+                    readHeaders(inputStream);
+                    outputStream.write(NEXT_RESPONSE);
+                    outputStream.flush();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new UpgradeRequiredServer(server, completion);
         }
 
         String uri() {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -647,6 +647,68 @@ class Http1ClientTest {
     }
 
     @ParameterizedTest
+    @MethodSource("headResponseMetadata")
+    void testHeadResponseMetadataDoesNotCloseConnection(String responseStatus, String responseMetadata) throws IOException {
+        String upgradeHeaders = responseStatus.startsWith("426") ? "Connection: Upgrade\r\nUpgrade: h2c\r\n" : "";
+        var connection = new FakeHttp1ClientConnection(("HTTP/1.1 " + responseStatus + "\r\n"
+                + upgradeHeaders + responseMetadata + "\r\n").getBytes(StandardCharsets.US_ASCII));
+        try {
+            try (Http1ClientResponse response = client.head("http://localhost:" + dummyPort + "/head")
+                    .connection(connection)
+                    .request()) {
+                assertThat(response.status().code(), is(Integer.parseInt(responseStatus.substring(0, 3))));
+                assertThat(response.entity().hasEntity(), is(false));
+                assertThat(response.entity().inputStream().readAllBytes().length, is(0));
+                assertThat(response.trailers().size(), is(0));
+                if (responseMetadata.startsWith("Content-Length: 7")) {
+                    assertThat(response.headers(), hasHeader(HeaderNames.CONTENT_LENGTH, "7"));
+                }
+                if (!upgradeHeaders.isEmpty()) {
+                    assertThat(response.headers(), hasHeader(HeaderNames.UPGRADE, "h2c"));
+                }
+                assertThat(connection.releaseCount(), is(0));
+            }
+            assertThat(connection.closeCount(), is(0));
+            assertThat(connection.releaseCount(), is(1));
+        } finally {
+            connection.closeResource();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"200 OK", "426 Upgrade Required"})
+    void testBufferedHeadResponseDoesNotContaminateNextRequest(String responseStatus) {
+        String upgradeHeaders = responseStatus.startsWith("426") ? "Connection: Upgrade\r\nUpgrade: h2c\r\n" : "";
+        var connection = new FakeHttp1ClientConnection(("HTTP/1.1 " + responseStatus + "\r\n"
+                + upgradeHeaders + "Content-Length: 42\r\n\r\n"
+                + "HTTP/1.1 200 OK\r\nContent-Length:4\r\n\r\nevil").getBytes(StandardCharsets.US_ASCII));
+        var replacementConnection = new FakeHttp1ClientConnection(
+                "HTTP/1.1 200 OK\r\nContent-Length:2\r\n\r\nok".getBytes(StandardCharsets.US_ASCII));
+        var connectionCache = new ReconnectingConnectionCache(connection, replacementConnection);
+        var configuredClient = (Http1ClientImpl) Http1Client.builder().shareConnectionCache(false).build();
+        var testClient = new FixedConnectionHttp1Client(configuredClient, connectionCache);
+        configuredClient.closeResource();
+
+        try {
+            try (Http1ClientResponse response = testClient.head("http://localhost:" + dummyPort + "/head").request()) {
+                assertThat(response.entity().hasEntity(), is(false));
+            }
+            try (Http1ClientResponse response = testClient.get("http://localhost:" + dummyPort + "/next").request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.entity().as(String.class), is("ok"));
+            }
+            assertThat(connection.closeCount(), is(1));
+            assertThat(connection.releaseCount(), is(0));
+            assertThat(replacementConnection.releaseCount(), is(1));
+        } finally {
+            testClient.closeResource();
+            connectionCache.closeResource();
+            connection.closeResource();
+            replacementConnection.closeResource();
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("notModifiedMetadata")
     void testMalformedNoContentFramingClosesConnection(Header responseFraming) throws IOException {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection("204 No Content", responseFraming);
@@ -1121,6 +1183,20 @@ class Http1ClientTest {
         return Stream.of("301 Moved Permanently", "302 Found", "303 See Other")
                 .flatMap(status -> Stream.of("Content-Length:42", "Transfer-Encoding:chunked")
                         .map(metadata -> arguments(status, metadata)));
+    }
+
+    private static Stream<Arguments> headResponseMetadata() {
+        return Stream.of(
+                arguments("200 OK", ""),
+                arguments("200 OK", "Content-Length: 0\r\n"),
+                arguments("200 OK", "Content-Length: 7\r\n"),
+                arguments("200 OK", "Transfer-Encoding: chunked\r\n"),
+                arguments("200 OK", "Transfer-Encoding: chunked\r\nTrailer: X-Test\r\n"),
+                arguments("426 Upgrade Required", "Content-Length: 7\r\n"),
+                arguments("205 Reset Content", ""),
+                arguments("205 Reset Content", "Content-Length: 7\r\n"),
+                arguments("205 Reset Content", "Transfer-Encoding: chunked\r\n")
+        );
     }
 
     private static Stream<Arguments> headers() {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -568,6 +568,85 @@ class Http1ClientTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"Content-Length:42", "Transfer-Encoding:chunked"})
+    void testBufferedNotModifiedResponseDoesNotContaminateNextRequest(String responseMetadata) {
+        var connection = new FakeHttp1ClientConnection(("HTTP/1.1 304 Not Modified\r\n"
+                + responseMetadata + "\r\n\r\n"
+                + "HTTP/1.1 200 OK\r\nContent-Length:4\r\n\r\nevil").getBytes(StandardCharsets.US_ASCII));
+        var replacementConnection = new FakeHttp1ClientConnection(
+                "HTTP/1.1 200 OK\r\nContent-Length:2\r\n\r\nok".getBytes(StandardCharsets.US_ASCII));
+        var connectionCache = new ReconnectingConnectionCache(connection, replacementConnection);
+        var configuredClient = (Http1ClientImpl) Http1Client.builder().shareConnectionCache(false).build();
+        var testClient = new FixedConnectionHttp1Client(configuredClient, connectionCache);
+        configuredClient.closeResource();
+
+        try {
+            try (Http1ClientResponse response = testClient.get("http://localhost:" + dummyPort + "/not-modified")
+                    .request()) {
+                assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+            }
+            try (Http1ClientResponse response = testClient.get("http://localhost:" + dummyPort + "/next").request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.entity().as(String.class), is("ok"));
+            }
+            assertThat(connection.closeCount(), is(1));
+            assertThat(connection.releaseCount(), is(0));
+            assertThat(replacementConnection.releaseCount(), is(1));
+        } finally {
+            testClient.closeResource();
+            connectionCache.closeResource();
+            connection.closeResource();
+            replacementConnection.closeResource();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("bufferedNotModifiedGetRedirects")
+    void testBufferedNotModifiedGetRedirectDoesNotContaminateNextRequest(String redirectStatus,
+                                                                        String responseMetadata) {
+        var targetConnection = new FakeHttp1ClientConnection(("HTTP/1.1 304 Not Modified\r\n"
+                + responseMetadata + "\r\n\r\n"
+                + "HTTP/1.1 200 OK\r\nContent-Length:4\r\n\r\nevil").getBytes(StandardCharsets.US_ASCII));
+        var replacementConnection = new FakeHttp1ClientConnection(
+                "HTTP/1.1 200 OK\r\nContent-Length:2\r\n\r\nok".getBytes(StandardCharsets.US_ASCII));
+        var connectionCache = new ReconnectingConnectionCache(targetConnection, replacementConnection);
+        var configuredClient = (Http1ClientImpl) Http1Client.builder()
+                .sendExpectContinue(true)
+                .shareConnectionCache(false)
+                .build();
+        var testClient = new FixedConnectionHttp1Client(configuredClient, connectionCache);
+        configuredClient.closeResource();
+        var redirectConnection = new FakeHttp1ClientConnection("HTTP/1.1 " + redirectStatus + "\r\n"
+                + "Location: http://localhost:" + dummyPort + "/target\r\n"
+                + "Content-Length: 0\r\n\r\n");
+
+        try {
+            Http1ClientRequest request = testClient.put("http://localhost:" + dummyPort + "/redirect")
+                    .connection(redirectConnection);
+            try (Http1ClientResponse response = request.outputStream(output -> {
+                output.write('x');
+                output.close();
+            })) {
+                assertThat(targetConnection.getPrologue(), startsWith("GET "));
+                assertThat(response.status(), is(Status.NOT_MODIFIED_304));
+            }
+            try (Http1ClientResponse response = testClient.get("http://localhost:" + dummyPort + "/next").request()) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.entity().as(String.class), is("ok"));
+            }
+            assertThat(targetConnection.closeCount(), is(1));
+            assertThat(targetConnection.releaseCount(), is(0));
+            assertThat(replacementConnection.releaseCount(), is(1));
+        } finally {
+            testClient.closeResource();
+            connectionCache.closeResource();
+            redirectConnection.closeResource();
+            targetConnection.closeResource();
+            replacementConnection.closeResource();
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("notModifiedMetadata")
     void testMalformedNoContentFramingClosesConnection(Header responseFraming) throws IOException {
         FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection("204 No Content", responseFraming);
@@ -1038,6 +1117,12 @@ class Http1ClientTest {
         );
     }
 
+    private static Stream<Arguments> bufferedNotModifiedGetRedirects() {
+        return Stream.of("301 Moved Permanently", "302 Found", "303 See Other")
+                .flatMap(status -> Stream.of("Content-Length:42", "Transfer-Encoding:chunked")
+                        .map(metadata -> arguments(status, metadata)));
+    }
+
     private static Stream<Arguments> headers() {
         return Stream.of(
                 // Valid headers
@@ -1137,6 +1222,7 @@ class Http1ClientTest {
         private final String expectContinueResponse;
         private final String responseStatus;
         private final Header responseMetadata;
+        private final byte[] fixedResponse;
         private Throwable serverException;
         private ExecutorService webServerEmulator;
         private String prologue;
@@ -1159,10 +1245,22 @@ class Http1ClientTest {
             this(true, "HTTP/1.1 100 Continue\r\n\r\n", responseStatus, responseMetadata);
         }
 
+        FakeHttp1ClientConnection(byte[] fixedResponse) {
+            this(false, "HTTP/1.1 100 Continue\r\n\r\n", "200 OK", null, fixedResponse);
+        }
+
         private FakeHttp1ClientConnection(boolean includeKeepAliveHeader,
                                           String expectContinueResponse,
                                           String responseStatus,
                                           Header responseMetadata) {
+            this(includeKeepAliveHeader, expectContinueResponse, responseStatus, responseMetadata, null);
+        }
+
+        private FakeHttp1ClientConnection(boolean includeKeepAliveHeader,
+                                          String expectContinueResponse,
+                                          String responseStatus,
+                                          Header responseMetadata,
+                                          byte[] fixedResponse) {
             ArrayBlockingQueue<byte[]> serverToClient = new ArrayBlockingQueue<>(1024);
             ArrayBlockingQueue<byte[]> clientToServer = new ArrayBlockingQueue<>(1024);
 
@@ -1174,6 +1272,7 @@ class Http1ClientTest {
             this.expectContinueResponse = expectContinueResponse;
             this.responseStatus = responseStatus;
             this.responseMetadata = responseMetadata;
+            this.fixedResponse = fixedResponse;
         }
 
         @Override
@@ -1316,6 +1415,12 @@ class Http1ClientTest {
                 }
             } catch (IllegalArgumentException e) {
                 requestFailed = true;
+            }
+
+            if (fixedResponse != null) {
+                // Deliver the complete response and any unexpected bytes in one reader chunk.
+                serverWriter.write(BufferData.create(fixedResponse));
+                return;
             }
 
             int entitySize = 0;
@@ -1803,6 +1908,38 @@ class Http1ClientTest {
                                     ClientUri uri,
                                     ClientRequestHeaders headers,
                                     boolean defaultKeepAlive) {
+            return connection;
+        }
+    }
+
+    private static class ReconnectingConnectionCache extends Http1ConnectionCache {
+        private final FakeHttp1ClientConnection connection;
+        private final FakeHttp1ClientConnection replacementConnection;
+        private boolean firstRequest = true;
+
+        private ReconnectingConnectionCache(FakeHttp1ClientConnection connection,
+                                             FakeHttp1ClientConnection replacementConnection) {
+            super(false);
+            this.connection = connection;
+            this.replacementConnection = replacementConnection;
+        }
+
+        @Override
+        ClientConnection connection(Http1ClientImpl http1Client,
+                                    Tls tls,
+                                    Proxy proxy,
+                                    ClientUri uri,
+                                    ClientRequestHeaders headers,
+                                    boolean defaultKeepAlive) {
+            if (firstRequest) {
+                firstRequest = false;
+                return connection;
+            }
+            if (connection.closeCount() > 0) {
+                return replacementConnection;
+            }
+            assertThat("The previous response must release the connection before it can be reused",
+                       connection.releaseCount(), is(1));
             return connection;
         }
     }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -73,6 +74,7 @@ import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
+import io.helidon.webclient.spi.WebClientService;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -460,15 +462,25 @@ class Http1ClientTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"307 Temporary Redirect", "308 Permanent Redirect"})
-    void testTerminalNoContentRedirectClosesIncompleteUploadConnection(String redirectStatus) throws Exception {
+    @MethodSource("terminalBodylessRedirects")
+    void testTerminalBodylessRedirectClosesIncompleteUploadConnection(String redirectStatus,
+                                                                      String responseStatus) throws Exception {
         String requestBody = "redirect-body";
-        try (NoContentRedirectServer redirectTarget = NoContentRedirectServer.start()) {
+        AtomicInteger serviceRequests = new AtomicInteger();
+        AtomicInteger serviceCompletions = new AtomicInteger();
+        WebClientService countingService = (chain, request) -> {
+            serviceRequests.incrementAndGet();
+            var response = chain.proceed(request);
+            response.whenComplete().thenRun(serviceCompletions::incrementAndGet);
+            return response;
+        };
+        try (NoContentRedirectServer redirectTarget = NoContentRedirectServer.start(responseStatus)) {
             String redirectResponse = "HTTP/1.1 " + redirectStatus + "\r\n"
                     + "Location: " + redirectTarget.uri() + "\r\n"
                     + "Content-Length: 0\r\n\r\n";
             Http1Client redirectClient = Http1Client.builder()
                     .sendExpectContinue(true)
+                    .addService(countingService)
                     .build();
             try {
                 Http1ClientRequest request = redirectClient.put(redirectTarget.redirectUri());
@@ -480,12 +492,14 @@ class Http1ClientTest {
                 });
 
                 try {
-                    assertThat(response.status(), is(Status.NO_CONTENT_204));
+                    assertThat(response.status().code(), is(Integer.parseInt(responseStatus.substring(0, 3))));
                     assertThat(response.entity().inputStream().readAllBytes().length, is(0));
                     assertThat(redirectTarget.awaitConnectionClose(), is(true));
                 } finally {
                     response.close();
                 }
+                assertThat(serviceRequests.get(), is(2));
+                assertThat(serviceCompletions.get(), is(2));
             } finally {
                 redirectClient.closeResource();
             }
@@ -919,6 +933,15 @@ class Http1ClientTest {
                 arguments(Arrays.asList(" HeaderValue"), false),
                 arguments(Arrays.asList("HeaderValue1", "Header\u007fValue"), false),
                 arguments(Arrays.asList("HeaderValue1\r\n", "HeaderValue2"), false)
+        );
+    }
+
+    private static Stream<Arguments> terminalBodylessRedirects() {
+        return Stream.of(
+                arguments("307 Temporary Redirect", "204 No Content"),
+                arguments("308 Permanent Redirect", "204 No Content"),
+                arguments("307 Temporary Redirect", "205 Reset Content"),
+                arguments("307 Temporary Redirect", "304 Not Modified")
         );
     }
 
@@ -1452,18 +1475,17 @@ class Http1ClientTest {
 
     private record NoContentRedirectServer(ServerSocket server,
                                            CompletableFuture<Boolean> connectionClosed) implements AutoCloseable {
-        private static final byte[] RESPONSE = ("HTTP/1.1 204 No Content\r\n"
-                + "\r\n").getBytes(StandardCharsets.US_ASCII);
-
-        static NoContentRedirectServer start() throws IOException {
+        static NoContentRedirectServer start(String responseStatus) throws IOException {
             ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
             server.setSoTimeout(5_000);
+            byte[] response = ("HTTP/1.1 " + responseStatus + "\r\n"
+                    + "\r\n").getBytes(StandardCharsets.US_ASCII);
             CompletableFuture<Boolean> connectionClosed = CompletableFuture.supplyAsync(() -> {
                 try (Socket socket = server.accept()) {
                     socket.setSoTimeout(5_000);
                     InputStream inputStream = socket.getInputStream();
                     readHeaders(inputStream);
-                    socket.getOutputStream().write(RESPONSE);
+                    socket.getOutputStream().write(response);
                     socket.getOutputStream().flush();
                     return inputStream.read() == -1;
                 } catch (IOException e) {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -51,6 +51,8 @@ import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.media.type.ParserMode;
 import io.helidon.common.socket.HelidonSocket;
 import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientRequestHeaders;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
@@ -68,6 +70,7 @@ import io.helidon.http.media.MediaContext;
 import io.helidon.http.media.MediaContextConfig;
 import io.helidon.logging.common.LogConfig;
 import io.helidon.webclient.api.ClientConnection;
+import io.helidon.webclient.api.ClientUri;
 import io.helidon.webclient.api.HttpClientResponse;
 import io.helidon.webclient.api.Proxy;
 
@@ -486,6 +489,47 @@ class Http1ClientTest {
             } finally {
                 redirectClient.closeResource();
             }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"301 Moved Permanently", "302 Found", "303 See Other"})
+    void testNoContentGetRedirectTransfersConnectionOwnership(String redirectStatus) {
+        FakeHttp1ClientConnection targetConnection = new FakeHttp1ClientConnection();
+        Http1ConnectionCache connectionCache = new FixedConnectionCache(targetConnection);
+        Http1ClientImpl configuredClient = (Http1ClientImpl) Http1Client.builder()
+                .sendExpectContinue(true)
+                .shareConnectionCache(false)
+                .build();
+        Http1ClientImpl redirectClient = new FixedConnectionHttp1Client(configuredClient, connectionCache);
+        configuredClient.closeResource();
+
+        String redirectResponse = "HTTP/1.1 " + redirectStatus + "\r\n"
+                + "Location: http://localhost:" + dummyPort + "/target\r\n"
+                + "Content-Length: 0\r\n\r\n";
+        FakeHttp1ClientConnection redirectConnection = new FakeHttp1ClientConnection(redirectResponse);
+        Http1ClientRequest request = redirectClient.put("http://localhost:" + dummyPort + "/redirect");
+        request.connection(redirectConnection);
+
+        try (Http1ClientResponse response = request.outputStream(output -> {
+                output.write('x');
+                output.close();
+            })) {
+            assertThat(targetConnection.getPrologue(), startsWith("GET "));
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(targetConnection.releaseCount(), is(0));
+
+            response.close();
+            assertThat(targetConnection.releaseCount(), is(1));
+            assertThat(targetConnection.closeCount(), is(0));
+
+            response.close();
+            assertThat(targetConnection.releaseCount(), is(1));
+        } finally {
+            redirectClient.closeResource();
+            connectionCache.closeResource();
+            redirectConnection.closeResource();
+            targetConnection.closeResource();
         }
     }
 
@@ -1463,6 +1507,39 @@ class Http1ClientTest {
                 default -> throw new IllegalStateException("Unexpected header parser state");
                 };
             }
+        }
+    }
+
+    private static class FixedConnectionHttp1Client extends Http1ClientImpl {
+        private final Http1ConnectionCache connectionCache;
+
+        private FixedConnectionHttp1Client(Http1ClientImpl configuredClient, Http1ConnectionCache connectionCache) {
+            super(configuredClient.webClient(), configuredClient.clientConfig());
+            this.connectionCache = connectionCache;
+        }
+
+        @Override
+        Http1ConnectionCache connectionCache() {
+            return connectionCache;
+        }
+    }
+
+    private static class FixedConnectionCache extends Http1ConnectionCache {
+        private final ClientConnection connection;
+
+        private FixedConnectionCache(ClientConnection connection) {
+            super(false);
+            this.connection = connection;
+        }
+
+        @Override
+        ClientConnection connection(Http1ClientImpl http1Client,
+                                    Tls tls,
+                                    Proxy proxy,
+                                    ClientUri uri,
+                                    ClientRequestHeaders headers,
+                                    boolean defaultKeepAlive) {
+            return connection;
         }
     }
 

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1003,6 +1003,7 @@ class Http1ClientTest {
                 arguments("307 Temporary Redirect", "204 No Content"),
                 arguments("308 Permanent Redirect", "204 No Content"),
                 arguments("307 Temporary Redirect", "205 Reset Content"),
+                arguments("302 Found", "205 Reset Content"),
                 arguments("307 Temporary Redirect", "304 Not Modified")
         );
     }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -16,7 +16,13 @@
 
 package io.helidon.webclient.http1;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -26,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -492,6 +499,55 @@ class Http1ClientTest {
             System.clearProperty("http.nonProxyHosts");
         }
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testInvalidHeaderClosesAcquiredConnection(boolean outputStream) throws Exception {
+        try (ConnectionCloseServer server = ConnectionCloseServer.start()) {
+            Http1Client testClient = Http1Client.builder()
+                    .connectionCacheSize(1)
+                    .build();
+            try {
+                Http1ClientRequest request = testClient.put(server.uri())
+                        .header(HeaderNames.create("X-Test"), "\u0100");
+
+                assertThrows(IllegalArgumentException.class, () -> {
+                    if (outputStream) {
+                        request.outputStream(OutputStream::close);
+                    } else {
+                        request.submit("test");
+                    }
+                });
+                assertThat(server.awaitFirstConnectionClose(), is(true));
+
+                try (Http1ClientResponse response = testClient.get(server.uri()).request()) {
+                    assertThat(response.status(), is(Status.OK_200));
+                }
+                server.awaitCompletion();
+            } finally {
+                testClient.closeResource();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testInvalidHeaderDoesNotCloseExplicitConnection(boolean outputStream) {
+        FakeHttp1ClientConnection connection = new FakeHttp1ClientConnection();
+        Http1ClientRequest request = client.put("http://localhost:" + dummyPort + "/test")
+                .connection(connection)
+                .header(HeaderNames.create("X-Test"), "\u0100");
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            if (outputStream) {
+                request.outputStream(OutputStream::close);
+            } else {
+                request.submit("test");
+            }
+        });
+        assertThat(connection.closeCount(), is(0));
+        assertThat(connection.releaseCount(), is(0));
     }
 
     @ParameterizedTest
@@ -1071,6 +1127,76 @@ class Http1ClientTest {
             }
         }
 
+    }
+
+    private record ConnectionCloseServer(ServerSocket server,
+                                         CompletableFuture<Boolean> firstConnectionClosed,
+                                         CompletableFuture<Void> completion) implements AutoCloseable {
+        private static final byte[] RESPONSE = ("HTTP/1.1 200 OK\r\n"
+                + "Connection: close\r\n"
+                + "Content-Length: 0\r\n"
+                + "\r\n").getBytes(StandardCharsets.US_ASCII);
+
+        static ConnectionCloseServer start() throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<Boolean> firstConnectionClosed = new CompletableFuture<>();
+            CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    firstConnectionClosed.complete(socket.getInputStream().read() == -1);
+                } catch (IOException e) {
+                    firstConnectionClosed.completeExceptionally(e);
+                    throw new UncheckedIOException(e);
+                }
+
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    readHeaders(socket.getInputStream());
+                    socket.getOutputStream().write(RESPONSE);
+                    socket.getOutputStream().flush();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new ConnectionCloseServer(server, firstConnectionClosed, completion);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort() + "/test";
+        }
+
+        boolean awaitFirstConnectionClose() throws Exception {
+            return firstConnectionClosed.get(5, TimeUnit.SECONDS);
+        }
+
+        void awaitCompletion() throws Exception {
+            completion.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
+            }
+        }
     }
 
     private static class FakeSocket implements HelidonSocket {

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1892,6 +1892,7 @@ class Http1ClientTest {
     private record UpgradeRequiredServer(ServerSocket server,
                                          CompletableFuture<Void> completion) implements AutoCloseable {
         private static final byte[] UPGRADE_RESPONSE = ("HTTP/1.1 426 Upgrade Required\r\n"
+                + "Connection: Upgrade\r\n"
                 + "Upgrade: h2c\r\n"
                 + "Content-Length: 7\r\n"
                 + "\r\n"

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.http1;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -425,6 +426,33 @@ class Http1ClientTest {
         })) {
             assertThat(response.status(), is(Status.EXPECTATION_FAILED_417));
             assertThat(response.headers().contentType().orElseThrow().text(), is("text/plain"));
+        }
+    }
+
+    @Test
+    void testRedirectProbeSkipsEarlyHintsBeforeContinue() throws Exception {
+        String requestBody = "redirect-body";
+        try (EarlyHintsRedirectServer redirectTarget = EarlyHintsRedirectServer.start()) {
+            String redirectResponse = "HTTP/1.1 307 Temporary Redirect\r\n"
+                    + "Location: " + redirectTarget.uri() + "\r\n"
+                    + "Content-Length: 0\r\n\r\n";
+            Http1Client redirectClient = Http1Client.builder()
+                    .sendExpectContinue(true)
+                    .build();
+            try {
+                Http1ClientRequest request = redirectClient.put(redirectTarget.redirectUri());
+                request.connection(new FakeHttp1ClientConnection(redirectResponse));
+
+                try (Http1ClientResponse response = request.outputStream(output -> {
+                    output.write(requestBody.getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                })) {
+                    assertThat(response.status(), is(Status.OK_200));
+                }
+                assertThat(redirectTarget.awaitBody(), is(requestBody));
+            } finally {
+                redirectClient.closeResource();
+            }
         }
     }
 
@@ -1230,6 +1258,117 @@ class Http1ClientTest {
                 case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
                 default -> throw new IllegalStateException("Unexpected header parser state");
                 };
+            }
+        }
+    }
+
+    private record EarlyHintsRedirectServer(ServerSocket server,
+                                            CompletableFuture<String> receivedBody,
+                                            CompletableFuture<Void> completion) implements AutoCloseable {
+        private static final byte[] CONTINUE_RESPONSE = ("HTTP/1.1 103 Early Hints\r\n"
+                + "Link: </style.css>; rel=preload\r\n"
+                + "\r\n"
+                + "HTTP/1.1 100 Continue\r\n"
+                + "\r\n").getBytes(StandardCharsets.US_ASCII);
+        private static final byte[] FINAL_RESPONSE = ("HTTP/1.1 200 OK\r\n"
+                + "Connection: close\r\n"
+                + "Content-Length: 0\r\n"
+                + "\r\n").getBytes(StandardCharsets.US_ASCII);
+
+        static EarlyHintsRedirectServer start() throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<String> receivedBody = new CompletableFuture<>();
+            CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    InputStream inputStream = socket.getInputStream();
+                    readHeaders(inputStream);
+                    socket.getOutputStream().write(CONTINUE_RESPONSE);
+                    socket.getOutputStream().flush();
+                    receivedBody.complete(readChunkedBody(inputStream));
+                    socket.getOutputStream().write(FINAL_RESPONSE);
+                    socket.getOutputStream().flush();
+                } catch (IOException e) {
+                    receivedBody.completeExceptionally(e);
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new EarlyHintsRedirectServer(server, receivedBody, completion);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort() + "/target";
+        }
+
+        String redirectUri() {
+            return "http://127.0.0.1:" + server.getLocalPort() + "/redirect";
+        }
+
+        String awaitBody() throws Exception {
+            completion.get(5, TimeUnit.SECONDS);
+            return receivedBody.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
+            }
+        }
+
+        private static String readChunkedBody(InputStream inputStream) throws IOException {
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            while (true) {
+                int chunkLength = Integer.parseUnsignedInt(readLine(inputStream), 16);
+                if (chunkLength == 0) {
+                    if (!readLine(inputStream).isEmpty()) {
+                        throw new IllegalStateException("Unexpected HTTP/1 chunk trailer");
+                    }
+                    return body.toString(StandardCharsets.UTF_8);
+                }
+                byte[] chunk = inputStream.readNBytes(chunkLength);
+                if (chunk.length != chunkLength) {
+                    throw new IllegalStateException("HTTP/1 request chunk was incomplete");
+                }
+                body.write(chunk);
+                if (!readLine(inputStream).isEmpty()) {
+                    throw new IllegalStateException("HTTP/1 request chunk was not terminated");
+                }
+            }
+        }
+
+        private static String readLine(InputStream inputStream) throws IOException {
+            StringBuilder line = new StringBuilder();
+            while (true) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 line was incomplete");
+                }
+                if (next == '\r') {
+                    if (inputStream.read() != '\n') {
+                        throw new IllegalStateException("HTTP/1 line had an invalid delimiter");
+                    }
+                    return line.toString();
+                }
+                line.append((char) next);
             }
         }
     }

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/RedirectionProcessorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http1;
+
+import java.net.URI;
+import java.util.Map;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientUri;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RedirectionProcessorTest {
+    private static final Header TEST_CONTENT_ENCODING = HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,
+                                                                                   "test-encoding");
+
+    @Test
+    void methodAndEntityPreservationUsesStatusCode() {
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(307, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(308, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.FOUND_302), is(false));
+    }
+
+    @Test
+    void entityPreservingRedirectPreservesContentEncoding() {
+        Http1ClientRequestImpl request = (Http1ClientRequestImpl) Http1Client.create()
+                .put("http://localhost/source")
+                .header(TEST_CONTENT_ENCODING);
+
+        Http1ClientRequestImpl redirect = new Http1ClientRequestImpl(request,
+                                                                     Method.PUT,
+                                                                     ClientUri.create(URI.create("http://localhost/target")),
+                                                                     Map.of(),
+                                                                     true);
+
+        assertThat(redirect.headers(), hasHeader(TEST_CONTENT_ENCODING));
+    }
+}

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -220,7 +220,8 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
                                                     Duration readTimeout) {
         Http2Headers headers = readHeaders(stream, readTimeout);
 
-        ClientResponseHeaders responseHeaders = ClientResponseHeaders.create(headers.httpHeaders());
+        ClientResponseHeaders responseHeaders = ClientResponseHeaders.create(headers.httpHeaders(),
+                                                                              clientConfig.mediaTypeParserMode());
         this.responseStatus = headers.status();
 
         WebClientServiceResponse.Builder builder = WebClientServiceResponse.builder();

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -257,7 +257,9 @@ abstract class Http2CallChainBase implements WebClientService.Chain {
 
     static Http2Headers readHeaders(Http2ClientStream stream, Duration readTimeout) {
         try {
-            return readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
+            Http2Headers headers = readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
+            stream.finishNoContent();
+            return headers;
         } catch (Http2Exception e) {
             resetAndClose(stream, e);
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -106,6 +106,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             //If cos is marked as interrupted, we know that our interrupted exception has been thrown, but
             //it was intercepted by the user OutputStreamHandler and not rethrown.
             //This is a fallback mechanism to correctly handle such a situations.
+            redirectedResponse = outputStream.response;
             stream(outputStream.stream);
             return outputStream.serviceResponse();
         } else if (!outputStream.closed()) {
@@ -438,16 +439,10 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         }
 
         WebClientServiceResponse serviceResponse() {
-            if (serviceResponse != null) {
-                return serviceResponse;
+            if (response != null) {
+                return response.toServiceResponse(request, whenComplete);
             }
-
-            return createServiceResponse(request,
-                                         clientConfig,
-                                         stream,
-                                         whenComplete,
-                                         response.status(),
-                                         response.headers());
+            return serviceResponse;
         }
 
         boolean closed() {
@@ -574,7 +569,9 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                     }
                     lastRequest = clientRequest;
 
-                    stream = response.stream();
+                    if (response.resource() instanceof Http2ClientStream responseStream) {
+                        stream = responseStream;
+                    }
 
                     if (RedirectionProcessor.redirectionStatusCode(response.status())) {
                         try (response) {
@@ -586,14 +583,11 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                             redirectedUri = response.headers().get(HeaderNames.LOCATION).get();
                         }
                     } else {
-                        if (!sendEntity || sendEmptyEntity) {
-                            //OS changed its state to interrupted, that means other usage of this OS will result in NOOP actions.
-                            this.interrupted = true;
-                            this.response = response;
-                            //we are not sending anything by this OS, we need to interrupt it.
-                            throw new OutputStreamInterruptedException();
-                        }
-                        return;
+                        //OS changed its state to interrupted, that means other usage of this OS will result in NOOP actions.
+                        this.interrupted = true;
+                        this.response = response;
+                        //we are not sending anything by this OS, we need to interrupt it.
+                        throw new OutputStreamInterruptedException();
                     }
                 } catch (StreamTimeoutException ignored) {
                     // We assume this is a timeout exception; if the socket got closed, the next read will throw the

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -113,6 +113,9 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         }
 
         Http2Headers responseHeaders = readHeaders(outputStream.stream);
+        ClientResponseHeaders clientResponseHeaders = ClientResponseHeaders.create(
+                responseHeaders.httpHeaders(),
+                clientConfig().mediaTypeParserMode());
 
         if (clientRequest().followRedirects()
                 && RedirectionProcessor.redirectionStatusCode(responseHeaders.status())) {
@@ -143,7 +146,8 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             Http2ClientRequestImpl request = new Http2ClientRequestImpl(outputStream.lastRequest,
                                                                         redirectedMethod,
                                                                         redirectUri,
-                                                                        outputStream.lastRequest.properties());
+                                                                        outputStream.lastRequest.properties(),
+                                                                        sendEntity);
             request.outputStreamRedirect(false);
             request.readTimeout(outputStream.originalRequest.readTimeout());
             int numberOfRedirects = outputStream.numberOfRedirects() + 1;
@@ -172,7 +176,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                      outputStream.stream,
                                      whenComplete(),
                                      responseHeaders.status(),
-                                     ClientResponseHeaders.create(responseHeaders.httpHeaders()));
+                                     clientResponseHeaders);
     }
 
     @Override
@@ -213,7 +217,8 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
         Http2ClientRequestImpl redirectedRequest = new Http2ClientRequestImpl(clientRequest(),
                                                                               method,
                                                                               redirectUri,
-                                                                              clientRequest().properties());
+                                                                              clientRequest().properties(),
+                                                                              sendEntity);
         redirectedRequest.readTimeout(clientRequest().readTimeout());
         redirectedRequest.maxRedirects(clientRequest().maxRedirects() - 1);
         if (sendEntity) {
@@ -489,6 +494,9 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 if (status != Status.CONTINUE_100) {
                     Http2Headers responseHeaders = readHeaders(stream);
                     Status responseStatus = responseHeaders.status();
+                    ClientResponseHeaders clientResponseHeaders = ClientResponseHeaders.create(
+                            responseHeaders.httpHeaders(),
+                            clientConfig.mediaTypeParserMode());
 
                     if (RedirectionProcessor.redirectionStatusCode(responseStatus) && originalRequest.followRedirects()) {
                         checkRedirectHeaders(responseHeaders);
@@ -501,8 +509,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                                                                      stream,
                                                                      whenComplete,
                                                                      responseHeaders.status(),
-                                                                     ClientResponseHeaders.create(
-                                                                             responseHeaders.httpHeaders()));
+                                                                     clientResponseHeaders);
                         //we are not sending anything by this OS, we need to interrupt it.
                         throw new OutputStreamInterruptedException();
                     }
@@ -515,8 +522,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
             ClientUri lastUri = originalRequest.uri();
             Method method;
             boolean sendEntity;
-            if (lastStatus == Status.TEMPORARY_REDIRECT_307
-                    || lastStatus == Status.PERMANENT_REDIRECT_308) {
+            if (RedirectionProcessor.keepsMethodAndEntity(lastStatus)) {
                 method = originalRequest.method();
                 sendEntity = true;
             } else {
@@ -551,7 +557,8 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                 Http2ClientRequestImpl clientRequest = new Http2ClientRequestImpl(lastRequest,
                                                                                   method,
                                                                                   redirectUri,
-                                                                                  lastRequest.properties());
+                                                                                  lastRequest.properties(),
+                                                                                  sendEntity);
                 clientRequest.followRedirects(false);
                 clientRequest.readTimeout(originalRequest.readTimeout());
                 try {
@@ -572,8 +579,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                     if (RedirectionProcessor.redirectionStatusCode(response.status())) {
                         try (response) {
                             checkRedirectHeaders(response.headers());
-                            if (response.status() != Status.TEMPORARY_REDIRECT_307
-                                    && response.status() != Status.PERMANENT_REDIRECT_308) {
+                            if (!RedirectionProcessor.keepsMethodAndEntity(response.status())) {
                                 method = Method.GET;
                                 sendEntity = false;
                             }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallOutputStreamChain.java
@@ -586,6 +586,7 @@ class Http2CallOutputStreamChain extends Http2CallChainBase {
                         //OS changed its state to interrupted, that means other usage of this OS will result in NOOP actions.
                         this.interrupted = true;
                         this.response = response;
+                        response.closeIfNoEntity();
                         //we are not sending anything by this OS, we need to interrupt it.
                         throw new OutputStreamInterruptedException();
                     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientConnection.java
@@ -807,9 +807,9 @@ public class Http2ClientConnection {
     private void handleDataFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {
         Http2ClientStream stream = stream(streamId);
         if (stream == null) {
-            if (LOGGER.isLoggable(DEBUG)) {
-                ctx.log(LOGGER, DEBUG, "%d: received data for stream %d, which does not exist", 0, streamId);
-            }
+            validateKnownAbandonedClientStream(streamId, Http2FrameType.DATA);
+            restoreDiscardedConnectionCredit(frameHeader);
+            logDroppedFrame(Http2FrameType.DATA, streamId);
             return;
         }
         Http2FrameData frameData = new Http2FrameData(frameHeader, data);
@@ -821,6 +821,11 @@ public class Http2ClientConnection {
             ctx.log(LOGGER, DEBUG, "%d: received data for stream %d", 0, streamId);
         }
         stream.push(frameData);
+    }
+
+    private void restoreDiscardedConnectionCredit(Http2FrameHeader frameHeader) {
+        connectionFlowControl.decrementInboundConnectionWindowSize(frameHeader.length());
+        connectionFlowControl.incrementInboundConnectionWindowSize(frameHeader.length());
     }
 
     private boolean handleHeadersFrame(int streamId, Http2FrameHeader frameHeader, BufferData data) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientRequestImpl.java
@@ -18,9 +18,12 @@ package io.helidon.webclient.http2;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import io.helidon.http.ClientRequestHeaders;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.webclient.api.ClientRequestBase;
 import io.helidon.webclient.api.ClientUri;
@@ -30,6 +33,9 @@ import io.helidon.webclient.api.WebClientServiceResponse;
 
 class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2ClientResponse>
         implements Http2ClientRequest, Http2StreamConfig, FullClientRequest<Http2ClientRequest> {
+    // RFC 9110, section 8.1: these define the replayed representation data's format and encoding.
+    private static final Set<HeaderName> REPRESENTATION_HEADERS = Set.of(HeaderNames.CONTENT_TYPE,
+                                                                         HeaderNames.CONTENT_ENCODING);
 
     private final Http2ClientImpl http2Client;
     private int priority = 16;
@@ -73,7 +79,8 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
     Http2ClientRequestImpl(Http2ClientRequestImpl request,
                            Method method,
                            ClientUri clientUri,
-                           Map<String, String> properties) {
+                           Map<String, String> properties,
+                           boolean preserveEntity) {
         this(request.http2Client,
              request.delegate,
              method,
@@ -94,6 +101,9 @@ class Http2ClientRequestImpl extends ClientRequestBase<Http2ClientRequest, Http2
         this.readContinueTimeout(request.readContinueTimeout());
         request.sendExpectContinue().ifPresent(this::sendExpectContinue);
         this.outputStreamRedirect(request.outputStreamRedirect);
+        if (preserveEntity) {
+            REPRESENTATION_HEADERS.forEach(name -> request.headers().find(name).ifPresent(headers()::set));
+        }
     }
 
     @Override

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
@@ -140,6 +140,12 @@ class Http2ClientResponseImpl implements Http2ClientResponse {
                 maxBufferedEntitySize);
     }
 
+    void closeIfNoEntity() {
+        if (inputStream == null) {
+            close();
+        }
+    }
+
     ReleasableResource resource() {
         return stream;
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientResponseImpl.java
@@ -140,8 +140,8 @@ class Http2ClientResponseImpl implements Http2ClientResponse {
                 maxBufferedEntitySize);
     }
 
-    Http2ClientStream stream() {
-        return (Http2ClientStream) stream;
+    ReleasableResource resource() {
+        return stream;
     }
 
     boolean hasRequestEntity() {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -798,6 +798,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream trailers must always close the remote side
      */
     private void trailersLocked(Http2Headers headers, boolean endOfStream) {
+        if (currentHeaders.status() == Status.NOT_MODIFIED_304) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers on a 304 response");
+        }
         Http2StreamState nextState =
                 Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
         if (endOfStream && (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL)) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -28,6 +28,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
@@ -83,7 +84,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private RuntimeException inboundFailure;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
+    // Wire completion is independent of whether the response semantics permit content.
     private boolean hasEntity;
+    private boolean headRequest;
+    private boolean responseNoContent;
     private boolean continue100Received;
     private volatile boolean inboundEndQueued;
 
@@ -234,15 +238,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     /**
-     * Determines if an entity is expected. Set to {@code false} when an EOS flag
-     * is received.
+     * Determines whether the response can expose an entity. HEAD and 304 responses
+     * have no entity even when empty DATA frames are needed to end the stream.
      *
      * @return {@code true} if entity expected, {@code false} otherwise.
      */
     public boolean hasEntity() {
         inboundStateLock.lock();
         try {
-            return hasEntity;
+            return hasEntity && !responseNoContent;
         } finally {
             inboundStateLock.unlock();
         }
@@ -331,6 +335,17 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         if (inboundEndQueued || currentReadState != ReadState.DATA) {
             throw invalidInboundDataState(currentReadState);
         }
+        if (responseNoContent && dataContentLength(frameData) != 0) {
+            var inbound = flowControl.inbound();
+            inbound.decrementWindowSize(frameData.header().length());
+            try {
+                failResponseContent();
+            } finally {
+                // Discarded DATA still consumes connection credit, including padding.
+                inbound.incrementWindowSize(frameData.header().length());
+            }
+            return false;
+        }
         if (!endOfStream) {
             return true;
         }
@@ -388,6 +403,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     BufferData read(int i) {
         return read();
+    }
+
+    void finishNoContent() {
+        if (!responseNoContent) {
+            return;
+        }
+        // Bodyless responses still have to receive END_STREAM before they can be closed.
+        while (expectsEntityData()) {
+            readOne(timeout);
+        }
+        inboundStateLock.lock();
+        try {
+            throwIfInboundFailed();
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     /**
@@ -455,6 +486,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         inboundStateLock.lock();
         try {
             updateState(Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true));
+            this.headRequest = http2Headers.method() == Method.HEAD;
             this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
                                                      ? ReadState.CONTINUE_100_HEADERS
                                                      : ReadState.HEADERS);
@@ -674,6 +706,17 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         }
     }
 
+    private static int dataContentLength(Http2FrameData frameData) {
+        int length = frameData.data().available();
+        if (frameData.header().flags(Http2FrameTypes.DATA).padded()) {
+            if (length == 0 || frameData.data().get(0) >= length) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid DATA padding");
+            }
+            length -= frameData.data().get(0) + 1;
+        }
+        return length;
+    }
+
     /**
      * Determines whether the caller should keep polling for inbound {@code DATA}
      * frames. Once final headers or trailers mark the response complete, reads
@@ -709,6 +752,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
         this.currentHeaders = headers;
         this.continue100Received = false;
+        this.responseNoContent = headRequest || headers.status() == Status.NOT_MODIFIED_304;
         this.hasEntity = !endOfStream;
     }
 
@@ -812,6 +856,23 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private Http2Exception invalidInboundDataState(ReadState currentReadState) {
         return new Http2Exception(Http2ErrorCode.PROTOCOL,
                                   "Received DATA frame in invalid response read state " + currentReadState);
+    }
+
+    private void failResponseContent() {
+        var failure = new Http2Exception(Http2ErrorCode.PROTOCOL, "Received content on a HEAD or 304 response");
+        inboundStateLock.lock();
+        try {
+            inboundFailure = failure;
+            try {
+                reset(Http2ErrorCode.PROTOCOL);
+            } finally {
+                buffer.fail(failure);
+                close();
+                inboundStateChanged.signalAll();
+            }
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     enum ReadState {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -199,9 +199,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     @Override
     public void data(Http2FrameHeader header, BufferData data, boolean endOfStream) {
-        updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
-        readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
-        flowControl.inbound().incrementWindowSize(header.length());
+        inboundStateLock.lock();
+        try {
+            updateState(Http2StreamState.checkAndGetState(this.state, header.type(), false, endOfStream, false));
+            readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
+            flowControl.inbound().incrementWindowSize(header.length());
+            buffer.dataProcessed(header.length());
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     @Override
@@ -866,11 +872,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         inboundStateLock.lock();
         try {
             inboundFailure = failure;
+            int discardedDataLength = buffer.failAndDiscard(failure);
             try {
                 reset(Http2ErrorCode.PROTOCOL);
             } finally {
-                buffer.fail(failure);
                 close();
+                connection.flowControl().incrementInboundConnectionWindowSize(discardedDataLength);
                 inboundStateChanged.signalAll();
             }
         } finally {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -684,7 +684,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private boolean expectsEntityData() {
         inboundStateLock.lock();
         try {
-            return state == Http2StreamState.HALF_CLOSED_LOCAL && readState != ReadState.END && hasEntity;
+            return (state == Http2StreamState.OPEN || state == Http2StreamState.HALF_CLOSED_LOCAL)
+                    && readState != ReadState.END
+                    && hasEntity;
         } finally {
             inboundStateLock.unlock();
         }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -709,10 +709,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private static int dataContentLength(Http2FrameData frameData) {
         int length = frameData.data().available();
         if (frameData.header().flags(Http2FrameTypes.DATA).padded()) {
-            if (length == 0 || frameData.data().get(0) >= length) {
+            if (length == 0 || (frameData.data().get(0) & 0xFF) >= length) {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid DATA padding");
             }
-            length -= frameData.data().get(0) + 1;
+            length -= (frameData.data().get(0) & 0xFF) + 1;
         }
         return length;
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/RedirectionProcessor.java
@@ -32,12 +32,15 @@ class RedirectionProcessor {
     }
 
     static boolean redirectionStatusCode(Status status) {
-        return status.family() == Status.Family.REDIRECTION;
+        // 304 is not a redirect; it instructs a cache to reuse its stored representation.
+        return status.code() != Status.NOT_MODIFIED_304.code()
+                && status.family() == Status.Family.REDIRECTION;
     }
 
     static boolean keepsMethodAndEntity(Status status) {
-        return status == Status.TEMPORARY_REDIRECT_307
-                || status == Status.PERMANENT_REDIRECT_308;
+        int statusCode = status.code();
+        return statusCode == Status.TEMPORARY_REDIRECT_307.code()
+                || statusCode == Status.PERMANENT_REDIRECT_308.code();
     }
 
     static void validateEntityRedirect(Http2ClientRequestImpl request,
@@ -119,14 +122,16 @@ class RedirectionProcessor {
                 clientRequest = new Http2ClientRequestImpl(clientRequest,
                                                            clientRequest.method(),
                                                            redirectUri,
-                                                           request.properties());
+                                                           request.properties(),
+                                                           true);
             } else {
                 //It is possible to change to GET and send no entity with all other redirect codes
                 entityToBeSent = BufferData.EMPTY_BYTES; //We do not want to send entity after this redirect
                 clientRequest = new Http2ClientRequestImpl(clientRequest,
                                                            Method.GET,
                                                            redirectUri,
-                                                           request.properties());
+                                                           request.properties(),
+                                                           false);
             }
         }
     }

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/StreamBuffer.java
@@ -21,6 +21,7 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -34,6 +35,7 @@ class StreamBuffer {
     private final Queue<InboundItem> buffer = new ArrayDeque<>();
     private final Http2ClientStream stream;
     private final int streamId;
+    private final AtomicInteger unprocessedDataLength = new AtomicInteger();
     private volatile RuntimeException failure;
 
     StreamBuffer(Http2ClientStream stream, int streamId) {
@@ -79,20 +81,14 @@ class StreamBuffer {
         try {
             streamLock.lock();
             buffer.add(item);
+            if (item instanceof InboundData inboundData) {
+                unprocessedDataLength.addAndGet(inboundData.frameData().header().length());
+            }
         } finally {
             streamLock.unlock();
             // Release deque threads
             dequeSemaphore.release();
         }
-    }
-
-    sealed interface InboundItem permits InboundData, InboundTrailers {
-    }
-
-    record InboundData(Http2FrameData frameData) implements InboundItem {
-    }
-
-    record InboundTrailers(Http2Headers trailers, boolean endOfStream) implements InboundItem {
     }
 
     void fail(RuntimeException failure) {
@@ -105,5 +101,34 @@ class StreamBuffer {
             streamLock.unlock();
             dequeSemaphore.release();
         }
+    }
+
+    int failAndDiscard(RuntimeException failure) {
+        int discardedDataLength;
+        try {
+            streamLock.lock();
+            if (this.failure == null) {
+                this.failure = failure;
+            }
+            discardedDataLength = unprocessedDataLength.getAndSet(0);
+            buffer.clear();
+        } finally {
+            streamLock.unlock();
+            dequeSemaphore.release();
+        }
+        return discardedDataLength;
+    }
+
+    void dataProcessed(int dataLength) {
+        unprocessedDataLength.addAndGet(-dataLength);
+    }
+
+    sealed interface InboundItem permits InboundData, InboundTrailers {
+    }
+
+    record InboundData(Http2FrameData frameData) implements InboundItem {
+    }
+
+    record InboundTrailers(Http2Headers trailers, boolean endOfStream) implements InboundItem {
     }
 }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -468,10 +468,21 @@ class Http2ClientConnectionTest {
             test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
             assertThat(malformedStream.readHeaders().status(), is(status));
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
-            test.offerInbound(padded
-                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
-                                      : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
-                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+            Http2FrameData firstData = padded
+                    ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
+                    : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream);
+            int discardedLength = firstData.header().length();
+            if (endOfStream) {
+                test.offerInbound(firstData);
+            } else {
+                // DATA already in flight after the reset still consumes connection credit, including padding.
+                Http2FrameData lateData = paddedDataFrame(malformedStream.streamId(), forbiddenContent, false, 255);
+                discardedLength += lateData.header().length();
+                test.offerInbound(firstData,
+                                  lateData,
+                                  dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, true));
+            }
+            test.offerInbound(encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
                               dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
 
             WebClientServiceRequest request = mock(WebClientServiceRequest.class);
@@ -492,6 +503,18 @@ class Http2ClientConnectionTest {
             byte[] entity = new byte[data.available()];
             data.read(entity);
             assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            int connectionCredit = 0;
+            for (BufferData written : test.writtenFrames) {
+                Http2FrameHeader header = Http2FrameHeader.create(written);
+                assertThat("Only credit updates may follow the malformed-stream reset",
+                           header.type(), is(Http2FrameType.WINDOW_UPDATE));
+                if (header.streamId() == 0) {
+                    connectionCredit += Http2WindowUpdate.create(written).windowSizeIncrement();
+                }
+            }
+            assertThat("Discarded DATA and the consumed sibling body must restore exact connection credit",
+                       connectionCredit, is(discardedLength + entity.length));
 
             Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
             assertThat(recoveredStream, notNullValue());

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -499,11 +499,23 @@ class Http2ClientConnectionTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"HEAD, 200, false, false", "HEAD, 200, true, false", "HEAD, 426, false, false", "HEAD, 426, true, false",
-                "GET, 304, false, false", "GET, 304, true, false",
-                "HEAD, 200, false, true", "HEAD, 200, true, true", "HEAD, 426, false, true", "HEAD, 426, true, true",
-                "GET, 304, false, true", "GET, 304, true, true"})
-    void forbiddenResponseContentResetsOnlyItsStream(String methodName, int statusCode, boolean endOfStream, boolean padded)
+    @CsvSource({"HEAD, 200, false, false, false", "HEAD, 200, true, false, false",
+                "HEAD, 426, false, false, false", "HEAD, 426, true, false, false",
+                "GET, 304, false, false, false", "GET, 304, true, false, false",
+                "HEAD, 200, false, true, false", "HEAD, 200, true, true, false",
+                "HEAD, 426, false, true, false", "HEAD, 426, true, true, false",
+                "GET, 304, false, true, false", "GET, 304, true, true, false",
+                "HEAD, 200, false, false, true", "HEAD, 200, true, false, true",
+                "HEAD, 426, false, false, true", "HEAD, 426, true, false, true",
+                "GET, 304, false, false, true", "GET, 304, true, false, true",
+                "HEAD, 200, false, true, true", "HEAD, 200, true, true, true",
+                "HEAD, 426, false, true, true", "HEAD, 426, true, true, true",
+                "GET, 304, false, true, true", "GET, 304, true, true, true"})
+    void forbiddenResponseContentResetsOnlyItsStream(String methodName,
+                                                    int statusCode,
+                                                    boolean endOfStream,
+                                                    boolean padded,
+                                                    boolean consumePriorData)
             throws Exception {
         Method method = Method.create(methodName);
         Status status = Status.create(statusCode);
@@ -524,19 +536,24 @@ class Http2ClientConnectionTest {
                     .status(status);
             test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
             assertThat(malformedStream.readHeaders().status(), is(status));
+            Http2FrameData queuedData = paddedDataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, false, 255);
+            assertThat(connection.handle(queuedData.header(), queuedData.data()), is(true));
+            if (consumePriorData) {
+                // Credit already returned by consumption must not be returned again when the stream fails.
+                malformedStream.readOne(TEST_WAIT_TIMEOUT);
+            }
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
             Http2FrameData firstData = padded
                     ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
                     : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream);
-            int discardedLength = firstData.header().length();
-            if (endOfStream) {
-                test.offerInbound(firstData);
-            } else {
+            int discardedLength = (consumePriorData ? 0 : queuedData.header().length()) + firstData.header().length();
+            // Process the rejection before response construction can consume the earlier queued padding.
+            assertThat(connection.handle(firstData.header(), firstData.data()), is(true));
+            if (!endOfStream) {
                 // DATA already in flight after the reset still consumes connection credit, including padding.
                 Http2FrameData lateData = paddedDataFrame(malformedStream.streamId(), forbiddenContent, false, 255);
                 discardedLength += lateData.header().length();
-                test.offerInbound(firstData,
-                                  lateData,
+                test.offerInbound(lateData,
                                   dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, true));
             }
             test.offerInbound(encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -33,29 +33,39 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
+import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.Headers;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
+import io.helidon.http.http2.Http2Exception;
 import io.helidon.http.http2.Http2Flag;
 import io.helidon.http.http2.Http2FrameData;
 import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
 import io.helidon.http.http2.Http2FrameTypes;
 import io.helidon.http.http2.Http2Headers;
 import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Util;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webclient.api.ClientConnection;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -342,6 +352,139 @@ class Http2ClientConnectionTest {
 
             secondStream.close();
             firstStream.close();
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"HEAD, 200, headers", "HEAD, 426, headers", "GET, 304, headers",
+                "HEAD, 200, data", "HEAD, 426, data", "GET, 304, data",
+                "HEAD, 200, padded", "HEAD, 426, padded", "GET, 304, padded",
+                "HEAD, 200, trailers", "HEAD, 426, trailers", "GET, 304, trailers"})
+    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName, int statusCode, String termination) {
+        Method method = Method.create(methodName);
+        Status status = Status.create(statusCode);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders().method(method), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(status);
+            boolean headersEndStream = termination.equals("headers");
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), headers, inboundTable, huffman, headersEndStream));
+            assertThat(stream.readHeaders().status(), is(status));
+
+            if (!headersEndStream) {
+                // Response semantics alone do not release the peer's concurrent-stream slot.
+                assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+                switch (termination) {
+                case "data" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], true));
+                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true));
+                case "trailers" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], false),
+                                                     encodedHeaderFrame(stream.streamId(),
+                                                                        encodedTrailers(),
+                                                                        inboundTable,
+                                                                        huffman,
+                                                                        true));
+                default -> throw new IllegalArgumentException("Unknown response termination: " + termination);
+                }
+            }
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            WebClientServiceResponse response = chain.readResponse(request, stream);
+            assertThat(response.status(), is(status));
+            assertThat(response.headers().get(HeaderNames.CONTENT_LENGTH).get(), is("123"));
+            assertThat(response.inputStream().isPresent(), is(false));
+
+            WebClientServiceResponse outputStreamResponse =
+                    Http2CallChainBase.createServiceResponse(request,
+                                                             test.clientConfig,
+                                                             stream,
+                                                             new CompletableFuture<>(),
+                                                             status,
+                                                             ClientResponseHeaders.create(headers.httpHeaders()));
+            assertThat(outputStreamResponse.headers().get(HeaderNames.CONTENT_LENGTH).get(), is("123"));
+            assertThat(outputStreamResponse.inputStream().isPresent(), is(false));
+
+            Http2ClientStream nextStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(nextStream, notNullValue());
+            nextStream.close();
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"HEAD, 200, false, false", "HEAD, 200, true, false", "HEAD, 426, false, false", "HEAD, 426, true, false",
+                "GET, 304, false, false", "GET, 304, true, false",
+                "HEAD, 200, false, true", "HEAD, 200, true, true", "HEAD, 426, false, true", "HEAD, 426, true, true",
+                "GET, 304, false, true", "GET, 304, true, true"})
+    void forbiddenResponseContentResetsOnlyItsStream(String methodName, int statusCode, boolean endOfStream, boolean padded)
+            throws Exception {
+        Method method = Method.create(methodName);
+        Status status = Status.create(statusCode);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(2));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream malformedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+            malformedStream.writeHeaders(requestHeaders().method(method), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(status);
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
+            assertThat(malformedStream.readHeaders().status(), is(status));
+            byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
+            test.offerInbound(padded
+                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream)
+                                      : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
+                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            Http2Exception failure = assertThrows(Http2Exception.class, () -> chain.readResponse(request, malformedStream));
+            assertThat(failure.code(), is(Http2ErrorCode.PROTOCOL));
+
+            Http2FrameData reset = test.awaitWrittenFrame(Http2FrameType.RST_STREAM);
+            assertThat(reset.header().streamId(), is(malformedStream.streamId()));
+            assertThat(Http2RstStream.create(reset.data()).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertThat(siblingStream.readHeaders().status(), is(Status.OK_200));
+            BufferData data = siblingStream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(recoveredStream, notNullValue());
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+            recoveredStream.close();
+            siblingStream.close();
+            malformedStream.close();
             connection.close();
         }
     }
@@ -669,6 +812,21 @@ class Http2ClientConnectionTest {
         return new Http2FrameData(header, BufferData.create(bytes));
     }
 
+    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream) {
+        int padding = 3;
+        byte[] paddedBytes = new byte[1 + bytes.length + padding];
+        paddedBytes[0] = (byte) padding;
+        System.arraycopy(bytes, 0, paddedBytes, 1, bytes.length);
+        Http2FrameHeader header = Http2FrameHeader.create(paddedBytes.length,
+                                                          Http2FrameTypes.DATA,
+                                                          Http2Flag.DataFlags.create(Http2Flag.PADDED
+                                                                                             | (endOfStream
+                                                                                                     ? Http2Flag.END_OF_STREAM
+                                                                                                     : 0)),
+                                                          streamId);
+        return new Http2FrameData(header, BufferData.create(paddedBytes));
+    }
+
     private static Http2FrameData windowUpdateFrame(int streamId) {
         return new Http2WindowUpdate(1)
                 .toFrameData(null, streamId, Http2Flag.NoFlags.create());
@@ -782,6 +940,7 @@ class Http2ClientConnectionTest {
 
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
+        private final LinkedBlockingQueue<BufferData> writtenFrames = new LinkedBlockingQueue<>();
         private final AtomicBoolean failWrites = new AtomicBoolean();
         private final AtomicReference<BlockedWrite> blockedWrite = new AtomicReference<>();
         private final DataWriter dataWriter = mock(DataWriter.class);
@@ -815,6 +974,7 @@ class Http2ClientConnectionTest {
             doAnswer(invocation -> {
                 maybeFailWrites();
                 maybeBlockWriteNow();
+                writtenFrames.add(invocation.<BufferData>getArgument(0).copy());
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));
             doAnswer(invocation -> {
@@ -851,6 +1011,26 @@ class Http2ClientConnectionTest {
 
         private void closeInbound() {
             inboundFrames.add(END_INBOUND);
+        }
+
+        private Http2FrameData awaitWrittenFrame(Http2FrameType expectedType) throws InterruptedException {
+            long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+            while (true) {
+                BufferData data = writtenFrames.poll(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
+                assertThat("Expected an outbound " + expectedType + " frame", data, notNullValue());
+                if (data.available() == Http2Util.PREFACE_LENGTH) {
+                    byte[] bytes = new byte[Http2Util.PREFACE_LENGTH];
+                    data.read(bytes);
+                    data.rewind();
+                    if (Http2Util.isPreface(bytes)) {
+                        continue;
+                    }
+                }
+                Http2FrameHeader header = Http2FrameHeader.create(data);
+                if (header.type() == expectedType) {
+                    return new Http2FrameData(header, data);
+                }
+            }
         }
 
         private void assertConnectionClosed() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -357,11 +357,20 @@ class Http2ClientConnectionTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"HEAD, 200, headers", "HEAD, 426, headers", "GET, 304, headers",
-                "HEAD, 200, data", "HEAD, 426, data", "GET, 304, data",
-                "HEAD, 200, padded", "HEAD, 426, padded", "GET, 304, padded",
-                "HEAD, 200, trailers", "HEAD, 426, trailers", "GET, 304, trailers"})
-    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName, int statusCode, String termination) {
+    @CsvSource({"HEAD, 200, headers, 0", "HEAD, 426, headers, 0", "GET, 304, headers, 0",
+                "HEAD, 200, data, 0", "HEAD, 426, data, 0", "GET, 304, data, 0",
+                "HEAD, 200, padded, 3", "HEAD, 426, padded, 3", "GET, 304, padded, 3",
+                "HEAD, 200, padded, 127", "HEAD, 426, padded, 127", "GET, 304, padded, 127",
+                "HEAD, 200, padded, 128", "HEAD, 426, padded, 128", "GET, 304, padded, 128",
+                "HEAD, 200, padded, 255", "HEAD, 426, padded, 255", "GET, 304, padded, 255",
+                "HEAD, 200, padded-buffer, 127", "HEAD, 426, padded-buffer, 127", "GET, 304, padded-buffer, 127",
+                "HEAD, 200, padded-buffer, 128", "HEAD, 426, padded-buffer, 128", "GET, 304, padded-buffer, 128",
+                "HEAD, 200, padded-buffer, 255", "HEAD, 426, padded-buffer, 255", "GET, 304, padded-buffer, 255",
+                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0", "GET, 304, trailers, 0"})
+    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName,
+                                                                 int statusCode,
+                                                                 String termination,
+                                                                 int padding) {
         Method method = Method.create(methodName);
         Status status = Status.create(statusCode);
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
@@ -386,7 +395,12 @@ class Http2ClientConnectionTest {
                 assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
                 switch (termination) {
                 case "data" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], true));
-                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true));
+                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true, padding));
+                case "padded-buffer" -> {
+                    // Mutable buffers expose signed bytes, unlike the reader's read-only buffers.
+                    Http2FrameData frame = paddedDataFrame(stream.streamId(), new byte[0], true, padding);
+                    assertThat(connection.handle(frame.header(), frame.data()), is(true));
+                }
                 case "trailers" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], false),
                                                      encodedHeaderFrame(stream.streamId(),
                                                                         encodedTrailers(),
@@ -455,7 +469,7 @@ class Http2ClientConnectionTest {
             assertThat(malformedStream.readHeaders().status(), is(status));
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
             test.offerInbound(padded
-                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream)
+                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
                                       : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
                               encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
                               dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
@@ -812,8 +826,7 @@ class Http2ClientConnectionTest {
         return new Http2FrameData(header, BufferData.create(bytes));
     }
 
-    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream) {
-        int padding = 3;
+    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream, int padding) {
         byte[] paddedBytes = new byte[1 + bytes.length + padding];
         paddedBytes[0] = (byte) padding;
         System.arraycopy(bytes, 0, paddedBytes, 1, bytes.length);

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -366,7 +366,7 @@ class Http2ClientConnectionTest {
                 "HEAD, 200, padded-buffer, 127", "HEAD, 426, padded-buffer, 127", "GET, 304, padded-buffer, 127",
                 "HEAD, 200, padded-buffer, 128", "HEAD, 426, padded-buffer, 128", "GET, 304, padded-buffer, 128",
                 "HEAD, 200, padded-buffer, 255", "HEAD, 426, padded-buffer, 255", "GET, 304, padded-buffer, 255",
-                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0", "GET, 304, trailers, 0"})
+                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0"})
     void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName,
                                                                  int statusCode,
                                                                  String termination,
@@ -437,6 +437,63 @@ class Http2ClientConnectionTest {
             assertThat(nextStream, notNullValue());
             nextStream.close();
             stream.close();
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"GET, false", "GET, true", "HEAD, false", "HEAD, true"})
+    void notModifiedTrailersResetOnlyTheirStream(String methodName, boolean emptyData) throws Exception {
+        Method method = Method.create(methodName);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(2));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream malformedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+            malformedStream.writeHeaders(requestHeaders().method(method), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(Status.NOT_MODIFIED_304);
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
+            assertThat(malformedStream.readHeaders().status(), is(Status.NOT_MODIFIED_304));
+            if (emptyData) {
+                test.offerInbound(dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, false));
+            }
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), encodedTrailers(), inboundTable, huffman, true),
+                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            Http2Exception failure = assertThrows(Http2Exception.class, () -> chain.readResponse(request, malformedStream));
+            assertThat(failure.code(), is(Http2ErrorCode.PROTOCOL));
+
+            Http2FrameData reset = test.awaitWrittenFrame(Http2FrameType.RST_STREAM);
+            assertThat(reset.header().streamId(), is(malformedStream.streamId()));
+            assertThat(Http2RstStream.create(reset.data()).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertThat(siblingStream.readHeaders().status(), is(Status.OK_200));
+            BufferData data = siblingStream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(recoveredStream, notNullValue());
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+            recoveredStream.close();
+            siblingStream.close();
+            malformedStream.close();
             connection.close();
         }
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/RedirectionProcessorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient.http2;
+
+import java.net.URI;
+import java.util.Map;
+
+import io.helidon.http.Header;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
+import io.helidon.http.Method;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientUri;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RedirectionProcessorTest {
+    private static final Header TEST_CONTENT_ENCODING = HeaderValues.createCached(HeaderNames.CONTENT_ENCODING,
+                                                                                   "test-encoding");
+
+    @Test
+    void methodAndEntityPreservationUsesStatusCode() {
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.TEMPORARY_REDIRECT_307), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.PERMANENT_REDIRECT_308), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(307, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.create(308, "Custom")), is(true));
+        assertThat(RedirectionProcessor.keepsMethodAndEntity(Status.FOUND_302), is(false));
+    }
+
+    @Test
+    void notModifiedIsNotARedirect() {
+        assertThat(RedirectionProcessor.redirectionStatusCode(Status.NOT_MODIFIED_304), is(false));
+    }
+
+    @Test
+    void entityPreservingRedirectPreservesContentEncoding() {
+        Http2ClientRequestImpl request = (Http2ClientRequestImpl) Http2Client.create()
+                .put("http://localhost/source")
+                .header(TEST_CONTENT_ENCODING);
+
+        Http2ClientRequestImpl redirect = new Http2ClientRequestImpl(request,
+                                                                     Method.PUT,
+                                                                     ClientUri.create(URI.create("http://localhost/target")),
+                                                                     Map.of(),
+                                                                     true);
+
+        assertThat(redirect.headers(), hasHeader(TEST_CONTENT_ENCODING));
+    }
+}

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -79,6 +79,7 @@ class Http1ClientTest {
     private static final Header REQ_EXPECT_100_HEADER_NAME = HeaderValues.createCached(
             HeaderNames.create("X-Req-Expect100"), "true");
     private static final HeaderName REQ_CONTENT_LENGTH_HEADER_NAME = HeaderNames.create("X-Req-ContentLength");
+    private static final HeaderName ENTITY_METADATA_HEADER = HeaderNames.create("X-Entity-Metadata");
     private static final String EXPECTED_GET_AFTER_REDIRECT_STRING = "GET after redirect endpoint reached";
     private static final long NO_CONTENT_LENGTH = -1L;
 
@@ -96,7 +97,12 @@ class Http1ClientTest {
     static void routing(HttpRules rules) {
         rules.put("/test", Http1ClientTest::responseHandler);
         rules.put("/redirectKeepMethod", Http1ClientTest::redirectKeepMethod);
+        rules.put("/redirectChainStart", Http1ClientTest::redirectChainStart);
+        rules.put("/redirectChainSecond", Http1ClientTest::redirectChainSecond);
+        rules.put("/redirectChainFinal", Http1ClientTest::redirectChainFinal);
         rules.put("/redirect", Http1ClientTest::redirect);
+        rules.get("/redirectDropEntity", Http1ClientTest::redirectDropEntity);
+        rules.get("/afterDropEntity", Http1ClientTest::afterDropEntity);
         rules.get("/afterRedirect", Http1ClientTest::afterRedirectGet);
         rules.put("/afterRedirect", Http1ClientTest::afterRedirectPut);
         rules.put("/chunkresponse", Http1ClientTest::chunkResponseHandler);
@@ -410,9 +416,37 @@ class Http1ClientTest {
         }
 
         try (HttpClientResponse response = injectedHttp1client.put("/redirectKeepMethod")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(ENTITY_METADATA_HEADER, "drop")
                 .submit("Test entity")) {
             assertThat(response.lastEndpointUri().path().path(), is("/afterRedirect"));
             assertThat(response.status(), is(Status.NO_CONTENT_204));
+        }
+    }
+
+    @Test
+    void testSameMethodRedirectDropsEntityHeaders() {
+        try (HttpClientResponse response = injectedHttp1client.get("/redirectDropEntity")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(ENTITY_METADATA_HEADER, "drop")
+                .submit("Test entity")) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("GET without entity metadata"));
+        }
+    }
+
+    @Test
+    void testOutputStreamChainedRedirectsWithCustomReasonPhrases() {
+        try (HttpClientResponse response = injectedHttp1client.put("/redirectChainStart")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(ENTITY_METADATA_HEADER, "drop")
+                .sendExpectContinue(true)
+                .outputStream(output -> {
+                    output.write("Test entity".getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("Test entity"));
         }
     }
 
@@ -492,6 +526,43 @@ class Http1ClientTest {
                 .send();
     }
 
+    private static void redirectDropEntity(ServerRequest req, ServerResponse res) {
+        res.status(Status.FOUND_302)
+                .header(HeaderNames.LOCATION, "/afterDropEntity")
+                .send();
+    }
+
+    private static void afterDropEntity(ServerRequest req, ServerResponse res) {
+        if (req.content().hasEntity()
+                || req.headers().contains(HeaderNames.CONTENT_TYPE)
+                || req.headers().contains(ENTITY_METADATA_HEADER)) {
+            res.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
+            return;
+        }
+        res.send("GET without entity metadata");
+    }
+
+    private static void redirectChainStart(ServerRequest req, ServerResponse res) {
+        res.status(Status.create(307, "Custom Temporary Redirect"))
+                .header(HeaderNames.LOCATION, "/redirectChainSecond")
+                .send();
+    }
+
+    private static void redirectChainSecond(ServerRequest req, ServerResponse res) {
+        res.status(Status.create(308, "Custom Permanent Redirect"))
+                .header(HeaderNames.LOCATION, "/redirectChainFinal")
+                .send();
+    }
+
+    private static void redirectChainFinal(ServerRequest req, ServerResponse res) {
+        if (req.headers().contains(ENTITY_METADATA_HEADER)
+                || !req.headers().contains(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)) {
+            res.status(Status.BAD_REQUEST_400).send("Unexpected redirected request headers");
+            return;
+        }
+        res.send(req.content().as(String.class));
+    }
+
     private static void afterRedirectGet(ServerRequest req, ServerResponse res) {
         if (req.content().hasEntity()) {
             res.status(Status.BAD_REQUEST_400)
@@ -502,6 +573,11 @@ class Http1ClientTest {
     }
 
     private static void afterRedirectPut(ServerRequest req, ServerResponse res) {
+        if (req.headers().contains(ENTITY_METADATA_HEADER)
+                || !req.headers().contains(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)) {
+            res.status(Status.BAD_REQUEST_400).send("Unexpected redirected request headers");
+            return;
+        }
         String entity = req.content().as(String.class);
         if (!entity.equals("Test entity")) {
             res.status(Status.BAD_REQUEST_400)

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/CookieRedirectLeakTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/CookieRedirectLeakTest.java
@@ -21,8 +21,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Status;
+import io.helidon.webclient.api.WebClientCookieManager;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientResponse;
 import io.helidon.webserver.WebServer;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -45,15 +49,21 @@ class CookieRedirectLeakTest {
     private static final String SET_STORED_COOKIE = STORED_COOKIE + "; Path=/";
     private static final String TARGET_COOKIE = "target=attacker-token";
     private static final String SET_TARGET_COOKIE = TARGET_COOKIE + "; Path=/";
+    private static final String PATH_COOKIE = "pathOnly=redirect-secret";
+    private static final String SET_PATH_COOKIE = PATH_COOKIE + "; Path=/source";
+    private static final HeaderName REDIRECT_HEADER = HeaderNames.create("X-Redirect-Test");
 
     private static final AtomicReference<String> TRUSTED_COOKIE = new AtomicReference<>();
     private static final AtomicReference<String> LEAKED_STEP_COOKIE = new AtomicReference<>();
     private static final AtomicReference<String> LEAKED_COLLECT_COOKIE = new AtomicReference<>();
+    private static final AtomicReference<String> REDIRECT_SOURCE_COOKIE = new AtomicReference<>();
+    private static final AtomicReference<String> REDIRECT_TARGET_COOKIE = new AtomicReference<>();
 
     private static WebServer redirector;
     private static WebServer collector;
     private static Http1Client storedCookieClient;
     private static Http1Client defaultCookieClient;
+    private static Http1Client pathCookieClient;
 
     @BeforeAll
     static void beforeAll() {
@@ -68,7 +78,10 @@ class CookieRedirectLeakTest {
         redirector = WebServer.builder()
                 .host(TRUSTED_HOST)
                 .routing(rules -> rules.get("/prime", CookieRedirectLeakTest::primeTrustedHandler)
-                        .get("/bounce", CookieRedirectLeakTest::redirectHandler))
+                        .get("/bounce", CookieRedirectLeakTest::redirectHandler)
+                        .get("/source/prime", CookieRedirectLeakTest::primePathCookie)
+                        .put("/source/bounce", CookieRedirectLeakTest::redirectWithEntity)
+                        .put("/target/collect", CookieRedirectLeakTest::collectRedirectedEntity))
                 .build()
                 .start();
 
@@ -92,6 +105,11 @@ class CookieRedirectLeakTest {
         defaultCookieClient = Http1Client.builder()
                 .config(defaultConfig.get("client"))
                 .baseUri("http://" + TRUSTED_HOST + ":" + redirector.port())
+                .build();
+
+        pathCookieClient = Http1Client.builder()
+                .baseUri("http://" + TRUSTED_HOST + ":" + redirector.port())
+                .cookieManager(WebClientCookieManager.builder().automaticStoreEnabled(true).build())
                 .build();
     }
 
@@ -149,6 +167,27 @@ class CookieRedirectLeakTest {
                    LEAKED_COLLECT_COOKIE.get(), is(nullValue()));
     }
 
+    @Test
+    void methodPreservingRedirectReselectsCookiesForTargetPath() {
+        REDIRECT_SOURCE_COOKIE.set(null);
+        REDIRECT_TARGET_COOKIE.set(null);
+
+        try (Http1ClientResponse response = pathCookieClient.get("/source/prime").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        try (Http1ClientResponse response = pathCookieClient.put("/source/bounce")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(REDIRECT_HEADER, "drop")
+                .submit("entity")) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("text/plain:entity"));
+        }
+
+        assertThat(REDIRECT_SOURCE_COOKIE.get(), containsString(PATH_COOKIE));
+        assertThat(REDIRECT_TARGET_COOKIE.get(), is(nullValue()));
+    }
+
     private static void primeTrustedHandler(ServerRequest req, ServerResponse res) {
         res.header(HeaderNames.SET_COOKIE, SET_STORED_COOKIE)
                 .status(Status.OK_200)
@@ -178,6 +217,29 @@ class CookieRedirectLeakTest {
     private static void collectHandler(ServerRequest req, ServerResponse res) {
         LEAKED_COLLECT_COOKIE.set(extractCookie(req));
         res.status(Status.OK_200).send("collector reached");
+    }
+
+    private static void primePathCookie(ServerRequest req, ServerResponse res) {
+        res.header(HeaderNames.SET_COOKIE, SET_PATH_COOKIE)
+                .status(Status.OK_200)
+                .send();
+    }
+
+    private static void redirectWithEntity(ServerRequest req, ServerResponse res) {
+        REDIRECT_SOURCE_COOKIE.set(extractCookie(req));
+        res.status(Status.create(307, "Custom Temporary Redirect"))
+                .header(HeaderNames.LOCATION, "/target/collect")
+                .send();
+    }
+
+    private static void collectRedirectedEntity(ServerRequest req, ServerResponse res) {
+        REDIRECT_TARGET_COOKIE.set(extractCookie(req));
+        if (req.headers().contains(REDIRECT_HEADER)) {
+            res.status(Status.BAD_REQUEST_400).send("Custom header was preserved");
+            return;
+        }
+        String contentType = req.headers().contentType().orElseThrow().mediaType().text();
+        res.send(contentType + ":" + req.content().as(String.class));
     }
 
     private static String extractCookie(ServerRequest req) {

--- a/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/Http1CrossOriginRedirectEntityTest.java
+++ b/webclient/tests/http1/src/test/java/io/helidon/webclient/tests/Http1CrossOriginRedirectEntityTest.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -311,6 +312,98 @@ class Http1CrossOriginRedirectEntityTest {
                 assertThat(originRequest.header("expect"), is("100-continue"));
                 assertThat(originRequest.body(), is(""));
                 secondHop.assertNoRequest();
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {307, 308})
+    @Timeout(20)
+    void doesNotSendOutputStreamBodyAfterRedirectTargetFinalResponse(int redirectStatus) throws Exception {
+        try (SecondHopFinalResponseServer secondHop =
+                     new SecondHopFinalResponseServer(InetAddress.getByName(SECOND_HOP_HOST));
+             FirstHopServer firstHop = new FirstHopServer(InetAddress.getByName(FIRST_HOP_HOST),
+                                                          secondHop.port(),
+                                                          false,
+                                                          redirectStatus)) {
+            Http1Client client = newClient(firstHop.port(), true);
+            try {
+                try (Http1ClientResponse response = client.post("/token")
+                        .maxRedirects(1)
+                        .sendExpectContinue(true)
+                        .readContinueTimeout(REQUEST_TIMEOUT)
+                        .readTimeout(REQUEST_TIMEOUT)
+                        .header(HeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                        .outputStream(outputStream -> {
+                            outputStream.write(requestBodyBytes());
+                            outputStream.close();
+                        })) {
+                    assertThat(response.status().code(), is(200));
+                }
+
+                CapturedRequest originRequest = firstHop.awaitRequest();
+                assertThat(originRequest.path(), is("/token"));
+                assertThat(originRequest.header("expect"), is("100-continue"));
+                assertThat(originRequest.body(), is(""));
+
+                CapturedRequest redirectRequest = secondHop.awaitRequest();
+                assertThat(redirectRequest.path(), is("/steal"));
+                assertThat(redirectRequest.header("expect"), is("100-continue"));
+                assertThat(redirectRequest.body(), is(""));
+            } finally {
+                client.closeResource();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {307, 308})
+    @Timeout(20)
+    void closesConnectionAfterRedirectTargetFinalResponseBeforeBody(int redirectStatus) throws Exception {
+        try (SecondHopKeepAliveFinalResponseServer secondHop =
+                     new SecondHopKeepAliveFinalResponseServer(InetAddress.getByName(SECOND_HOP_HOST));
+             FirstHopServer firstHop = new FirstHopServer(InetAddress.getByName(FIRST_HOP_HOST),
+                                                          secondHop.port(),
+                                                          false,
+                                                          redirectStatus)) {
+            Http1Client client = newClient(firstHop.port(), true);
+            try {
+                try (Http1ClientResponse response = client.post("/token")
+                        .maxRedirects(1)
+                        .sendExpectContinue(true)
+                        .readContinueTimeout(REQUEST_TIMEOUT)
+                        .readTimeout(REQUEST_TIMEOUT)
+                        .header(HeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                        .outputStream(outputStream -> {
+                            outputStream.write(requestBodyBytes());
+                            outputStream.close();
+                        })) {
+                    assertThat(response.status().code(), is(200));
+                    assertThat(response.entity().as(String.class), is("OK"));
+                }
+
+                try (Http1ClientResponse response = client.get("http://" + SECOND_HOP_HOST + ":" + secondHop.port()
+                                                                       + "/reuse")
+                        .readTimeout(REQUEST_TIMEOUT)
+                        .request()) {
+                    assertThat(response.status().code(), is(200));
+                    assertThat(response.entity().as(String.class), is("REUSE"));
+                }
+
+                CapturedRequest originRequest = firstHop.awaitRequest();
+                assertThat(originRequest.path(), is("/token"));
+                assertThat(originRequest.header("expect"), is("100-continue"));
+                assertThat(originRequest.body(), is(""));
+
+                CapturedRequest redirectRequest = secondHop.awaitFinalRequest();
+                assertThat(redirectRequest.path(), is("/steal"));
+                assertThat(redirectRequest.header("expect"), is("100-continue"));
+                assertThat(redirectRequest.body(), is(""));
+
+                CapturedRequest reuseRequest = secondHop.awaitReuseRequest();
+                assertThat(reuseRequest.path(), is("/reuse"));
             } finally {
                 client.closeResource();
             }
@@ -643,6 +736,133 @@ class Http1CrossOriginRedirectEntityTest {
                                + "OK");
 
             return request.withBody(body);
+        }
+    }
+
+    private static final class SecondHopFinalResponseServer extends SingleRequestServer {
+        private SecondHopFinalResponseServer(InetAddress bindAddress) throws IOException {
+            super(bindAddress);
+        }
+
+        @Override
+        protected CapturedRequest handle(Socket socket) throws IOException {
+            InputStream inputStream = socket.getInputStream();
+            OutputStream outputStream = socket.getOutputStream();
+
+            CapturedRequest request = readHeadersOnly(inputStream);
+            writeAscii(outputStream,
+                       "HTTP/1.1 200 OK\r\n"
+                               + "Content-Length: 2\r\n"
+                               + "Connection: close\r\n"
+                               + "\r\n"
+                               + "OK");
+            socket.setSoTimeout(1_000);
+            try {
+                int read = inputStream.read();
+                if (read != -1) {
+                    throw new IOException("Expected no body after final redirect response");
+                }
+            } catch (SocketTimeoutException ignored) {
+                // No body arrived while the final response was available to the client.
+            }
+            return request;
+        }
+    }
+
+    private static final class SecondHopKeepAliveFinalResponseServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final CompletableFuture<CapturedRequest> finalRequestFuture = new CompletableFuture<>();
+        private final CompletableFuture<CapturedRequest> reuseRequestFuture = new CompletableFuture<>();
+        private volatile Socket finalSocket;
+        private volatile Socket reuseSocket;
+
+        private SecondHopKeepAliveFinalResponseServer(InetAddress bindAddress) throws IOException {
+            this.serverSocket = new ServerSocket();
+            this.serverSocket.bind(new InetSocketAddress(bindAddress, 0));
+            this.thread = new Thread(this::serve, getClass().getSimpleName() + "-" + port());
+            this.thread.setDaemon(true);
+            this.thread.start();
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        CapturedRequest awaitFinalRequest() throws InterruptedException, ExecutionException, TimeoutException {
+            return finalRequestFuture.get(10, TimeUnit.SECONDS);
+        }
+
+        CapturedRequest awaitReuseRequest() throws InterruptedException, ExecutionException, TimeoutException {
+            return reuseRequestFuture.get(10, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() throws Exception {
+            Socket socket = finalSocket;
+            if (socket != null) {
+                socket.close();
+            }
+            socket = reuseSocket;
+            if (socket != null) {
+                socket.close();
+            }
+            serverSocket.close();
+            thread.join(TimeUnit.SECONDS.toMillis(2));
+        }
+
+        private void serve() {
+            try {
+                try (Socket socket = serverSocket.accept()) {
+                    finalSocket = socket;
+                    socket.setSoTimeout((int) REQUEST_TIMEOUT.toMillis());
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream();
+
+                    CapturedRequest request = readHeadersOnly(inputStream);
+                    finalRequestFuture.complete(request);
+                    writeAscii(outputStream,
+                               "HTTP/1.1 200 OK\r\n"
+                                       + "Content-Length: 2\r\n"
+                                       + "\r\n"
+                                       + "OK");
+
+                    try {
+                        int read = inputStream.read();
+                        if (read != -1) {
+                            writeAscii(outputStream,
+                                       "HTTP/1.1 400 Bad Request\r\n"
+                                               + "Content-Length: 0\r\n"
+                                               + "Connection: close\r\n"
+                                               + "\r\n");
+                            throw new IOException("Expected client to close the incomplete upload connection, but received "
+                                                          + read + " on the same socket");
+                        }
+                    } catch (SocketException ignored) {
+                        // Peer closed or reset the incomplete upload connection.
+                    }
+                }
+
+                try (Socket socket = serverSocket.accept()) {
+                    reuseSocket = socket;
+                    socket.setSoTimeout((int) REQUEST_TIMEOUT.toMillis());
+                    CapturedRequest request = readHeadersOnly(socket.getInputStream());
+                    reuseRequestFuture.complete(request);
+                    writeAscii(socket.getOutputStream(),
+                               "HTTP/1.1 200 OK\r\n"
+                                       + "Content-Length: 5\r\n"
+                                       + "Connection: close\r\n"
+                                       + "\r\n"
+                                       + "REUSE");
+                }
+            } catch (Throwable t) {
+                if (!finalRequestFuture.isDone()) {
+                    finalRequestFuture.completeExceptionally(t);
+                }
+                if (!reuseRequestFuture.isDone()) {
+                    reuseRequestFuture.completeExceptionally(t);
+                }
+            }
         }
     }
 

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.tests.http2;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -23,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
@@ -41,6 +43,10 @@ import io.helidon.webclient.spi.WebClientService;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.http.ServerRequest;
 
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -453,6 +459,92 @@ class CrossOriginRedirectHeaderTest {
     @Test
     void h2cFallbackOutputStreamRedirectHonorsRequestExpectContinueOverride() throws Exception {
         followsH2cFallbackOutputStreamRedirectWithEntityWhenEnabled(307, true, false, false);
+    }
+
+    @Test
+    void doesNotSendOutputStreamBodyAfterRedirectTargetFinalResponse() {
+        doesNotSendOutputStreamBodyAfterRedirectTargetFinalResponse(307);
+        doesNotSendOutputStreamBodyAfterRedirectTargetFinalResponse(308);
+    }
+
+    private static void doesNotSendOutputStreamBodyAfterRedirectTargetFinalResponse(int redirectStatus) {
+        AtomicInteger dataFrames = new AtomicInteger();
+        MockHttp2Server finalResponseServer = MockHttp2Server.builder()
+                .onHeaders((ctx, streamId, headers, unused, encoder) -> {
+                    Http2Headers responseHeaders =
+                            new DefaultHttp2Headers().status(HttpResponseStatus.OK.codeAsText())
+                                    .add("content-length", "2");
+                    encoder.writeHeaders(ctx, streamId, responseHeaders, 0, false, ctx.newPromise());
+                    encoder.writeData(ctx,
+                                      streamId,
+                                      Unpooled.wrappedBuffer("OK".getBytes(StandardCharsets.UTF_8)),
+                                      0,
+                                      true,
+                                      ctx.newPromise());
+                    ctx.flush();
+                })
+                .onData((ctx, streamId, data, padding, endOfStream, encoder) -> {
+                    dataFrames.incrementAndGet();
+                    return data.readableBytes() + padding;
+                })
+                .build();
+        WebServer firstHop = WebServer.builder()
+                .host("127.0.0.1")
+                .port(-1)
+                .routing(rules -> rules.put("/redirect/final-response", (req, res) -> {
+                    res.status(Status.create(redirectStatus))
+                            .header(HeaderNames.LOCATION,
+                                    "http://localhost:" + finalResponseServer.port() + "/final-response")
+                            .send();
+                }))
+                .build()
+                .start();
+        Http2Client client = newClient(firstHop.port(), true, true, true, true, true);
+        try (Http2ClientResponse response = client.put("/redirect/final-response")
+                .maxRedirects(1)
+                .outputStream(it -> {
+                    it.write(requestBodyBytes());
+                    it.close();
+                })) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.entity().as(String.class), is("OK"));
+        } finally {
+            client.closeResource();
+            firstHop.stop();
+            finalResponseServer.shutdown();
+        }
+
+        assertThat(dataFrames.get(), is(0));
+    }
+
+    @Test
+    void followsOutputStreamRedirectThroughHttp1Fallback() throws Exception {
+        try (Http1FallbackRedirectServer finalResponseServer = new Http1FallbackRedirectServer()) {
+            WebServer firstHop = WebServer.builder()
+                    .host("127.0.0.1")
+                    .port(-1)
+                    .routing(rules -> rules.put("/redirect/http1-fallback", (req, res) -> {
+                        res.status(Status.TEMPORARY_REDIRECT_307)
+                                .header(HeaderNames.LOCATION, finalResponseServer.redirectUri())
+                                .send();
+                    }))
+                    .build()
+                    .start();
+            Http2Client client = newClient(firstHop.port(), true, true, true, false, true);
+            try (Http2ClientResponse response = client.put("/redirect/http1-fallback")
+                    .maxRedirects(2)
+                    .outputStream(output -> {
+                        output.write(requestBodyBytes());
+                        output.close();
+                    })) {
+                assertThat(response.status(), is(Status.OK_200));
+                assertThat(response.entity().as(String.class), is("OK"));
+            } finally {
+                client.closeResource();
+                firstHop.stop();
+            }
+            assertThat(finalResponseServer.closedWithoutBody(), is(true));
+        }
     }
 
     private static void rejectOutputStreamEntityWhenH2cUpgradeRedirectsCrossOrigin(String redirectPath) {
@@ -899,6 +991,72 @@ class CrossOriginRedirectHeaderTest {
     }
 
     private record CapturedHeaders(String authorization, String apiKey) {
+    }
+
+    private static final class Http1FallbackRedirectServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final CompletableFuture<Boolean> closedWithoutBody = new CompletableFuture<>();
+
+        private Http1FallbackRedirectServer() throws IOException {
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0));
+            thread = new Thread(this::serve, "h2c-fallback-final-" + serverSocket.getLocalPort());
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+            thread.join(TimeUnit.SECONDS.toMillis(2));
+        }
+
+        private String redirectUri() {
+            return "http://localhost:" + serverSocket.getLocalPort() + "/redirect";
+        }
+
+        private boolean closedWithoutBody() throws Exception {
+            return closedWithoutBody.get(5, TimeUnit.SECONDS);
+        }
+
+        private void serve() {
+            try {
+                try (Socket socket = serverSocket.accept()) {
+                    String requestHeaders = RedirectingHttp1Server.readHeaders(socket.getInputStream())
+                            .toLowerCase(Locale.ROOT);
+                    assertThat(requestHeaders.contains("\r\nupgrade: h2c\r\n"), is(true));
+                    socket.getOutputStream().write(("HTTP/1.1 307 Temporary Redirect\r\n"
+                                                            + "Location: /final\r\n"
+                                                            + "Content-Length: 0\r\n"
+                                                            + "Connection: close\r\n"
+                                                            + "\r\n")
+                                                           .getBytes(StandardCharsets.US_ASCII));
+                }
+
+                try (Socket socket = serverSocket.accept()) {
+                    RedirectingHttp1Server.readHeaders(socket.getInputStream());
+                    socket.getOutputStream().write(("HTTP/1.1 200 OK\r\n"
+                                                            + "Content-Length: 2\r\n"
+                                                            + "Connection: close\r\n"
+                                                            + "\r\n"
+                                                            + "OK")
+                                                           .getBytes(StandardCharsets.US_ASCII));
+                    socket.setSoTimeout(2_000);
+                    try {
+                        closedWithoutBody.complete(socket.getInputStream().read() == -1);
+                    } catch (SocketTimeoutException e) {
+                        closedWithoutBody.complete(false);
+                    }
+                }
+            } catch (SocketException e) {
+                if (!serverSocket.isClosed()) {
+                    closedWithoutBody.completeExceptionally(e);
+                }
+            } catch (Throwable t) {
+                closedWithoutBody.completeExceptionally(t);
+            }
+        }
     }
 
     private static final class RedirectingHttp1Server implements AutoCloseable {

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/CrossOriginRedirectHeaderTest.java
@@ -65,6 +65,7 @@ class CrossOriginRedirectHeaderTest {
     private static final AtomicReference<String> CROSS_ORIGIN_BODY_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<String> CROSS_ORIGIN_PROTOCOL_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<Boolean> CROSS_ORIGIN_EXPECT_CAPTURE = new AtomicReference<>();
+    private static final AtomicReference<String> CROSS_ORIGIN_AUTHORITY_CAPTURE = new AtomicReference<>();
 
     private static WebServer trustedServer;
     private static WebServer redirectTargetServer;
@@ -83,6 +84,7 @@ class CrossOriginRedirectHeaderTest {
                     CROSS_ORIGIN_CAPTURE.set(capturedHeaders(req));
                     CROSS_ORIGIN_PROTOCOL_CAPTURE.set(req.prologue().protocolVersion());
                     CROSS_ORIGIN_EXPECT_CAPTURE.set(req.headers().contains(HeaderNames.EXPECT));
+                    CROSS_ORIGIN_AUTHORITY_CAPTURE.set(req.requestedUri().authority());
                     try (InputStream inputStream = req.content().inputStream()) {
                         CROSS_ORIGIN_BODY_CAPTURE.set(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
                         res.send("captured");
@@ -163,6 +165,7 @@ class CrossOriginRedirectHeaderTest {
         CROSS_ORIGIN_BODY_CAPTURE.set(null);
         CROSS_ORIGIN_PROTOCOL_CAPTURE.set(null);
         CROSS_ORIGIN_EXPECT_CAPTURE.set(null);
+        CROSS_ORIGIN_AUTHORITY_CAPTURE.set(null);
     }
 
     @Test
@@ -671,6 +674,18 @@ class CrossOriginRedirectHeaderTest {
     @Test
     void followsCrossOrigin308WithEntityWhenEnabled() {
         followsCrossOriginRedirectWithEntityWhenEnabled("/redirect/cross-origin-keep-method-308");
+    }
+
+    @Test
+    void redirectRegeneratesAuthorityForTarget() {
+        try (Http2ClientResponse response = newClient()
+                .put("/redirect/cross-origin-keep-method")
+                .header(io.helidon.http.http2.Http2Headers.AUTHORITY_NAME, "stale.example")
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        assertThat(CROSS_ORIGIN_AUTHORITY_CAPTURE.get(), is("localhost:" + redirectTargetServer.port()));
     }
 
     private static Http2Client newClient() {

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -23,11 +23,15 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import io.helidon.http.HeaderName;
 import io.helidon.http.HeaderNames;
+import io.helidon.http.HeaderValues;
 import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClientCookieManager;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientResponse;
 import io.helidon.webserver.http.HttpRouting;
@@ -40,16 +44,23 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.http.Status.INTERNAL_SERVER_ERROR_500;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServerTest
 class FollowRedirectTest {
     private static final StringBuilder BUFFER = new StringBuilder();
+    private static final String PATH_COOKIE = "pathOnly=redirect-secret";
+    private static final HeaderName REDIRECT_HEADER = HeaderNames.create("X-Redirect-Test");
+    private static final AtomicReference<String> REDIRECT_SOURCE_COOKIE = new AtomicReference<>();
+    private static final AtomicReference<String> REDIRECT_TARGET_COOKIE = new AtomicReference<>();
     private final Http2Client webClient;
 
     FollowRedirectTest(URI uri) {
         this.webClient = Http2Client.builder()
                 .baseUri(uri)
+                .cookieManager(WebClientCookieManager.builder().automaticStoreEnabled(true).build())
                 .build();
     }
 
@@ -96,6 +107,38 @@ class FollowRedirectTest {
                 res.status(INTERNAL_SERVER_ERROR_500)
                         .send(e.getMessage());
             }
+        }).route(Method.GET, "/source/prime", (req, res) -> {
+            res.header(HeaderNames.SET_COOKIE, PATH_COOKIE + "; Path=/source")
+                    .send();
+        }).route(Method.PUT, "/source/bounce", (req, res) -> {
+            REDIRECT_SOURCE_COOKIE.set(req.headers().contains(HeaderNames.COOKIE)
+                                               ? req.headers().get(HeaderNames.COOKIE).values()
+                                               : null);
+            res.status(Status.create(308, "Custom Permanent Redirect"))
+                    .header(HeaderNames.LOCATION, "/target/collect")
+                    .send();
+        }).route(Method.PUT, "/target/collect", (req, res) -> {
+            REDIRECT_TARGET_COOKIE.set(req.headers().contains(HeaderNames.COOKIE)
+                                               ? req.headers().get(HeaderNames.COOKIE).values()
+                                               : null);
+            if (req.headers().contains(REDIRECT_HEADER)) {
+                res.status(Status.BAD_REQUEST_400).send("Custom header was preserved");
+                return;
+            }
+            String contentType = req.headers().contentType().orElseThrow().mediaType().text();
+            res.send(contentType + ":" + req.content().as(String.class));
+        }).route(Method.GET, "/redirectDropEntity", (req, res) -> {
+            res.status(Status.FOUND_302)
+                    .header(HeaderNames.LOCATION, "/afterDropEntity")
+                    .send();
+        }).route(Method.GET, "/afterDropEntity", (req, res) -> {
+            if (req.content().hasEntity()
+                    || req.headers().contains(HeaderNames.CONTENT_TYPE)
+                    || req.headers().contains(REDIRECT_HEADER)) {
+                res.status(Status.BAD_REQUEST_400).send("Entity metadata was preserved");
+                return;
+            }
+            res.send("GET without entity metadata");
         }).route(Method.PUT, "/plain", (req, res) -> {
             try (InputStream in = req.content().inputStream()) {
                 byte[] buffer = new byte[128];
@@ -156,6 +199,8 @@ class FollowRedirectTest {
     @AfterEach
     void clearBuffer() {
         BUFFER.setLength(0);
+        REDIRECT_SOURCE_COOKIE.set(null);
+        REDIRECT_TARGET_COOKIE.set(null);
     }
 
     @Test
@@ -220,6 +265,39 @@ class FollowRedirectTest {
                     it.close();
                 })) {
             assertThat(response.entity().as(String.class), is(expected));
+        }
+    }
+
+    @Test
+    void methodPreservingRedirectReselectsCookiesForTargetPath() {
+        try (Http2ClientResponse response = webClient.get()
+                .path("/source/prime")
+                .request()) {
+            assertThat(response.status(), is(Status.OK_200));
+        }
+
+        try (Http2ClientResponse response = webClient.put()
+                .path("/source/bounce")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(REDIRECT_HEADER, "drop")
+                .submit("entity")) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("text/plain:entity"));
+        }
+
+        assertThat(REDIRECT_SOURCE_COOKIE.get(), containsString(PATH_COOKIE));
+        assertThat(REDIRECT_TARGET_COOKIE.get(), is(nullValue()));
+    }
+
+    @Test
+    void sameMethodRedirectDropsEntityHeaders() {
+        try (Http2ClientResponse response = webClient.get()
+                .path("/redirectDropEntity")
+                .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN)
+                .header(REDIRECT_HEADER, "drop")
+                .submit("entity")) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is("GET without entity metadata"));
         }
     }
 

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -34,9 +34,12 @@ import io.helidon.webclient.api.ClientResponseTyped;
 import io.helidon.webclient.api.WebClientCookieManager;
 import io.helidon.webclient.http2.Http2Client;
 import io.helidon.webclient.http2.Http2ClientResponse;
+import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
 import io.helidon.webserver.testing.junit5.ServerTest;
 import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +56,7 @@ class FollowRedirectTest {
     private static final StringBuilder BUFFER = new StringBuilder();
     private static final String PATH_COOKIE = "pathOnly=redirect-secret";
     private static final HeaderName REDIRECT_HEADER = HeaderNames.create("X-Redirect-Test");
+    private static final HeaderName PEER_PORT_HEADER = HeaderNames.create("X-Peer-Port");
     private static final AtomicReference<String> REDIRECT_SOURCE_COOKIE = new AtomicReference<>();
     private static final AtomicReference<String> REDIRECT_TARGET_COOKIE = new AtomicReference<>();
     private final Http2Client webClient;
@@ -62,6 +66,13 @@ class FollowRedirectTest {
                 .baseUri(uri)
                 .cookieManager(WebClientCookieManager.builder().automaticStoreEnabled(true).build())
                 .build();
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder server) {
+        server.addProtocol(Http2Config.builder()
+                                   .maxConcurrentStreams(1)
+                                   .build());
     }
 
     @SetUpRoute
@@ -78,6 +89,16 @@ class FollowRedirectTest {
             res.status(Status.TEMPORARY_REDIRECT_307)
                     .header(HeaderNames.LOCATION, "/plain")
                     .send();
+        }).route(Method.PUT, "/redirectNoContent", (req, res) -> {
+            res.status(Status.TEMPORARY_REDIRECT_307)
+                    .header(HeaderNames.LOCATION, "/noContent")
+                    .send();
+        }).route(Method.PUT, "/noContent", (req, res) -> {
+            res.status(Status.NO_CONTENT_204)
+                    .header(PEER_PORT_HEADER, String.valueOf(req.remotePeer().port()))
+                    .send();
+        }).route(Method.GET, "/peerPort", (req, res) -> {
+            res.send(String.valueOf(req.remotePeer().port()));
         }).route(Method.PUT, "/redirectKeepMethodThenGet", (req, res) -> {
             res.status(Status.TEMPORARY_REDIRECT_307)
                     .header(HeaderNames.LOCATION, "/redirectNoEntityAfterKeepMethod")
@@ -220,6 +241,24 @@ class FollowRedirectTest {
                     it.close();
                 })) {
             assertThat(response.entity().as(String.class), is(expected));
+        }
+    }
+
+    @Test
+    void noContentRedirectProbeReleasesStreamCapacity() throws IOException {
+        Http2ClientResponse response = webClient.put()
+                .path("/redirectNoContent")
+                .sendExpectContinue(true)
+                .outputStream(output -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(response.status(), is(Status.NO_CONTENT_204));
+        String peerPort = response.headers().get(PEER_PORT_HEADER).get();
+        assertThat(response.inputStream().readAllBytes().length, is(0));
+
+        try (Http2ClientResponse followUp = webClient.get()
+                .path("/peerPort")
+                .request()) {
+            assertThat(followUp.entity().as(String.class), is(peerPort));
         }
     }
 

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/FollowRedirectTest.java
@@ -251,14 +251,18 @@ class FollowRedirectTest {
                 .sendExpectContinue(true)
                 .outputStream(output -> output.write("entity".getBytes(StandardCharsets.UTF_8)));
 
-        assertThat(response.status(), is(Status.NO_CONTENT_204));
-        String peerPort = response.headers().get(PEER_PORT_HEADER).get();
-        assertThat(response.inputStream().readAllBytes().length, is(0));
+        try {
+            assertThat(response.status(), is(Status.NO_CONTENT_204));
+            String peerPort = response.headers().get(PEER_PORT_HEADER).get();
+            assertThat(response.inputStream().readAllBytes().length, is(0));
 
-        try (Http2ClientResponse followUp = webClient.get()
-                .path("/peerPort")
-                .request()) {
-            assertThat(followUp.entity().as(String.class), is(peerPort));
+            try (Http2ClientResponse followUp = webClient.get()
+                    .path("/peerPort")
+                    .request()) {
+                assertThat(followUp.entity().as(String.class), is(peerPort));
+            }
+        } finally {
+            response.close();
         }
     }
 

--- a/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/HeadersClientTest.java
+++ b/webclient/tests/http2/src/test/java/io/helidon/webclient/tests/http2/HeadersClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webclient.tests.http2;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +30,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.helidon.common.media.type.ParserMode;
+import io.helidon.http.BadRequestException;
 import io.helidon.http.Header;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
@@ -68,10 +71,12 @@ class HeadersClientTest {
     private static final Header TRAILER_HEADER = HeaderValues.create("Trailer-header", "trailer-test");
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
     private static final String DATA = "Helidon!!!".repeat(10);
+    private static final String INVALID_CONTENT_TYPE = "text/plain; charset=";
     private static final Vertx VERTX = Vertx.vertx(new VertxOptions().setBlockedThreadCheckInterval(1000*60*60));
     private static final ExecutorService EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
     private static HttpServer SERVER;
     private static Http2Client CLIENT;
+    private static Http2Client RELAXED_CLIENT;
     private static HttpClient VERTX_CLIENT;
 
     @BeforeAll
@@ -132,6 +137,18 @@ class HeadersClientTest {
                         case "/100-continue-not" -> {
                             res.setStatusCode(418).send();
                         }
+                        case "/invalid-content-type" -> {
+                            res.putHeader(HeaderNames.CONTENT_TYPE.defaultCase(), INVALID_CONTENT_TYPE);
+                            res.end();
+                        }
+                        case "/invalid-content-type-upload" -> req.body(ignored -> {
+                            res.putHeader(HeaderNames.CONTENT_TYPE.defaultCase(), INVALID_CONTENT_TYPE);
+                            res.end();
+                        });
+                        case "/invalid-content-type-before-upload" -> {
+                            res.putHeader(HeaderNames.CONTENT_TYPE.defaultCase(), INVALID_CONTENT_TYPE);
+                            res.setStatusCode(418).end();
+                        }
                         case "/100-continue" -> {
                             AtomicBoolean continueSent = new AtomicBoolean(false);
                             req.body(event -> {
@@ -173,6 +190,11 @@ class HeadersClientTest {
         CLIENT = Http2Client.builder()
                 .baseUri("http://localhost:" + port + "/")
                 .readContinueTimeout(Duration.ofSeconds(2))
+                .build();
+        RELAXED_CLIENT = Http2Client.builder()
+                .baseUri("http://localhost:" + port + "/")
+                .readContinueTimeout(Duration.ofSeconds(2))
+                .mediaTypeParserMode(ParserMode.RELAXED)
                 .build();
 
         HttpClientOptions clientOptions = new HttpClientOptions()
@@ -279,6 +301,55 @@ class HeadersClientTest {
             Header after100Header = HeaderValues.create("after_100", "test");
             assertThat(res.headers(), hasHeader(before100Header));
             assertThat(res.headers(), hasHeader(after100Header));
+        }
+    }
+
+    @Test
+    void contentTypeUsesConfiguredParserMode() {
+        try (Http2ClientResponse res = CLIENT
+                .method(Method.GET)
+                .path("/invalid-content-type")
+                .priorKnowledge(true)
+                .request()) {
+            assertThrows(BadRequestException.class, res.headers()::contentType);
+        }
+
+        try (Http2ClientResponse res = RELAXED_CLIENT
+                .method(Method.GET)
+                .path("/invalid-content-type")
+                .priorKnowledge(true)
+                .request()) {
+            assertThat(res.headers().contentType().orElseThrow().text(), is("text/plain"));
+        }
+    }
+
+    @Test
+    void outputStreamContentTypeUsesConfiguredParserMode() {
+        try (Http2ClientResponse res = RELAXED_CLIENT
+                .method(Method.PUT)
+                .path("/invalid-content-type-upload")
+                .priorKnowledge(true)
+                .outputStream(output -> {
+                    output.write(DATA.getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                })) {
+            assertThat(res.headers().contentType().orElseThrow().text(), is("text/plain"));
+        }
+    }
+
+    @Test
+    void preUploadContentTypeUsesConfiguredParserMode() {
+        try (Http2ClientResponse res = RELAXED_CLIENT
+                .method(Method.PUT)
+                .path("/invalid-content-type-before-upload")
+                .priorKnowledge(true)
+                .sendExpectContinue(true)
+                .outputStream(output -> {
+                    output.write(DATA.getBytes(StandardCharsets.UTF_8));
+                    output.close();
+                })) {
+            assertThat(res.status(), is(Status.I_AM_A_TEAPOT_418));
+            assertThat(res.headers().contentType().orElseThrow().text(), is("text/plain"));
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class RoutingTest extends RoutingTestBase {
                 .post("/post", (req, res) -> res.send("post"))
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
-                .head("/head", (req, res) -> res.send("head"))
+                .head("/head", (req, res) -> sendHead(res, "head"))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
@@ -66,7 +66,7 @@ class RoutingTest extends RoutingTestBase {
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))
                 .put("/put_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("put_multi"))
                 .delete("/delete_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("delete_multi"))
-                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("head_multi"))
+                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> sendHead(res, "head_multi"))
                 .options("/options_multi",
                          RoutingTestBase::multiHandler,
                          (req, res) -> res.send("options_multi"))
@@ -77,7 +77,7 @@ class RoutingTest extends RoutingTestBase {
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))
-                .head((req, res) -> res.send("head_catchall"))
+                .head((req, res) -> sendHead(res, "head_catchall"))
                 .options((req, res) -> res.send("options_catchall"))
                 .trace((req, res) -> res.send("trace_catchall"))
                 .patch((req, res) -> res.send("patch_catchall")));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -73,7 +73,7 @@ class RoutingTest extends RoutingTestBase {
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
                 // shortcut methods with no path pattern
-                .get((req, res) -> res.send("get_catchall"))
+                .get((req, res) -> res.send(GET_CATCHALL_RESPONSE))
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.tests;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -38,12 +39,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 // Use by both RoutingTest and RulesTest to share the same test methods
 abstract class RoutingTestBase {
     private static final Header MULTI_HANDLER = HeaderValues.createCached(
             HeaderNames.create("X-Multi-Handler"), "true");
+    private static final String HEAD_ROUTE_HEADER = "X-Head-Route";
     static Http1Client client;
     // Functions that will be used to execute http webclient shortcut methods
     private static Function<String, Http1ClientRequest> get = x -> client.get(x);
@@ -59,6 +62,12 @@ abstract class RoutingTestBase {
     static void multiHandler(ServerRequest req, ServerResponse res) {
         res.headers().set(MULTI_HANDLER);
         res.next();
+    }
+
+    static void sendHead(ServerResponse res, String responseMessage) {
+        res.headers().set(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage));
+        res.headers().contentLength(responseMessage.getBytes(StandardCharsets.UTF_8).length);
+        res.send();
     }
 
     @Test
@@ -105,10 +114,13 @@ abstract class RoutingTestBase {
 
     @ParameterizedTest
     @MethodSource("basic")
-    void testHttpShortcutMethods(Function<String, Http1ClientRequest> request, String path, String responseMessage) {
+    void testHttpShortcutMethods(Function<String, Http1ClientRequest> request,
+                                 String path,
+                                 String responseMessage,
+                                 boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertThat(response.as(String.class), is(responseMessage));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
         }
     }
 
@@ -116,10 +128,11 @@ abstract class RoutingTestBase {
     @MethodSource("withoutPathPattern")
     void testHttpShortcutMethodsWithoutPathPattern(Function<String, Http1ClientRequest> request,
                                                    String path,
-                                                   String responseMessage) {
+                                                   String responseMessage,
+                                                   boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertThat(response.as(String.class), is(responseMessage));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
         }
     }
 
@@ -138,40 +151,53 @@ abstract class RoutingTestBase {
     @MethodSource("withMultiHandlers")
     void testHttpShortcutMethodsWithMultiHandlers(Function<String, Http1ClientRequest> request,
                                                   String path,
-                                                  String responseMessage) {
+                                                  String responseMessage,
+                                                  boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), hasHeader(MULTI_HANDLER));
+            assertResponseEntity(response, responseMessage, hasResponseEntity);
+        }
+    }
+
+    private static void assertResponseEntity(Http1ClientResponse response,
+                                             String responseMessage,
+                                             boolean hasResponseEntity) {
+        if (hasResponseEntity) {
             assertThat(response.as(String.class), is(responseMessage));
+        } else {
+            assertThat(response.headers(),
+                       hasHeader(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage)));
+            assertThrows(IllegalStateException.class, () -> response.as(String.class));
         }
     }
 
     private static Stream<Arguments> basic() {
         return Stream.of(
-                arguments(get, "/get", "get"),
-                arguments(post, "/post", "post"),
-                arguments(put, "/put", "put"),
-                arguments(delete, "/delete", "delete"),
-                arguments(head, "/head", "head"),
-                arguments(options, "/options", "options"),
-                arguments(trace, "/trace", "trace"),
-                arguments(patch, "/patch", "patch"),
-                arguments(delete, "/any", "any"),
-                arguments(post, "/any", "any"),
-                arguments(get, "/any", "any")
+                arguments(get, "/get", "get", true),
+                arguments(post, "/post", "post", true),
+                arguments(put, "/put", "put", true),
+                arguments(delete, "/delete", "delete", true),
+                arguments(head, "/head", "head", false),
+                arguments(options, "/options", "options", true),
+                arguments(trace, "/trace", "trace", true),
+                arguments(patch, "/patch", "patch", true),
+                arguments(delete, "/any", "any", true),
+                arguments(post, "/any", "any", true),
+                arguments(get, "/any", "any", true)
         );
     }
 
     private static Stream<Arguments> withoutPathPattern() {
         return Stream.of(
-                arguments(get, "/get_catchall", "get_catchall"),
-                arguments(post, "/post_catchall", "post_catchall"),
-                arguments(put, "/put_catchall", "put_catchall"),
-                arguments(delete, "/delete_catchall", "delete_catchall"),
-                arguments(head, "/head_catchall", "head_catchall"),
-                arguments(options, "/options_catchall", "options_catchall"),
-                arguments(trace, "/trace_catchall", "trace_catchall"),
-                arguments(patch, "/patch_catchall", "patch_catchall")
+                arguments(get, "/get_catchall", "get_catchall", true),
+                arguments(post, "/post_catchall", "post_catchall", true),
+                arguments(put, "/put_catchall", "put_catchall", true),
+                arguments(delete, "/delete_catchall", "delete_catchall", true),
+                arguments(head, "/head_catchall", "head_catchall", false),
+                arguments(options, "/options_catchall", "options_catchall", true),
+                arguments(trace, "/trace_catchall", "trace_catchall", true),
+                arguments(patch, "/patch_catchall", "patch_catchall", true)
         );
     }
 
@@ -184,14 +210,14 @@ abstract class RoutingTestBase {
 
     private static Stream<Arguments> withMultiHandlers() {
         return Stream.of(
-                arguments(get, "/get_multi", "get_multi"),
-                arguments(post, "/post_multi", "post_multi"),
-                arguments(put, "/put_multi", "put_multi"),
-                arguments(delete, "/delete_multi", "delete_multi"),
-                arguments(head, "/head_multi", "head_multi"),
-                arguments(options, "/options_multi", "options_multi"),
-                arguments(trace, "/trace_multi", "trace_multi"),
-                arguments(patch, "/patch_multi", "patch_multi")
+                arguments(get, "/get_multi", "get_multi", true),
+                arguments(post, "/post_multi", "post_multi", true),
+                arguments(put, "/put_multi", "put_multi", true),
+                arguments(delete, "/delete_multi", "delete_multi", true),
+                arguments(head, "/head_multi", "head_multi", false),
+                arguments(options, "/options_multi", "options_multi", true),
+                arguments(trace, "/trace_multi", "trace_multi", true),
+                arguments(patch, "/patch_multi", "patch_multi", true)
         );
     }
 }

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -44,6 +44,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 // Use by both RoutingTest and RulesTest to share the same test methods
 abstract class RoutingTestBase {
+    static final String GET_CATCHALL_RESPONSE = "get_catchall";
+
     private static final Header MULTI_HANDLER = HeaderValues.createCached(
             HeaderNames.create("X-Multi-Handler"), "true");
     private static final String HEAD_ROUTE_HEADER = "X-Head-Route";
@@ -66,7 +68,7 @@ abstract class RoutingTestBase {
 
     static void sendHead(ServerResponse res, String responseMessage) {
         res.headers().set(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage));
-        res.headers().contentLength(responseMessage.getBytes(StandardCharsets.UTF_8).length);
+        res.headers().contentLength(GET_CATCHALL_RESPONSE.getBytes(StandardCharsets.UTF_8).length);
         res.send();
     }
 
@@ -120,7 +122,7 @@ abstract class RoutingTestBase {
                                  boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
@@ -132,7 +134,7 @@ abstract class RoutingTestBase {
                                                    boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
@@ -156,11 +158,12 @@ abstract class RoutingTestBase {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), hasHeader(MULTI_HANDLER));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
     private static void assertResponseEntity(Http1ClientResponse response,
+                                             String path,
                                              String responseMessage,
                                              boolean hasResponseEntity) {
         if (hasResponseEntity) {
@@ -169,6 +172,11 @@ abstract class RoutingTestBase {
             assertThat(response.headers(),
                        hasHeader(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage)));
             assertThrows(IllegalStateException.class, () -> response.as(String.class));
+            try (Http1ClientResponse getResponse = client.get(path).request()) {
+                assertThat(getResponse.status(), is(Status.OK_200));
+                byte[] getContent = getResponse.as(byte[].class);
+                assertThat(response.headers().contentLength().orElse(-1), is((long) getContent.length));
+            }
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class RulesTest extends RoutingTestBase {
                 .post("/post", (req, res) -> res.send("post"))
                 .put("/put", (req, res) -> res.send("put"))
                 .delete("/delete", (req, res) -> res.send("delete"))
-                .head("/head", (req, res) -> res.send("head"))
+                .head("/head", (req, res) -> sendHead(res, "head"))
                 .options("/options", (req, res) -> res.send("options"))
                 .trace("/trace", (req, res) -> res.send("trace"))
                 .patch("/patch", (req, res) -> res.send("patch"))
@@ -65,7 +65,7 @@ class RulesTest extends RoutingTestBase {
                 .post("/post_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("post_multi"))
                 .put("/put_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("put_multi"))
                 .delete("/delete_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("delete_multi"))
-                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("head_multi"))
+                .head("/head_multi", RoutingTestBase::multiHandler, (req, res) -> sendHead(res, "head_multi"))
                 .options("/options_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("options_multi"))
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
@@ -74,7 +74,7 @@ class RulesTest extends RoutingTestBase {
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))
-                .head((req, res) -> res.send("head_catchall"))
+                .head((req, res) -> sendHead(res, "head_catchall"))
                 .options((req, res) -> res.send("options_catchall"))
                 .trace((req, res) -> res.send("trace_catchall"))
                 .patch((req, res) -> res.send("patch_catchall"));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -70,7 +70,7 @@ class RulesTest extends RoutingTestBase {
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
                 // shortcut methods with no path pattern
-                .get((req, res) -> res.send("get_catchall"))
+                .get((req, res) -> res.send(GET_CATCHALL_RESPONSE))
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))


### PR DESCRIPTION
Resolves #12526

Backports #12505 to Helidon 4.x, preserving HTTP field-value octets and aligning HTTP parsing and redirect handling with main.

Includes 4.x-specific adaptations for early final responses and redirect-response lifecycle management.

Follow up issue: https://github.com/helidon-io/helidon/issues/12533 - please do not report findings mentioned in the follow up issue