### PR TITLE
Optimize common WebServer hot paths (27.x)

### DIFF
--- a/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/DataReader.java
@@ -80,11 +80,7 @@ public class DataReader {
      * Pull next data.
      */
     public void pullData() {
-        byte[] bytes = bytesSupplier.get();
-        if (bytes == null) {
-            throw new InsufficientDataAvailableException();
-        }
-        Node n = new Node(bytes);
+        Node n = new Node(pullBytes());
         tail.next = n;
         tail = n;
     }
@@ -110,9 +106,11 @@ public class DataReader {
     public void ensureAvailable() {
         while (!head.hasAvailable()) {
             if (head.next == null) {
-                pullData();
+                head.reuse(pullBytes());
+                tail = head;
+            } else {
+                head = head.next;
             }
-            head = head.next;
         }
     }
 
@@ -466,6 +464,14 @@ public class DataReader {
         this.context = context;
     }
 
+    private byte[] pullBytes() {
+        byte[] bytes = bytesSupplier.get();
+        if (bytes == null) {
+            throw new InsufficientDataAvailableException();
+        }
+        return bytes;
+    }
+
     /**
      * New line not valid.
      */
@@ -492,7 +498,7 @@ public class DataReader {
     }
 
     private class Node {
-        private final byte[] bytes;
+        private byte[] bytes;
         private int position;
         private Node next;
 
@@ -511,6 +517,11 @@ public class DataReader {
 
         boolean hasAvailable() {
             return position < bytes.length;
+        }
+
+        void reuse(byte[] bytes) {
+            this.bytes = bytes;
+            this.position = 0;
         }
 
         /*

--- a/common/buffers/src/main/java/io/helidon/common/buffers/GrowingBufferData.java
+++ b/common/buffers/src/main/java/io/helidon/common/buffers/GrowingBufferData.java
@@ -150,20 +150,15 @@ class GrowingBufferData implements BufferData {
 
     @Override
     public void write(BufferData toWrite) {
-        ensureSize(toWrite.available());
-        byte[] buffer = new byte[toWrite.available()];
-        int read = toWrite.read(buffer);
-        System.arraycopy(buffer, 0, this.bytes, writePosition, read);
-        writePosition += read;
+        write(toWrite, toWrite.available());
     }
 
     @Override
     public void write(BufferData toWrite, int length) {
         ensureSize(length);
-        byte[] buffer = new byte[length];
-        int read = toWrite.read(buffer);
-        System.arraycopy(buffer, 0, this.bytes, writePosition, read);
+        int read = readSource(toWrite, length);
         writePosition += read;
+        this.length = Math.max(this.length, writePosition);
     }
 
     @Override
@@ -240,8 +235,22 @@ class GrowingBufferData implements BufferData {
         return Arrays.copyOfRange(bytes, 0, length);
     }
 
+    private int readSource(BufferData source, int length) {
+        Class<?> sourceType = source.getClass();
+        if (sourceType == FixedBufferData.class
+                || sourceType == GrowingBufferData.class
+                || sourceType == ReadOnlyArrayData.class) {
+            return source.read(bytes, writePosition, length);
+        }
+
+        byte[] buffer = new byte[length];
+        int read = source.read(buffer);
+        System.arraycopy(buffer, 0, bytes, writePosition, read);
+        return read;
+    }
+
     private void ensureSize(int i) {
-        if (this.bytes.length > writePosition + i) {
+        if (this.bytes.length >= writePosition + i) {
             return;
         }
 

--- a/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/BufferDataTest.java
@@ -18,7 +18,10 @@ package io.helidon.common.buffers;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
 import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.hamcrest.Matchers;
@@ -35,6 +38,69 @@ class BufferDataTest {
         return Stream.of(new TestContext("fixed", BufferData.create(1024)),
                          new TestContext("growing", BufferData.growing(0)),
                          new TestContext("byte[]", BufferData.create(new byte[1024]).clear()));
+    }
+
+    @Test
+    void growingBufferWriteBufferSurvivesLaterGrowth() {
+        byte[] prefix = new byte[250];
+        byte[] payload = new byte[20];
+        byte[] suffix = new byte[300];
+        Arrays.fill(prefix, (byte) 1);
+        Arrays.fill(payload, (byte) 2);
+        Arrays.fill(suffix, (byte) 3);
+
+        BufferData buffer = BufferData.growing(256);
+        buffer.write(prefix);
+        buffer.write(BufferData.create(payload));
+        buffer.write(suffix);
+
+        assertThat(buffer.readBytes(), is(concat(prefix, payload, suffix)));
+    }
+
+    @Test
+    void growingBufferWritePartialBufferSurvivesLaterGrowth() {
+        byte[] prefix = new byte[250];
+        byte[] payload = new byte[20];
+        byte[] suffix = new byte[300];
+        Arrays.fill(prefix, (byte) 1);
+        Arrays.fill(payload, (byte) 2);
+        Arrays.fill(suffix, (byte) 3);
+        BufferData source = BufferData.create(payload);
+
+        BufferData buffer = BufferData.growing(256);
+        buffer.write(prefix);
+        buffer.write(source, 10);
+        buffer.write(suffix);
+
+        assertThat(buffer.readBytes(), is(concat(prefix, Arrays.copyOf(payload, 10), suffix)));
+        assertThat(source.available(), is(10));
+    }
+
+    @Test
+    void growingBufferWriteDoesNotExposeBackingArray() {
+        AtomicReference<byte[]> retained = new AtomicReference<>();
+        BufferData source = (BufferData) Proxy.newProxyInstance(BufferData.class.getClassLoader(),
+                                                                 new Class<?>[] {BufferData.class},
+                                                                 (_, method, arguments) -> {
+                                                                     return switch (method.getName()) {
+                                                                         case "available" -> 1;
+                                                                         case "read" -> {
+                                                                             byte[] target = (byte[]) arguments[0];
+                                                                             retained.set(target);
+                                                                             target[0] = 1;
+                                                                             yield 1;
+                                                                         }
+                                                                         default -> throw new IllegalStateException(method.toString());
+                                                                     };
+                                                                 });
+        BufferData buffer = BufferData.growing(256);
+
+        buffer.write(source);
+        byte[] retainedBytes = retained.get();
+        assertThat(retainedBytes, Matchers.notNullValue());
+        retainedBytes[0] = 2;
+
+        assertThat(buffer.read(), is(1));
     }
 
     @ParameterizedTest
@@ -471,6 +537,17 @@ class BufferDataTest {
     BufferData dataFromHex(String hexEncoded) {
         byte[] bytes = HexFormat.of().parseHex(hexEncoded.replace(" ", ""));
         return BufferData.create(bytes);
+    }
+
+    private static byte[] concat(byte[]... arrays) {
+        int length = Arrays.stream(arrays).mapToInt(array -> array.length).sum();
+        byte[] result = new byte[length];
+        int offset = 0;
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, result, offset, array.length);
+            offset += array.length;
+        }
+        return result;
     }
 
     private record TestContext(String name, BufferData bufferData) {

--- a/common/buffers/src/test/java/io/helidon/common/buffers/DataReaderTest.java
+++ b/common/buffers/src/test/java/io/helidon/common/buffers/DataReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package io.helidon.common.buffers;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class DataReaderTest {
+
+    @Test
+    void reusedNodeDoesNotInvalidateLazyString() {
+        Iterator<byte[]> chunks = List.of("first".getBytes(StandardCharsets.US_ASCII),
+                                          "second".getBytes(StandardCharsets.US_ASCII))
+                .iterator();
+        DataReader reader = DataReader.create(() -> chunks.hasNext() ? chunks.next() : null);
+
+        LazyString first = reader.readLazyString(StandardCharsets.US_ASCII, 5);
+        assertThat(reader.readAsciiString(6), is("second"));
+        assertThat(first.toString(), is("first"));
+    }
 
     @Test
     void testFindNewLineWithLoneCR() {

--- a/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
+++ b/common/uri/src/main/java/io/helidon/common/uri/UriPathNoParam.java
@@ -117,6 +117,10 @@ class UriPathNoParam implements UriPath {
 
          we use decoded and normalized path to match routing, so we need to resolve all of that
          */
+        if (isSimplePath(rawPath)) {
+            return rawPath;
+        }
+
         int percent = rawPath.indexOf('%');
         int dot = rawPath.indexOf(".");
         int doubleSlash = rawPath.indexOf("//");
@@ -140,4 +144,33 @@ class UriPathNoParam implements UriPath {
         String path = URI.create(rawPath).normalize().getPath();
         return path == null ? "" : path;
     }
+
+    private static boolean isSimplePath(String rawPath) {
+        int length = rawPath.length();
+        if (length == 0 || rawPath.charAt(0) != '/') {
+            return false;
+        }
+
+        boolean slash = true;
+        for (int i = 1; i < length; i++) {
+            char c = rawPath.charAt(i);
+            if (c == '/') {
+                if (slash) {
+                    return false;
+                }
+                slash = true;
+            } else if ((c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-'
+                    || c == '_'
+                    || c == '~') {
+                slash = false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
+++ b/common/uri/src/test/java/io/helidon/common/uri/UriPathTest.java
@@ -26,6 +26,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UriPathTest {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "/baseline11",
+            "/json/25",
+            "/async-db",
+            "/alpha_beta/~user"
+    })
+    void simplePathValidationPreservesPath(String rawPath) {
+        UriPath path = UriPath.create(rawPath);
+
+        path.validate();
+
+        assertThat(path.path(), is(rawPath));
+    }
+
     @Test
     void testEncodePercent() {
         // the path contains string %20, not a space!

--- a/tests/benchmark/jmh/pom.xml
+++ b/tests/benchmark/jmh/pom.xml
@@ -34,6 +34,14 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-buffers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-socket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-uri</artifactId>
         </dependency>
         <dependency>

--- a/tests/benchmark/jmh/src/main/java/io/helidon/common/benchmark/jmh/CommonWebServerHotPathJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/common/benchmark/jmh/CommonWebServerHotPathJmhBenchmark.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.benchmark.jmh;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.common.socket.NioSocket;
+import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.uri.UriPath;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.WritableHeaders;
+import io.helidon.webserver.http1.Http1Headers;
+import io.helidon.webserver.http1.Http1Prologue;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class CommonWebServerHotPathJmhBenchmark {
+    private static final String REQUEST_TEXT = "GET /json/25 HTTP/1.1\r\n"
+            + "Host: localhost:8080\r\n"
+            + "Accept: */*\r\n"
+            + "\r\n";
+    private static final byte[] REQUEST = REQUEST_TEXT.getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] PIPELINED_REQUESTS = REQUEST_TEXT.repeat(16).getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] RESPONSE_HEADERS = ("HTTP/1.1 200 OK\r\n"
+            + "Content-Type: text/plain\r\n"
+            + "Content-Length: 13\r\n"
+            + "\r\n").getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] RESPONSE_PAYLOAD = "Hello, World!".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] RESPONSE_PAYLOAD_1K = new byte[1024];
+
+    @Benchmark
+    public void dataReader(DataReaderState state, Blackhole blackhole) {
+        readRequest(state.prologue, state.headers, blackhole);
+    }
+
+    @Benchmark
+    public void dataReaderPipelined(DataReaderState state, Blackhole blackhole) {
+        readRequest(state.pipelinedPrologue, state.pipelinedHeaders, blackhole);
+    }
+
+    @Benchmark
+    public UriPath uriPathHelperAndNoParam(SimpleUriPathState state) {
+        UriPath path = UriPath.create(state.path);
+        path.path();
+        return path;
+    }
+
+    @Benchmark
+    public UriPath uriPathHelperAndNoParamValidated(SimpleUriPathState state) {
+        UriPath path = UriPath.create(state.path);
+        path.validate();
+        path.path();
+        return path;
+    }
+
+    @Benchmark
+    public UriPath uriPathHelperAndNoParamFallback(FallbackUriPathState state) {
+        UriPath path = UriPath.create(state.path);
+        path.path();
+        return path;
+    }
+
+    @Benchmark
+    public UriPath uriPathHelperAndNoParamFallbackValidated(FallbackUriPathState state) {
+        UriPath path = UriPath.create(state.path);
+        path.validate();
+        path.path();
+        return path;
+    }
+
+    @Benchmark
+    public BufferData growingBufferData(GrowingBufferState state) {
+        BufferData result = BufferData.growing(256 + RESPONSE_PAYLOAD.length);
+        result.write(RESPONSE_HEADERS);
+        result.write(state.payload);
+        state.payload.rewind();
+        return result;
+    }
+
+    @Benchmark
+    public int growingBufferDataReused(GrowingBufferState state) {
+        BufferData result = state.reusable.clear();
+        result.write(RESPONSE_HEADERS);
+        result.write(state.payload);
+        state.payload.rewind();
+        return result.available();
+    }
+
+    @Benchmark
+    public BufferData growingBufferData1K(GrowingBufferState state) {
+        BufferData result = BufferData.growing(256 + RESPONSE_PAYLOAD_1K.length);
+        result.write(RESPONSE_HEADERS);
+        result.write(state.payload1K);
+        state.payload1K.rewind();
+        return result;
+    }
+
+    @Benchmark
+    public int growingBufferDataReused1K(GrowingBufferState state) {
+        BufferData result = state.reusable1K.clear();
+        result.write(RESPONSE_HEADERS);
+        result.write(state.payload1K);
+        state.payload1K.rewind();
+        return result.available();
+    }
+
+    @Benchmark
+    public void socketWriterDirect(SocketState state) {
+        state.writer.write(state.buffer);
+        state.buffer.rewind();
+    }
+
+    @Benchmark
+    public void socketWriter(SocketState state) {
+        state.writer.writeNow(state.buffer);
+        state.buffer.rewind();
+    }
+
+    @Benchmark
+    public void nioSocket(SocketState state) {
+        state.socket.write(state.buffer);
+        state.buffer.rewind();
+    }
+
+    @Benchmark
+    public void nioSocketComposite(SocketState state) {
+        state.socket.write(state.compositeBuffer);
+        state.compositeBuffer.rewind();
+    }
+
+    @Benchmark
+    public byte[] nioSocketRead(SocketReadState state) {
+        try {
+            state.requestBuffer.rewind();
+            while (state.requestBuffer.hasRemaining()) {
+                state.writer.write(state.requestBuffer);
+            }
+            return state.socket.get();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void readRequest(Http1Prologue requestPrologue,
+                                    Http1Headers requestHeaders,
+                                    Blackhole blackhole) {
+        HttpPrologue prologue = requestPrologue.readPrologue();
+        WritableHeaders<?> headers = requestHeaders.readHeaders(prologue);
+        blackhole.consume(prologue);
+        blackhole.consume(headers.get(HeaderNames.HOST));
+    }
+
+    @State(Scope.Thread)
+    public static class DataReaderState {
+        private DataReader reader;
+        private Http1Headers headers;
+        private Http1Prologue prologue;
+        private Http1Headers pipelinedHeaders;
+        private Http1Prologue pipelinedPrologue;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            reader = DataReader.create(() -> REQUEST);
+            headers = new Http1Headers(reader, 4096, false);
+            prologue = new Http1Prologue(reader, 1024, false);
+            DataReader pipelinedReader = DataReader.create(() -> PIPELINED_REQUESTS);
+            pipelinedHeaders = new Http1Headers(pipelinedReader, 4096, false);
+            pipelinedPrologue = new Http1Prologue(pipelinedReader, 1024, false);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class GrowingBufferState {
+        private final BufferData payload = BufferData.create(RESPONSE_PAYLOAD);
+        private final BufferData payload1K = BufferData.create(RESPONSE_PAYLOAD_1K);
+        private final BufferData reusable = BufferData.growing(256 + RESPONSE_PAYLOAD.length);
+        private final BufferData reusable1K = BufferData.growing(256 + RESPONSE_PAYLOAD_1K.length);
+    }
+
+    @State(Scope.Thread)
+    public static class SimpleUriPathState {
+        @Param("/json/25")
+        private String path;
+    }
+
+    @State(Scope.Thread)
+    public static class FallbackUriPathState {
+        @Param({
+                "/static/index.html",
+                "/json/%32%35",
+                "/json//25"
+        })
+        private String path;
+    }
+
+    @State(Scope.Thread)
+    public static class SocketState {
+        private final BufferData buffer = BufferData.create(RESPONSE_HEADERS);
+        private final BufferData compositeBuffer = BufferData.create(BufferData.create(RESPONSE_HEADERS),
+                                                                     BufferData.create(RESPONSE_PAYLOAD));
+
+        private ServerSocketChannel listener;
+        private SocketChannel reader;
+        private NioSocket socket;
+        private SocketWriter writer;
+        private Thread drainThread;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            try {
+                listener = ServerSocketChannel.open();
+                listener.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+                reader = SocketChannel.open(listener.getLocalAddress());
+                socket = NioSocket.server(listener.accept(), "benchmark", "benchmark");
+                writer = SocketWriter.create(socket);
+                drainThread = Thread.ofPlatform()
+                        .daemon()
+                        .name("common-hot-path-jmh-drain")
+                        .start(this::drain);
+            } catch (IOException e) {
+                closeResources();
+                throw new UncheckedIOException(e);
+            } catch (RuntimeException e) {
+                closeResources();
+                throw e;
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws InterruptedException {
+            closeResources();
+            if (drainThread != null) {
+                drainThread.join();
+            }
+        }
+
+        private static void close(NioSocket socket) {
+            if (socket == null) {
+                return;
+            }
+            try {
+                socket.close();
+            } catch (RuntimeException _) {
+                // best effort after a benchmark trial
+            }
+        }
+
+        private static void close(AutoCloseable closeable) {
+            if (closeable == null) {
+                return;
+            }
+            try {
+                closeable.close();
+            } catch (Exception _) {
+                // best effort after a benchmark trial
+            }
+        }
+
+        private void drain() {
+            ByteBuffer drainBuffer = ByteBuffer.allocate(8 * 1024);
+            try {
+                while (reader.read(drainBuffer) >= 0) {
+                    drainBuffer.clear();
+                }
+            } catch (IOException e) {
+                if (reader.isOpen()) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+
+        private void closeResources() {
+            close(socket);
+            close(reader);
+            close(listener);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class SocketReadState {
+        private final ByteBuffer requestBuffer = ByteBuffer.wrap(REQUEST);
+
+        private ServerSocketChannel listener;
+        private SocketChannel writer;
+        private NioSocket socket;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            try {
+                listener = ServerSocketChannel.open();
+                listener.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+                writer = SocketChannel.open(listener.getLocalAddress());
+                socket = NioSocket.server(listener.accept(), "benchmark-read", "benchmark-read");
+            } catch (IOException e) {
+                closeResources();
+                throw new UncheckedIOException(e);
+            } catch (RuntimeException e) {
+                closeResources();
+                throw e;
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            closeResources();
+        }
+
+        private static void close(NioSocket socket) {
+            if (socket == null) {
+                return;
+            }
+            try {
+                socket.close();
+            } catch (RuntimeException _) {
+                // best effort after a benchmark trial
+            }
+        }
+
+        private static void close(AutoCloseable closeable) {
+            if (closeable == null) {
+                return;
+            }
+            try {
+                closeable.close();
+            } catch (Exception _) {
+                // best effort after a benchmark trial
+            }
+        }
+
+        private void closeResources() {
+            close(socket);
+            close(writer);
+            close(listener);
+        }
+    }
+}

--- a/tests/benchmark/jmh/src/test/java/io/helidon/common/benchmark/jmh/CommonWebServerHotPathJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/common/benchmark/jmh/CommonWebServerHotPathJmhRunnerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.benchmark.jmh;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+class CommonWebServerHotPathJmhRunnerTest {
+    @Test
+    void run() throws RunnerException {
+        String result = System.getProperty("common.hotpath.jmh.result", "./target/common-hot-path-jmh-result.json");
+        String method = System.getProperty("common.hotpath.jmh.method");
+        OptionsBuilder builder = new OptionsBuilder();
+        if (method == null) {
+            builder.include(exact("dataReader"))
+                    .include(exact("dataReaderPipelined"))
+                    .include(exact("growingBufferData"))
+                    .include(exact("growingBufferData1K"))
+                    .include(exact("growingBufferDataReused"))
+                    .include(exact("growingBufferDataReused1K"))
+                    .include(exact("nioSocket"))
+                    .include(exact("nioSocketComposite"))
+                    .include(exact("nioSocketRead"))
+                    .include(exact("socketWriter"))
+                    .include(exact("socketWriterDirect"))
+                    .include(exact("uriPathHelperAndNoParam"))
+                    .include(exact("uriPathHelperAndNoParamFallback"))
+                    .include(exact("uriPathHelperAndNoParamFallbackValidated"))
+                    .include(exact("uriPathHelperAndNoParamValidated"));
+        } else {
+            builder.include(exact(method));
+        }
+        Options options = builder
+                .forks(3)
+                .threads(1)
+                .resultFormat(ResultFormatType.JSON)
+                .result(result)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.milliseconds(500))
+                .measurementIterations(8)
+                .measurementTime(TimeValue.seconds(1))
+                .addProfiler(GCProfiler.class)
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(options).run();
+    }
+
+    private static String exact(String method) {
+        return "^" + Pattern.quote(CommonWebServerHotPathJmhBenchmark.class.getName() + "." + method) + "$";
+    }
+}


### PR DESCRIPTION
Resolves #12536

Reduces per-request allocation and CPU cost in common buffer and URI handling
used by WebServer. Reuses exhausted `DataReader` nodes, avoids temporary copies
for exact built-in array-backed `BufferData` implementations, and skips URI
normalization only for already canonical paths. Custom buffers and non-canonical
URI paths retain the existing fallback behavior.

Adds regression coverage for the changed behavior and targeted JMH benchmarks
for the five common classes used on every successful HttpArena request:
`DataReader`, `GrowingBufferData`, `UriPathHelper`, `UriPathNoParam`, and
`SocketWriterDirect`.

JMH highlights:

| Operation | Before | After | Allocation before | Allocation after |
| --- | ---: | ---: | ---: | ---: |
| `DataReader`, one supplied chunk | 133.6 ns | 77.4 ns | 688 B | 656 B |
| `GrowingBufferData`, reused 1 KiB write | 38.3 ns | 8.9 ns | 1040 B | approximately 0 B |
| Validated canonical URI path | 22.5 ns | 6.5 ns | 32 B | 32 B |

Balanced source-bound HttpArena comparison:

| HTTP/1.1 profile | Before RPS | After RPS | Throughput | Average latency | p99 latency |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline | 1,204,824 | 1,224,875 | +1.66% | -1.21% | +1.36% |
| Pipelined | 5,970,501 | 6,202,094 | +3.88% | -4.81% | -13.24% |

All eight A/B/B/A samples were accepted on their first attempt. The measured
tradeoffs are a 0.5 ns increase for a fresh 13-byte buffer write, a roughly 1.2
to 1.3 ns increase for duplicate-slash URI fallback, and the 1.36% baseline p99
increase shown above.
