### PR TITLE
Upgrade ASM to 9.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         Changing these version requires approval for a new third party dependency!
         -->
-        <version.lib.asm>9.9.1</version.lib.asm>
+        <version.lib.asm>9.10.1</version.lib.asm>
         <version.lib.checkstyle>14.1.0</version.lib.checkstyle>
         <!-- Dependencies convergence via jinjava -->
         <version.lib.mockito>2.23.4</version.lib.mockito>


### PR DESCRIPTION
Related to #11323

Upgrade ASM to 9.10.1 so Maven compiler, Javadoc, Surefire, and plugin tooling can process Java 27 class files.

This prepares the build for the Java 27 upgrade.
