### PR TITLE
27.x: Force upgrade kotlin to 2.4.20

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -75,6 +75,8 @@
         <!-- Jetbrains annotations: dependency convergence requirement, we never use this directly -->
         <version.lib.jetbrains.annotations>17.0.0</version.lib.jetbrains.annotations>
         <version.lib.junit>5.12.2</version.lib.junit>
+        <!-- Force upgrade. Kotlin used by grpc-okhttp -->
+        <version.lib.kotlin>2.4.20</version.lib.kotlin>
         <version.lib.log4j>2.25.5</version.lib.log4j>
         <version.lib.micrometer>1.17.1</version.lib.micrometer>
         <version.lib.micrometer-prometheus>1.17.1</version.lib.micrometer-prometheus>
@@ -453,6 +455,14 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <version>${version.lib.google-protobuf}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Force upgrade. Used by grpc-okhttp via helidon-tracing-providers-opentelemetry -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${version.lib.kotlin}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tracing/providers/opentelemetry/pom.xml
+++ b/tracing/providers/opentelemetry/pom.xml
@@ -95,6 +95,13 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-okhttp</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Legacy. Replaced by kotlin-stdlib -->
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
### Description

Force upgrade kotlin to 2.4.20.

Kotlin is pulled in by `grpc-okhttp` 
Which is needed by `opentelemetry-exporter-sender-grpc-managed-channel` 
Which is a grpc exporter used by `helidon-tracing-providers-opentelemetry`
