### PR TITLE
Log expected WebServer connection termination at trace (4.x)

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -232,6 +232,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     public void handle(Limit limit) throws InterruptedException {
         try {
             doHandle(limit);
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            throw new CloseConnectionException("Connection closed by client", e);
         } catch (Http2Exception e) {
             if (state == State.FINISHED) {
                 // already handled

--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2ServerStream.java
@@ -249,7 +249,7 @@ class Http2ServerStream implements Runnable, Http2Stream {
                 writer.write(frame.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
                 connectionAttackVectorMetrics.madeYouResetCheck();
             }
-        } catch (UncheckedIOException e) {
+        } catch (SocketWriterException | UncheckedIOException e) {
             throw new ServerConnectionException("Failed to write window update", e);
         }
     }
@@ -597,7 +597,11 @@ class Http2ServerStream implements Runnable, Http2Stream {
         }
         streams.remove(this.streamId);
         Http2RstStream rst = new Http2RstStream(Http2ErrorCode.PROTOCOL);
-        writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        try {
+            writer.write(rst.toFrameData(clientSettings, streamId, Http2Flag.NoFlags.create()));
+        } catch (SocketWriterException | UncheckedIOException e) {
+            throw new ServerConnectionException("Failed to write reset stream", e);
+        }
         connectionAttackVectorMetrics.madeYouResetCheck();
 
         if (currentFrameLength > 0) {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -22,6 +22,7 @@ import java.net.SocketException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -95,6 +96,23 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class Http2ConnectionTest {
+
+    @Test
+    void peerCloseWhileReadingPrefaceClosesConnection() {
+        byte[] preface = Http2Util.prefaceData().readBytes();
+        Queue<byte[]> input = new ConcurrentLinkedQueue<>();
+        input.add(Arrays.copyOf(preface, preface.length - 1));
+        DataWriter writer = mock(DataWriter.class);
+        Http2Connection connection = new Http2Connection(http2Context(writer, DataReader.create(input::poll)),
+                                                         Http2Config.create(),
+                                                         List.of());
+        connection.expectPreface();
+
+        CloseConnectionException exception = assertThrows(CloseConnectionException.class,
+                                                          () -> connection.handle(FixedLimit.create()));
+
+        assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+    }
 
     @Test
     void h2cUpgradeRespectsConcurrentStreamLimit() throws InterruptedException {

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ServerStreamTest.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
+import io.helidon.common.socket.SocketWriterException;
+import io.helidon.http.HeaderNames;
 import io.helidon.http.Method;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.ConnectionFlowControl;
@@ -39,6 +41,7 @@ import io.helidon.http.http2.Http2StreamWriter;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.Router;
+import io.helidon.webserver.ServerConnectionException;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http2.spi.Http2SubProtocolSelector;
 
@@ -47,6 +50,10 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -155,7 +162,40 @@ class Http2ServerStreamTest {
         assertThat(flowControl.getRemainingWindowSize(), is(initialWindowSize));
     }
 
+    @Test
+    void invalidContentLengthResetWrapsSocketWriterException() {
+        SocketWriterException writeFailure = new SocketWriterException();
+        Http2ServerStream stream = stream(new ClosingHandler(), failingWriter(writeFailure));
+        WritableHeaders<?> headers = WritableHeaders.create();
+        headers.add(HeaderNames.CONTENT_LENGTH, 2);
+        stream.headers(Http2Headers.create(headers), false);
+        BufferData payload = BufferData.create("frank");
+        Http2FrameHeader header = dataHeader(payload.available(), Http2Flag.END_OF_STREAM);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> stream.data(header, payload, true));
+
+        assertThat(exception.getCause(), sameInstance(writeFailure));
+    }
+
+    @Test
+    void invalidWindowUpdateResetWrapsSocketWriterException() {
+        SocketWriterException writeFailure = new SocketWriterException();
+        Http2ServerStream stream = stream(new ClosingHandler(), failingWriter(writeFailure));
+        stream.headers(headers(), false);
+
+        ServerConnectionException exception = assertThrows(ServerConnectionException.class,
+                                                           () -> stream.windowUpdate(new Http2WindowUpdate(0)));
+
+        assertThat(exception.getCause(), sameInstance(writeFailure));
+    }
+
     private static Http2ServerStream stream(Http2SubProtocolSelector.SubProtocolHandler handler) {
+        return stream(handler, noOpWriter());
+    }
+
+    private static Http2ServerStream stream(Http2SubProtocolSelector.SubProtocolHandler handler,
+                                            Http2StreamWriter writer) {
         ConnectionContext ctx = mock(ConnectionContext.class);
         when(ctx.router()).thenReturn(Router.empty());
         when(ctx.socketId()).thenReturn("socket");
@@ -180,7 +220,7 @@ class Http2ServerStreamTest {
                                      STREAM_ID,
                                      Http2Settings.create(),
                                      Http2Settings.create(),
-                                     noOpWriter(),
+                                     writer,
                                      flowControl,
                                      mock(Http2ConnectionChecks.class));
     }
@@ -239,6 +279,12 @@ class Http2ServerStreamTest {
                 return 0;
             }
         };
+    }
+
+    private static Http2StreamWriter failingWriter(RuntimeException failure) {
+        Http2StreamWriter writer = mock(Http2StreamWriter.class);
+        doThrow(failure).when(writer).write(any(Http2FrameData.class));
+        return writer;
     }
 
     private static class ClosingHandler implements Http2SubProtocolSelector.SubProtocolHandler {

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConnectionIdentificationTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConnectionIdentificationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.net.Socket;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2Util;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ServerTest
+class ConnectionIdentificationTest {
+    private static final Logger CONNECTION_HANDLER_LOGGER = Logger.getLogger("io.helidon.webserver.ConnectionHandler");
+
+    static {
+        LogConfig.configureRuntime();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.get("/", (req, res) -> res.send());
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.addProtocol(Http2Config.builder().build());
+    }
+
+    @Test
+    void peerCloseDuringConnectionIdentificationIsTrace(WebServer server) throws Exception {
+        try (TestLogHandler logHandler = new TestLogHandler(CONNECTION_HANDLER_LOGGER);
+             Socket socket = new Socket("127.0.0.1", server.port())) {
+            byte[] preface = Http2Util.prefaceData().readBytes();
+            socket.getOutputStream().write(preface, 0, preface.length - 1);
+            socket.shutdownOutput();
+
+            LogRecord record = logHandler.await(Duration.ofSeconds(5));
+            assertThat("Connection failure was not logged", record, is(notNullValue()));
+            assertThat(record.getLevel(), is(Level.FINER));
+            assertThat(record.getMessage(), not(containsString("unexpected exception")));
+        }
+    }
+
+    @Test
+    void exactHttp2PrefaceIdentifiesConnection(WebServer server) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write(Http2Util.prefaceData().readBytes());
+            socket.getOutputStream().flush();
+
+            byte[] frameHeaderBytes = socket.getInputStream().readNBytes(Http2FrameHeader.LENGTH);
+            assertThat(frameHeaderBytes.length, is(Http2FrameHeader.LENGTH));
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(frameHeaderBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.SETTINGS));
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level originalLevel;
+        private final boolean originalUseParentHandlers;
+        private final CountDownLatch recordReceived = new CountDownLatch(1);
+        private volatile LogRecord record;
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.originalLevel = logger.getLevel();
+            this.originalUseParentHandlers = logger.getUseParentHandlers();
+            setLevel(Level.ALL);
+            logger.addHandler(this);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getThrown() instanceof DataReader.InsufficientDataAvailableException) {
+                this.record = record;
+                recordReceived.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(originalLevel);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+        }
+
+        private LogRecord await(Duration timeout) throws InterruptedException {
+            return recordReceived.await(timeout.toMillis(), TimeUnit.MILLISECONDS) ? record : null;
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -44,6 +44,7 @@ import io.helidon.common.socket.NioSocket;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.PlainSocket;
 import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.socket.TlsNioSocket;
 import io.helidon.common.socket.TlsSocket;
 import io.helidon.common.task.InterruptableTask;
@@ -199,6 +200,12 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         } catch (CloseConnectionException e) {
             // end of request stream - safe to close the connection, as it was requested by our client
             helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
+        } catch (DataReader.InsufficientDataAvailableException | SocketWriterException e) {
+            // the connection ended while reading or writing data
+            helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            helidonSocket.log(LOGGER, TRACE, "connection interrupted", e);
         } catch (UncheckedIOException e) {
             if (e.getCause() instanceof SocketException) {
                 // socket exception - the socket failed, probably killed by OS, proxy or client
@@ -369,7 +376,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                 int expectedBytes = candidate.bytesToIdentifyConnection();
 
                 ServerConnectionSelector.Support supports;
-                if (expectedBytes == 0 || expectedBytes < currentBuffer.available()) {
+                if (expectedBytes == 0 || expectedBytes <= currentBuffer.available()) {
                     supports = candidate.supports(currentBuffer);
                 } else {
                     // we need more data, let's keep this provider for now

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -281,6 +281,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                     throw tooManyConcurrentRequests();
                 }
             }
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            throw new CloseConnectionException("Connection closed by client", e);
         } catch (CloseConnectionException e) {
             throw e;
         } catch (BadRequestException e) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,37 @@
  */
 package io.helidon.webserver;
 
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
+import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.concurrency.limits.FixedLimit;
+import io.helidon.common.concurrency.limits.Limit;
+import io.helidon.common.socket.SocketWriterException;
+import io.helidon.common.tls.Tls;
+import io.helidon.webserver.spi.ServerConnection;
+import io.helidon.webserver.spi.ServerConnectionSelector;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ConnectionHandlerTest {
 
@@ -30,5 +53,139 @@ class ConnectionHandlerTest {
     void testHttp10Prologue() {
         DataReader reader = DataReader.create(() -> "GET / HTTP/1.0\r\n".getBytes(StandardCharsets.US_ASCII));
         assertThat(ConnectionHandler.isHttp10Connection(reader), is(true));
+    }
+
+    @Test
+    void socketWriterFailureIsTrace() throws Exception {
+        assertConnectionFailureLevel(new SocketWriterException(), Level.FINER);
+    }
+
+    @Test
+    void connectionInterruptionIsTrace() throws Exception {
+        assertConnectionFailureLevel(new InterruptedException("test interruption"), Level.FINER);
+    }
+
+    @Test
+    void unexpectedConnectionFailureRemainsWarning() throws Exception {
+        assertConnectionFailureLevel(new IllegalStateException("unexpected"), Level.WARNING);
+    }
+
+    private static void assertConnectionFailureLevel(Exception failure, Level expectedLevel) throws Exception {
+        ListenerConfig listenerConfig = mock(ListenerConfig.class);
+        when(listenerConfig.useNio()).thenReturn(true);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(listenerConfig);
+        SocketChannel socket = mock(SocketChannel.class);
+        when(socket.getRemoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 12345));
+        when(socket.getLocalAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 80));
+        Tls tls = mock(Tls.class);
+        ConnectionProviders connectionProviders =
+                ConnectionProviders.create(List.of(new TestConnectionSelector(failure)));
+        ConnectionHandler handler = new ConnectionHandler(listenerContext,
+                                                          new Semaphore(1),
+                                                          FixedLimit.create(),
+                                                          connectionProviders,
+                                                          new HashMap<>(),
+                                                          socket,
+                                                          "server",
+                                                          Router.empty(),
+                                                          tls);
+
+        try (TestLogHandler logHandler = TestLogHandler.install(failure)) {
+            Thread thread = Thread.ofVirtual().start(handler::run);
+            LogRecord record = logHandler.await();
+            thread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(thread.isAlive(), is(false));
+            assertThat(record.getThrown(), sameInstance(failure));
+            assertThat(record.getLevel(), is(expectedLevel));
+        }
+    }
+
+    private record TestConnectionSelector(Exception failure) implements ServerConnectionSelector {
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of();
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            return new ServerConnection() {
+                @Override
+                public void handle(Limit limit) throws InterruptedException {
+                    if (failure instanceof RuntimeException runtimeException) {
+                        throw runtimeException;
+                    }
+                    throw (InterruptedException) failure;
+                }
+
+                @Override
+                public Duration idleTime() {
+                    return Duration.ZERO;
+                }
+
+                @Override
+                public void close(boolean interrupt) {
+                }
+            };
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Throwable failure;
+        private final Level originalLevel;
+        private final boolean originalUseParentHandlers;
+        private final CountDownLatch recordReceived = new CountDownLatch(1);
+        private volatile LogRecord record;
+
+        private TestLogHandler(Logger logger, Throwable failure) {
+            this.logger = logger;
+            this.failure = failure;
+            this.originalLevel = logger.getLevel();
+            this.originalUseParentHandlers = logger.getUseParentHandlers();
+            setLevel(Level.ALL);
+            logger.addHandler(this);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+        }
+
+        static TestLogHandler install(Throwable failure) {
+            return new TestLogHandler(Logger.getLogger(ConnectionHandler.class.getName()), failure);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getThrown() == failure) {
+                this.record = record;
+                recordReceived.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(originalLevel);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+        }
+
+        private LogRecord await() throws InterruptedException {
+            assertThat(recordReceived.await(5, TimeUnit.SECONDS), is(true));
+            return record;
+        }
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
@@ -35,6 +36,7 @@ import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.SocketWriter;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.http.encoding.ContentEncodingContext;
+import io.helidon.webserver.CloseConnectionException;
 import io.helidon.webserver.ConnectionContext;
 import io.helidon.webserver.ListenerContext;
 import io.helidon.webserver.Router;
@@ -112,6 +114,20 @@ class Http1ConnectionTest {
             writer.releaseFlush.countDown();
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    void peerCloseWhileReadingHeadersClosesConnection() {
+        AtomicReference<byte[]> input =
+                new AtomicReference<>("GET / HTTP/1.1\r\nHost:".getBytes(StandardCharsets.UTF_8));
+        Http1Connection connection = createConnection(mock(DataWriter.class),
+                                                      DataReader.create(() -> input.getAndSet(null)),
+                                                      Router.empty());
+
+        CloseConnectionException exception = assertThrows(CloseConnectionException.class,
+                                                          () -> connection.handle(FixedLimit.create()));
+
+        assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
     }
 
     private static Http1Connection createConnection(DataWriter dataWriter) {


### PR DESCRIPTION
Handle peer EOF, socket writer failures, and connection interruption as expected connection termination so these paths are logged at trace instead of warning.

Also select fixed-length protocols once their advertised byte count is available and normalize truncated HTTP/1 headers and HTTP/2 prefaces to connection closure. On 4.x, align two HTTP/2 reset writes with the existing connection-level server I/O classification.

Main carry-forward: #12542
