### PR TITLE
Complete HTTP header and redirect follow-up (27.x)

### DIFF
--- a/docs/guides/webclient.md
+++ b/docs/guides/webclient.md
@@ -57,10 +57,12 @@ WebClient provides the following features:
 - **Following redirects**: The WebClient is able to follow the redirect chain
   and perform requests on the correct endpoint for you. You no longer have to
   point your client to the correct/final endpoint. On a cross-origin redirect,
-  WebClient strips the `Authorization` and `Cookie` headers by default. It also
-  rejects `307` and `308` redirects that would replay a request entity to
-  another origin. Set `follow-cross-origin-entity-redirects` to `true` only when
-  every possible redirect target is trusted.
+  WebClient strips `Authorization`, `Cookie`, `Proxy-Authorization`, and any
+  configured redirect-sensitive headers by default, then selects stored cookies
+  for the target URI. It also rejects redirects that would preserve and replay a
+  non-empty request entity (`307`, `308`, and `301` or `302` for QUERY) unless
+  `follow-cross-origin-entity-redirects` is enabled. Enable it only when every
+  possible redirect target is trusted.
 - **Tracing, metrics and security propagation**: When you configure the Helidon
   WebServer to use tracing, metrics and security, the settings are automatically
   propagated to the WebClient and used during request/response.

--- a/docs/modules/webclient.md
+++ b/docs/modules/webclient.md
@@ -141,10 +141,34 @@ var response = client.method(Method.QUERY)
         .submit(query);
 ```
 
-When redirects are enabled, WebClient preserves the QUERY method and its
-content for `301`, `302`, `307`, and `308` responses. A `303` response changes
-the redirected request to GET without the original query content, as required
-by [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html#section-2.5).
+When redirects are enabled, WebClient preserves the request method and entity
+for `307` and `308` responses, and for QUERY requests receiving a `301` or
+`302` response. Other followed redirects change the request method to GET and
+discard the entity; a `304` response is not treated as a redirect. In
+particular, a `303` response changes a QUERY request to GET without the
+original query content, as required by
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html#section-2.5).
+
+For a redirect that preserves the method and entity, WebClient copies only the
+`Accept`, `Accept-Charset`, `Accept-Encoding`, `Accept-Language`,
+`Content-Encoding`, `Content-Language`, `Content-Location`, and `Content-Type`
+headers from the preceding request. A redirect that changes the method does
+not copy request-specific headers. Each redirected request still starts with
+the client default headers, invokes the configured client services, and
+selects stored cookies for the target URI.
+
+Two URIs have the same origin when their schemes and hosts match
+case-insensitively and their ports are equal. WebClient follows a same-origin
+redirect that preserves a non-empty entity, but rejects such a redirect across
+origins by default. Set `follow-cross-origin-entity-redirects` to `true` only
+when every possible redirect target is trusted.
+
+With redirect header filtering enabled, a cross-origin redirect removes the
+configured redirect-sensitive headers, including `Authorization`, `Cookie`,
+and `Proxy-Authorization`. This filtering remains active for later hops after
+a redirect chain crosses an origin boundary. Disabling the filtering does not
+change which request-specific headers WebClient copies from the preceding
+request.
 
 ### Customizing the Request
 

--- a/http/http/src/main/java/io/helidon/http/Header.java
+++ b/http/http/src/main/java/io/helidon/http/Header.java
@@ -107,9 +107,15 @@ public interface Header extends Value<String> {
     boolean changing();
 
     /**
-     * Cached bytes of a single valued header's value.
+     * Bytes of a single-valued header value.
+     * <p>
+     * Each character in the value is mapped to the byte with the same numeric value using
+     * {@link java.nio.charset.StandardCharsets#ISO_8859_1}. Characters from {@code U+0080} through
+     * {@code U+00FF} therefore represent opaque HTTP field-value octets; they are not interpreted
+     * as UTF-8 or as ISO-8859-1 text.
      *
      * @return value bytes
+     * @throws IllegalArgumentException if the value contains a character above {@code U+00FF}
      */
     default byte[] valueBytes() {
         return encodeValue(get());
@@ -132,9 +138,13 @@ public interface Header extends Value<String> {
     }
 
     /**
-     * Check validity of header name and values.
+     * Check validity of the header name and values.
+     * <p>
+     * The name must be a non-empty HTTP token. Values may contain opaque octets represented by
+     * characters from {@code U+0080} through {@code U+00FF}; characters above {@code U+00FF}
+     * cannot be represented in an HTTP field value and are rejected.
      *
-     * @throws IllegalArgumentException in case the HeaderValue is not valid
+     * @throws IllegalArgumentException if the header name or a value is not valid
      */
     default void validate() throws IllegalArgumentException {
         String name = name();

--- a/http/http/src/main/java/io/helidon/http/HttpMediaType.java
+++ b/http/http/src/main/java/io/helidon/http/HttpMediaType.java
@@ -154,16 +154,18 @@ public sealed interface HttpMediaType extends Predicate<HttpMediaType>,
      * Create a new {@link HttpMediaType} instance with the same type, subtype and parameters
      * copied from the original instance and the supplied {@value #CHARSET_PARAMETER} parameter.
      *
-     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If {@code null} or empty
-     *                the {@value #CHARSET_PARAMETER} parameter will not be set or updated.
+     * @param charset the {@value #CHARSET_PARAMETER} parameter value. If empty the
+     *                {@value #CHARSET_PARAMETER} parameter will not be set or updated.
      * @return copy of the current {@code MediaType} instance with the {@value #CHARSET_PARAMETER}
      *         parameter set to the supplied value.
+     * @throws NullPointerException if {@code charset} is {@code null}
      */
     default HttpMediaType withCharset(String charset) {
+        Objects.requireNonNull(charset);
         Builder builder = builder()
                 .mediaType(mediaType())
                 .parameters(parameters());
-        if (charset != null && !charset.isEmpty()) {
+        if (!charset.isEmpty()) {
             builder.charset(charset);
         }
         return builder.build();

--- a/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
+++ b/http/http/src/test/java/io/helidon/http/HttpTokenTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HttpTokenTest {
@@ -45,7 +44,7 @@ class HttpTokenTest {
 
     private static void assertValid(String token) {
         assertThat(HttpToken.isValid(token), is(true));
-        assertDoesNotThrow(() -> HttpToken.validate(token));
+        HttpToken.validate(token);
     }
 
     private static void assertInvalid(String token) {

--- a/http/http/src/test/java/io/helidon/http/MediaTypeTest.java
+++ b/http/http/src/test/java/io/helidon/http/MediaTypeTest.java
@@ -68,13 +68,18 @@ class MediaTypeTest {
     }
 
     @Test
-    void nullOrEmptyCharsetDoesNotUpdateParameter() {
+    void nullCharsetIsRejected() {
+        HttpMediaType mediaType = HttpMediaType.create("text/plain");
+
+        assertThrows(NullPointerException.class, () -> mediaType.withCharset((String) null));
+    }
+
+    @Test
+    void emptyCharsetDoesNotUpdateParameter() {
         HttpMediaType withCharset = HttpMediaType.create("text/plain; charset=utf-8");
         HttpMediaType withoutCharset = HttpMediaType.create("text/plain");
 
-        assertThat(withCharset.withCharset((String) null).charset(), is(Optional.of("utf-8")));
         assertThat(withCharset.withCharset("").charset(), is(Optional.of("utf-8")));
-        assertThat(withoutCharset.withCharset((String) null).charset(), is(Optional.empty()));
         assertThat(withoutCharset.withCharset("").charset(), is(Optional.empty()));
     }
 

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -89,6 +89,9 @@ public class Http2Headers {
     private static final String HTTPS = "https";
     private static final String PATH_SLASH = "/";
     private static final String PATH_INDEX = "/index.html";
+    private static final int SHOULD_INDEX = 1;
+    private static final int NEVER_INDEX = 1 << 1;
+    private static final int VALIDATE_NAME = 1 << 2;
 
     private final Headers headers;
     private final PseudoHeaders pseudoHeaders;
@@ -464,95 +467,15 @@ public class Http2Headers {
      * @param growingBuffer buffer to write to
      */
     public void write(DynamicTable table, Http2HuffmanEncoder huffman, BufferData growingBuffer) {
-        // A rejected header block is not sent to the peer, so validate the complete block before changing the
-        // connection-scoped HPACK table.
-        validateEncoding();
-
-        // first write pseudoheaders
-        if (pseudoHeaders.hasStatus()) {
-            StaticHeader indexed = null;
-            Status status = pseudoHeaders.status();
-            if (status == Status.OK_200) {
-                indexed = StaticHeader.STATUS_200;
-            } else if (status == Status.NO_CONTENT_204) {
-                indexed = StaticHeader.STATUS_204;
-            } else if (status == Status.PARTIAL_CONTENT_206) {
-                indexed = StaticHeader.STATUS_206;
-            } else if (status == Status.NOT_MODIFIED_304) {
-                indexed = StaticHeader.STATUS_304;
-            } else if (status == Status.BAD_REQUEST_400) {
-                indexed = StaticHeader.STATUS_400;
-            } else if (status == Status.NOT_FOUND_404) {
-                indexed = StaticHeader.STATUS_404;
-            } else if (status == Status.INTERNAL_SERVER_ERROR_500) {
-                indexed = StaticHeader.STATUS_500;
-            }
-            if (indexed == null) {
-                writeHeader(huffman,
-                            table,
-                            growingBuffer,
-                            STATUS_NAME,
-                            status().codeText(),
-                            true,
-                            false);
-            } else {
-                writeHeader(growingBuffer, indexed);
-            }
-        }
-        if (pseudoHeaders.hasMethod()) {
-            Method method = pseudoHeaders.method();
-            StaticHeader indexed = null;
-            if (method == Method.GET) {
-                indexed = StaticHeader.METHOD_GET;
-            } else if (method == Method.POST) {
-                indexed = StaticHeader.METHOD_POST;
-            }
-            if (indexed == null) {
-                writeHeader(huffman, table, growingBuffer, METHOD_NAME, method.text(), true, false);
-            } else {
-                writeHeader(growingBuffer, indexed);
-            }
-        }
-        if (pseudoHeaders.hasScheme()) {
-            String scheme = pseudoHeaders.scheme();
-            if (scheme.equals(HTTP)) {
-                writeHeader(growingBuffer, StaticHeader.SCHEME_HTTP);
-            } else if (scheme.equals(HTTPS)) {
-                writeHeader(growingBuffer, StaticHeader.SCHEME_HTTPS);
-            } else {
-                writeHeader(huffman, table, growingBuffer, SCHEME_NAME, scheme, true, false);
-            }
-        }
-        if (pseudoHeaders.hasPath()) {
-            String path = pseudoHeaders.path();
-            if (path.equals(PATH_SLASH)) {
-                writeHeader(growingBuffer, StaticHeader.PATH_ROOT);
-            } else if (path.equals(PATH_INDEX)) {
-                writeHeader(growingBuffer, StaticHeader.PATH_INDEX);
-            } else {
-                writeHeader(huffman, table, growingBuffer, PATH_NAME, path, true, false);
-            }
-        }
-        if (pseudoHeaders.hasAuthority()) {
-            writeHeader(huffman, table, growingBuffer, AUTHORITY_NAME, pseudoHeaders.authority, true, false);
-        }
-
-        for (Header header : headers) {
-            HeaderName headerName = header.headerName();
-            boolean shouldIndex = !header.changing();
-            boolean neverIndex = header.sensitive();
-
-            // check count to call header.get() instead of header.allValues()
-            if (header.valueCount() == 1) {
-                writeHeader(huffman, table, growingBuffer, headerName, header.get(), shouldIndex, neverIndex);
-            } else if (headerName == HeaderNames.SET_COOKIE) {      // cannot combine, commas allowed
-                for (String value : header.allValues()) {
-                    writeHeader(huffman, table, growingBuffer, headerName, value, shouldIndex, neverIndex);
-                }
-            } else {
-                String value = header.values();         // send all combined values in single header
-                writeHeader(huffman, table, growingBuffer, headerName, value, shouldIndex, neverIndex);
-            }
+        int initialBufferSize = growingBuffer.available();
+        table.beginEncoding();
+        try {
+            writeHeaders(table, huffman, growingBuffer);
+            table.commitEncoding();
+        } catch (RuntimeException | Error e) {
+            table.rollbackEncoding();
+            growingBuffer.trim(growingBuffer.available() - initialBufferSize);
+            throw e;
         }
     }
 
@@ -929,15 +852,116 @@ public class Http2Headers {
         headers.remove(pseudoHeader, it -> valueConsumer.accept(it.get()));
     }
 
+    private void writeHeaders(DynamicTable table, Http2HuffmanEncoder huffman, BufferData growingBuffer) {
+        // first write pseudoheaders
+        if (pseudoHeaders.hasStatus()) {
+            StaticHeader indexed = null;
+            Status status = pseudoHeaders.status();
+            if (status == Status.OK_200) {
+                indexed = StaticHeader.STATUS_200;
+            } else if (status == Status.NO_CONTENT_204) {
+                indexed = StaticHeader.STATUS_204;
+            } else if (status == Status.PARTIAL_CONTENT_206) {
+                indexed = StaticHeader.STATUS_206;
+            } else if (status == Status.NOT_MODIFIED_304) {
+                indexed = StaticHeader.STATUS_304;
+            } else if (status == Status.BAD_REQUEST_400) {
+                indexed = StaticHeader.STATUS_400;
+            } else if (status == Status.NOT_FOUND_404) {
+                indexed = StaticHeader.STATUS_404;
+            } else if (status == Status.INTERNAL_SERVER_ERROR_500) {
+                indexed = StaticHeader.STATUS_500;
+            }
+            if (indexed == null) {
+                writeHeader(huffman,
+                            table,
+                            growingBuffer,
+                            STATUS_NAME,
+                            status().codeText(),
+                            SHOULD_INDEX);
+            } else {
+                writeHeader(growingBuffer, indexed);
+            }
+        }
+        if (pseudoHeaders.hasMethod()) {
+            Method method = pseudoHeaders.method();
+            StaticHeader indexed = null;
+            if (method == Method.GET) {
+                indexed = StaticHeader.METHOD_GET;
+            } else if (method == Method.POST) {
+                indexed = StaticHeader.METHOD_POST;
+            }
+            if (indexed == null) {
+                writeHeader(huffman, table, growingBuffer, METHOD_NAME, method.text(), SHOULD_INDEX);
+            } else {
+                writeHeader(growingBuffer, indexed);
+            }
+        }
+        if (pseudoHeaders.hasScheme()) {
+            String scheme = pseudoHeaders.scheme();
+            if (scheme.equals(HTTP)) {
+                writeHeader(growingBuffer, StaticHeader.SCHEME_HTTP);
+            } else if (scheme.equals(HTTPS)) {
+                writeHeader(growingBuffer, StaticHeader.SCHEME_HTTPS);
+            } else {
+                writeHeader(huffman, table, growingBuffer, SCHEME_NAME, scheme, SHOULD_INDEX);
+            }
+        }
+        if (pseudoHeaders.hasPath()) {
+            String path = pseudoHeaders.path();
+            if (path.equals(PATH_SLASH)) {
+                writeHeader(growingBuffer, StaticHeader.PATH_ROOT);
+            } else if (path.equals(PATH_INDEX)) {
+                writeHeader(growingBuffer, StaticHeader.PATH_INDEX);
+            } else {
+                writeHeader(huffman, table, growingBuffer, PATH_NAME, path, SHOULD_INDEX);
+            }
+        }
+        if (pseudoHeaders.hasAuthority()) {
+            writeHeader(huffman, table, growingBuffer, AUTHORITY_NAME, pseudoHeaders.authority, SHOULD_INDEX);
+        }
+
+        for (Header header : headers) {
+            HeaderName headerName = header.headerName();
+            int flags = VALIDATE_NAME;
+            if (!header.changing()) {
+                flags |= SHOULD_INDEX;
+            }
+            if (header.sensitive()) {
+                flags |= NEVER_INDEX;
+            }
+
+            // check count to call header.get() instead of header.allValues()
+            if (header.valueCount() == 1) {
+                writeHeader(huffman, table, growingBuffer, headerName, header.get(), flags);
+            } else if (headerName == HeaderNames.SET_COOKIE) {      // cannot combine, commas allowed
+                for (String value : header.allValues()) {
+                    writeHeader(huffman, table, growingBuffer, headerName, value, flags);
+                }
+            } else {
+                String value = header.values();         // send all combined values in single header
+                writeHeader(huffman, table, growingBuffer, headerName, value, flags);
+            }
+        }
+    }
+
     private void writeHeader(Http2HuffmanEncoder huffman, DynamicTable table,
                              BufferData buffer,
                              HeaderName name,
                              String value,
-                             boolean shouldIndex,
-                             boolean neverIndex) {
+                             int flags) {
         int index = table.findIndex(name, value);
         HeaderApproach approach;
 
+        if ((flags & VALIDATE_NAME) != 0 && index <= 0) {
+            String lowerCaseName = name.lowerCase();
+            if (name.index() < 0 || lowerCaseName.isEmpty() || lowerCaseName.charAt(0) == ':') {
+                HttpToken.validate(lowerCaseName);
+            }
+        }
+
+        boolean shouldIndex = (flags & SHOULD_INDEX) != 0;
+        boolean neverIndex = (flags & NEVER_INDEX) != 0;
         if (index == 0) {
             // neither name nor value exists in an index
             if (shouldIndex) {
@@ -957,37 +981,6 @@ public class Http2Headers {
         }
 
         approach.write(huffman, buffer, name, value);
-    }
-
-    private void validateEncoding() {
-        if (pseudoHeaders.hasStatus()) {
-            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.status().codeText());
-        }
-        if (pseudoHeaders.hasMethod()) {
-            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.method().text());
-        }
-        if (pseudoHeaders.hasScheme()) {
-            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.scheme());
-        }
-        if (pseudoHeaders.hasPath()) {
-            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.path());
-        }
-        if (pseudoHeaders.hasAuthority()) {
-            Http2HuffmanEncoder.validateLatin1(pseudoHeaders.authority());
-        }
-
-        for (Header header : headers) {
-            HeaderName headerName = header.headerName();
-            String lowerCaseName = headerName.lowerCase();
-            if (headerName.index() < 0 || lowerCaseName.isEmpty() || lowerCaseName.charAt(0) == ':') {
-                HttpToken.validate(lowerCaseName);
-            }
-            if (header.valueCount() == 1) {
-                Http2HuffmanEncoder.validateLatin1(header.get());
-            } else {
-                header.allValues().forEach(Http2HuffmanEncoder::validateLatin1);
-            }
-        }
     }
 
     private void writeHeader(BufferData buffer,
@@ -1341,7 +1334,7 @@ public class Http2Headers {
             if (hasName) {
                 String name = headerName.lowerCase();
                 if (name.length() > 3) {
-                    huffman.encodeValidated(buffer, name);
+                    huffman.encode(buffer, name);
                 } else {
                     byte[] nameBytes = name.getBytes(StandardCharsets.US_ASCII);
                     buffer.writeHpackInt(nameBytes.length, 0, 7);
@@ -1351,7 +1344,7 @@ public class Http2Headers {
             }
             if (writeValue) {
                 if (value.length() > 3) {
-                    huffman.encodeValidated(buffer, value);
+                    huffman.encode(buffer, value);
                 } else {
                     byte[] valueBytes = Http2HuffmanEncoder.encodeLatin1(value);
                     buffer.writeHpackInt(valueBytes.length, 0, 7);
@@ -1373,6 +1366,9 @@ public class Http2Headers {
         private volatile long protocolMaxTableSize;
         private long maxTableSize;
         private int currentTableSize;
+        private List<DynamicHeader> encodingSnapshot;
+        private int encodingSnapshotSize;
+        private boolean encoding;
 
         private DynamicTable(long protocolMaxTableSize) {
             this.protocolMaxTableSize = protocolMaxTableSize;
@@ -1425,6 +1421,7 @@ public class Http2Headers {
         }
 
         int add(HeaderName headerName, String headerValue) {
+            checkpointEncoding();
             String name = headerName.lowerCase();
             int size = name.length() + headerValue.length() + 32;
 
@@ -1457,6 +1454,35 @@ public class Http2Headers {
 
         int currentTableSize() {
             return currentTableSize;
+        }
+
+        private void beginEncoding() {
+            if (encoding) {
+                throw new IllegalStateException("An HPACK header block is already being encoded");
+            }
+            encoding = true;
+        }
+
+        private void commitEncoding() {
+            encoding = false;
+            encodingSnapshot = null;
+        }
+
+        private void rollbackEncoding() {
+            if (encodingSnapshot != null) {
+                headers.clear();
+                headers.addAll(encodingSnapshot);
+                currentTableSize = encodingSnapshotSize;
+            }
+            encoding = false;
+            encodingSnapshot = null;
+        }
+
+        private void checkpointEncoding() {
+            if (encoding && encodingSnapshot == null) {
+                encodingSnapshot = new ArrayList<>(headers);
+                encodingSnapshotSize = currentTableSize;
+            }
         }
 
         private int findIndex(HeaderName headerName, String headerValue) {

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -953,7 +953,7 @@ public class Http2Headers {
         int index = table.findIndex(name, value);
         HeaderApproach approach;
 
-        if ((flags & VALIDATE_NAME) != 0 && index <= 0) {
+        if ((flags & VALIDATE_NAME) != 0) {
             String lowerCaseName = name.lowerCase();
             if (name.index() < 0 || lowerCaseName.isEmpty() || lowerCaseName.charAt(0) == ':') {
                 HttpToken.validate(lowerCaseName);

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2Headers.java
@@ -964,23 +964,20 @@ public class Http2Headers {
         boolean neverIndex = (flags & NEVER_INDEX) != 0;
         if (index == 0) {
             // neither name nor value exists in an index
-            if (shouldIndex) {
-                table.add(name, value);
-            }
             approach = new HeaderApproach(shouldIndex, neverIndex, true, true, 0);
         } else if (index > 0) {
             // this is the exact same name and value
             approach = new HeaderApproach(false, neverIndex, false, false, index);
         } else {
             // same name
-            if (shouldIndex) {
-                table.add(name, value);
-            }
             // in both cases, we use index to record name
             approach = new HeaderApproach(shouldIndex, neverIndex, false, true, -index);
         }
 
         approach.write(huffman, buffer, name, value);
+        if (shouldIndex && index <= 0) {
+            table.add(name, value);
+        }
     }
 
     private void writeHeader(BufferData buffer,

--- a/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
+++ b/http/http2/src/main/java/io/helidon/http/http2/Http2HuffmanEncoder.java
@@ -16,8 +16,6 @@
 
 package io.helidon.http.http2;
 
-import java.nio.charset.StandardCharsets;
-
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.HuffmanCodec;
 
@@ -43,34 +41,18 @@ public class Http2HuffmanEncoder {
     }
 
     static byte[] encodeLatin1(String value) {
-        return value.getBytes(StandardCharsets.ISO_8859_1);
-    }
-
-    static void validateLatin1(String value) {
-        int length = value.length();
-        int i = 0;
-        for (; i + 3 < length; i += 4) {
-            int characters = value.charAt(i)
-                    | value.charAt(i + 1)
-                    | value.charAt(i + 2)
-                    | value.charAt(i + 3);
-            if ((characters & 0xff00) != 0) {
+        byte[] bytes = new byte[value.length()];
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (character > 0xff) {
                 throw new IllegalArgumentException("Header value contains a character above 0xff");
             }
+            bytes[i] = (byte) character;
         }
-        for (; i < length; i++) {
-            if (value.charAt(i) > 0xff) {
-                throw new IllegalArgumentException("Header value contains a character above 0xff");
-            }
-        }
+        return bytes;
     }
 
     void encode(BufferData buffer, String string) {
-        validateLatin1(string);
-        encodeValidated(buffer, string);
-    }
-
-    void encodeValidated(BufferData buffer, String string) {
         byte[] bytes = new byte[string.length()];
         int encodedLength = HuffmanCodec.encode(string, bytes);
         if (encodedLength == -1) {

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -213,6 +213,28 @@ class Http2HeadersTest {
         assertThat(buffer.available(), is(0));
     }
 
+    @Test
+    void testRejectsNonLatin1ValueWhenHeaderNameIsIndexed() {
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        Http2HuffmanEncoder encoder = Http2HuffmanEncoder.create();
+        Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "valid"))
+                .status(Status.OK_200)
+                .write(dynamicTable, encoder, BufferData.growing(32));
+        int tableSize = dynamicTable.currentTableSize();
+        HeaderRecord indexedHeader = dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1);
+
+        BufferData rejectedBlock = BufferData.growing(32).write(42);
+        Http2Headers rejected = Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "\u0100"))
+                .status(Status.OK_200);
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> rejected.write(dynamicTable, encoder, rejectedBlock));
+        assertThat(dynamicTable.currentTableSize(), is(tableSize));
+        assertThat(dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1), is(indexedHeader));
+        assertThat(rejectedBlock.available(), is(1));
+        assertThat(rejectedBlock.get(0), is(42));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"custom-\u0080", ":custom", ":bad\u0100"})
     void testRejectsInvalidHeaderNameBeforeWritingOrIndexing(String invalidName) {

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -17,7 +17,9 @@
 package io.helidon.http.http2;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HexFormat;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.http.HeaderName;
@@ -35,6 +37,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -233,6 +236,32 @@ class Http2HeadersTest {
         assertThat(dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1), is(indexedHeader));
         assertThat(rejectedBlock.available(), is(1));
         assertThat(rejectedBlock.get(0), is(42));
+    }
+
+    @Test
+    void testRejectsNonLatin1ValueBeforeOversizedIndexing() throws InterruptedException {
+        DynamicTable dynamicTable = DynamicTable.create(1);
+        BufferData rejectedBlock = BufferData.growing(32);
+        Http2Headers rejected = Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "a\u0100"))
+                .status(Status.OK_200);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread encoder = Thread.ofVirtual().start(() -> {
+            try {
+                rejected.write(dynamicTable, Http2HuffmanEncoder.create(), rejectedBlock);
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        boolean completed = encoder.join(Duration.ofSeconds(1));
+        if (!completed) {
+            encoder.interrupt();
+        }
+
+        assertThat("Header encoding did not complete", completed, is(true));
+        assertThat(failure.get(), instanceOf(IllegalArgumentException.class));
+        assertThat(dynamicTable.currentTableSize(), is(0));
+        assertThat(rejectedBlock.available(), is(0));
     }
 
     @ParameterizedTest

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -217,25 +217,39 @@ class Http2HeadersTest {
     }
 
     @Test
-    void testRejectsNonLatin1ValueWhenHeaderNameIsIndexed() {
-        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+    void testRejectsNonLatin1ValueAfterPopulatedTableMutation() {
+        DynamicTable outboundTable = DynamicTable.create(Http2Settings.create());
+        DynamicTable inboundTable = DynamicTable.create(Http2Settings.create());
         Http2HuffmanEncoder encoder = Http2HuffmanEncoder.create();
+        BufferData initialBlock = BufferData.growing(32);
         Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "valid"))
                 .status(Status.OK_200)
-                .write(dynamicTable, encoder, BufferData.growing(32));
-        int tableSize = dynamicTable.currentTableSize();
-        HeaderRecord indexedHeader = dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1);
+                .write(outboundTable, encoder, initialBlock);
+        headers(HexFormat.of().formatHex(initialBlock.readBytes()), inboundTable);
+        int tableSize = outboundTable.currentTableSize();
+        HeaderRecord indexedHeader = outboundTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1);
 
         BufferData rejectedBlock = BufferData.growing(32).write(42);
-        Http2Headers rejected = Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "\u0100"))
+        Http2Headers rejected = Http2Headers.create(WritableHeaders.create()
+                                                             .add(HeaderNames.CONTENT_TYPE, "text/plain")
+                                                             .add(CUSTOM_HEADER_NAME, "\u0100"))
                 .status(Status.OK_200);
 
         assertThrows(IllegalArgumentException.class,
-                     () -> rejected.write(dynamicTable, encoder, rejectedBlock));
-        assertThat(dynamicTable.currentTableSize(), is(tableSize));
-        assertThat(dynamicTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1), is(indexedHeader));
+                     () -> rejected.write(outboundTable, encoder, rejectedBlock));
+        assertThat(outboundTable.currentTableSize(), is(tableSize));
+        assertThat(outboundTable.get(Http2Headers.StaticHeader.MAX_INDEX + 1), is(indexedHeader));
         assertThat(rejectedBlock.available(), is(1));
         assertThat(rejectedBlock.get(0), is(42));
+
+        BufferData nextBlock = BufferData.growing(32);
+        Http2Headers.create(WritableHeaders.create().add(CUSTOM_HEADER_NAME, "valid"))
+                .status(Status.OK_200)
+                .write(outboundTable, encoder, nextBlock);
+        Headers decoded = headers(HexFormat.of().formatHex(nextBlock.readBytes()), inboundTable).httpHeaders();
+
+        assertThat(decoded.get(CUSTOM_HEADER_NAME).get(), is("valid"));
+        assertThat(inboundTable.currentTableSize(), is(tableSize));
     }
 
     @Test

--- a/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
+++ b/http/http2/src/test/java/io/helidon/http/http2/Http2HeadersTest.java
@@ -283,6 +283,24 @@ class Http2HeadersTest {
     }
 
     @Test
+    void testRejectsPseudoHeaderAddedAfterCreation() {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        Http2Headers http2Headers = Http2Headers.create(headers)
+                .method(Method.GET)
+                .scheme("https")
+                .path("/")
+                .authority("example.com");
+        headers.add(Http2Headers.METHOD_NAME, Method.GET.text());
+        DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
+        BufferData buffer = BufferData.growing(32);
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> http2Headers.write(dynamicTable, Http2HuffmanEncoder.create(), buffer));
+        assertThat(dynamicTable.currentTableSize(), is(0));
+        assertThat(buffer.available(), is(0));
+    }
+
+    @Test
     void testFailedHeaderEncodingDoesNotPoisonNextHeaderBlock() {
         DynamicTable outboundTable = DynamicTable.create(Http2Settings.create());
         Http2HuffmanEncoder encoder = Http2HuffmanEncoder.create();

--- a/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
@@ -118,8 +118,18 @@ public class HttpCodecJmhBenchmark {
     }
 
     @Benchmark
+    public int writeHpackEmptyTableInsertControl(EmptyTableInsertionState state) {
+        return state.table.currentTableSize() + state.buffer.available();
+    }
+
+    @Benchmark
     public int writeHpackPopulatedTableInsert(PopulatedTableInsertionState state) {
         return state.write();
+    }
+
+    @Benchmark
+    public int writeHpackPopulatedTableInsertControl(PopulatedTableInsertionState state) {
+        return state.table.currentTableSize() + state.buffer.available();
     }
 
     private static Http2Headers requestHeaders(String value) {

--- a/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
+++ b/tests/benchmark/jmh/src/main/java/io/helidon/http/http2/HttpCodecJmhBenchmark.java
@@ -27,13 +27,16 @@ import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 public class HttpCodecJmhBenchmark {
     private static final String SIMPLE_CONTENT_TYPE = "application/json";
     private static final String QUOTED_CONTENT_TYPE = "text/plain; profile=\"a\u0080\u00ff\"";
     private static final String ASCII_VALUE = "0123456789";
+    private static final String OTHER_ASCII_VALUE = "abcdefghij";
     private static final String LATIN1_VALUE = "\u008012345678\u00ff";
     private static final HeaderName CUSTOM_HEADER_NAME = HeaderNames.create("x-jmh-custom-header");
     private static final HeaderName MULTI_VALUE_HEADER_NAME = HeaderNames.create("x-jmh-multi-value");
@@ -109,6 +112,16 @@ public class HttpCodecJmhBenchmark {
         return state.responseLatin1.write();
     }
 
+    @Benchmark
+    public int writeHpackEmptyTableInsert(EmptyTableInsertionState state) {
+        return state.write();
+    }
+
+    @Benchmark
+    public int writeHpackPopulatedTableInsert(PopulatedTableInsertionState state) {
+        return state.write();
+    }
+
     private static Http2Headers requestHeaders(String value) {
         return Http2Headers.create(headers(value))
                 .method(CUSTOM_METHOD)
@@ -131,6 +144,16 @@ public class HttpCodecJmhBenchmark {
         return headers;
     }
 
+    private static Http2Headers indexedHeaders(String value) {
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderValues.create(CUSTOM_HEADER_NAME, value));
+        return Http2Headers.create(headers)
+                .method(Method.GET)
+                .scheme("https")
+                .path("/")
+                .authority("example.com");
+    }
+
     @State(Scope.Thread)
     public static class EncodingState {
         private final Header asciiHeader = HeaderValues.create("X-JMH", ASCII_VALUE);
@@ -142,6 +165,47 @@ public class HttpCodecJmhBenchmark {
         private final HeaderBlockState requestLatin1 = new HeaderBlockState(requestHeaders(LATIN1_VALUE));
         private final HeaderBlockState responseAscii = new HeaderBlockState(responseHeaders(ASCII_VALUE));
         private final HeaderBlockState responseLatin1 = new HeaderBlockState(responseHeaders(LATIN1_VALUE));
+    }
+
+    @State(Scope.Thread)
+    public static class EmptyTableInsertionState {
+        private final Http2Headers headers = indexedHeaders(ASCII_VALUE);
+        private final Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+        private final BufferData buffer = BufferData.growing(64);
+        private Http2Headers.DynamicTable table;
+
+        @Setup(Level.Invocation)
+        public void setup() {
+            table = Http2Headers.DynamicTable.create(Http2Settings.create());
+            buffer.clear();
+        }
+
+        private int write() {
+            headers.write(table, huffman, buffer);
+            return buffer.available();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class PopulatedTableInsertionState {
+        private final Http2Headers existingHeaders = indexedHeaders(ASCII_VALUE);
+        private final Http2Headers newHeaders = indexedHeaders(OTHER_ASCII_VALUE);
+        private final Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+        private final BufferData buffer = BufferData.growing(64);
+        private Http2Headers.DynamicTable table;
+
+        @Setup(Level.Invocation)
+        public void setup() {
+            table = Http2Headers.DynamicTable.create(Http2Settings.create());
+            buffer.clear();
+            existingHeaders.write(table, huffman, buffer);
+            buffer.clear();
+        }
+
+        private int write() {
+            newHeaders.write(table, huffman, buffer);
+            return buffer.available();
+        }
     }
 
     private static class HeaderBlockState {

--- a/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
@@ -37,7 +37,8 @@ class HttpCodecJmhRunnerTest {
             "(parseSimpleContentType|parseQuotedContentType|serializeSimpleContentType|serializeQuotedContentType|"
                     + "writeHttp1Ascii|writeHttp1Latin1|"
                     + "encodeHpackAscii|encodeHpackLatin1|writeHpackRequestAscii|writeHpackRequestLatin1|"
-                    + "writeHpackResponseAscii|writeHpackResponseLatin1)";
+                    + "writeHpackResponseAscii|writeHpackResponseLatin1|"
+                    + "writeHpackEmptyTableInsert|writeHpackPopulatedTableInsert)";
 
     @Test
     void runExactBenchmarks() throws RunnerException {

--- a/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
+++ b/tests/benchmark/jmh/src/test/java/io/helidon/http/benchmark/jmh/HttpCodecJmhRunnerTest.java
@@ -38,7 +38,8 @@ class HttpCodecJmhRunnerTest {
                     + "writeHttp1Ascii|writeHttp1Latin1|"
                     + "encodeHpackAscii|encodeHpackLatin1|writeHpackRequestAscii|writeHpackRequestLatin1|"
                     + "writeHpackResponseAscii|writeHpackResponseLatin1|"
-                    + "writeHpackEmptyTableInsert|writeHpackPopulatedTableInsert)";
+                    + "writeHpackEmptyTableInsert|writeHpackEmptyTableInsertControl|"
+                    + "writeHpackPopulatedTableInsert|writeHpackPopulatedTableInsertControl)";
 
     @Test
     void runExactBenchmarks() throws RunnerException {


### PR DESCRIPTION
Addresses #12533

Rejects null charset updates and clarifies the HTTP header octet and WebClient
redirect contracts.

Reduces repeated HPACK field validation by rolling back partial encodings and
dynamic-table updates when encoding fails, while preserving the header-name
validation introduced by #12505.
