### PR TITLE
Log expected WebServer connection termination at trace

### DIFF
--- a/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
+++ b/webserver/http2/src/main/java/io/helidon/webserver/http2/Http2Connection.java
@@ -211,6 +211,8 @@ public class Http2Connection implements ServerConnection, InterruptableTask<Void
     public void handle(Limit limit) throws InterruptedException {
         try {
             doHandle(limit);
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            throw new CloseConnectionException("Connection closed by client", e);
         } catch (Http2Exception e) {
             if (closing || state == State.FINISHED) {
                 // already handled

--- a/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
+++ b/webserver/http2/src/test/java/io/helidon/webserver/http2/Http2ConnectionTest.java
@@ -22,6 +22,7 @@ import java.net.SocketException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -360,6 +361,23 @@ class Http2ConnectionTest {
                 () -> assertThat(exception.getCause(), instanceOf(UncheckedIOException.class)),
                 () -> assertThat(exception.getCause().getCause(), instanceOf(SocketException.class))
         );
+    }
+
+    @Test
+    void peerCloseWhileReadingPrefaceClosesConnection() {
+        byte[] preface = Http2Util.prefaceData().readBytes();
+        Queue<byte[]> input = new ConcurrentLinkedQueue<>();
+        input.add(Arrays.copyOf(preface, preface.length - 1));
+        DataWriter writer = mock(DataWriter.class);
+        Http2Connection connection = new Http2Connection(http2Context(writer, DataReader.create(input::poll)),
+                                                         Http2Config.create(),
+                                                         List.of());
+        connection.expectPreface();
+
+        CloseConnectionException exception = assertThrows(CloseConnectionException.class,
+                                                          () -> connection.handle(mock(Limit.class)));
+
+        assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
     }
 
     @Test

--- a/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConnectionIdentificationTest.java
+++ b/webserver/tests/http2/src/test/java/io/helidon/webserver/tests/http2/ConnectionIdentificationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.tests.http2;
+
+import java.net.Socket;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import io.helidon.common.buffers.BufferData;
+import io.helidon.common.buffers.DataReader;
+import io.helidon.http.http2.Http2FrameHeader;
+import io.helidon.http.http2.Http2FrameType;
+import io.helidon.http.http2.Http2Util;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http2.Http2Config;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+@ServerTest
+class ConnectionIdentificationTest {
+    private static final Logger CONNECTION_HANDLER_LOGGER = Logger.getLogger("io.helidon.webserver.ConnectionHandler");
+
+    static {
+        LogConfig.configureRuntime();
+    }
+
+    @SetUpRoute
+    static void routing(HttpRouting.Builder routing) {
+        routing.get("/", (_, res) -> res.send());
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.addProtocol(Http2Config.builder().build());
+    }
+
+    @Test
+    void peerCloseDuringConnectionIdentificationIsTrace(WebServer server) throws Exception {
+        try (TestLogHandler logHandler = new TestLogHandler(CONNECTION_HANDLER_LOGGER);
+             Socket socket = new Socket("127.0.0.1", server.port())) {
+            byte[] preface = Http2Util.prefaceData().readBytes();
+            socket.getOutputStream().write(preface, 0, preface.length - 1);
+            socket.shutdownOutput();
+
+            LogRecord record = logHandler.await(Duration.ofSeconds(5));
+            assertThat("Connection failure was not logged", record, is(notNullValue()));
+            assertThat(record.getLevel(), is(Level.FINER));
+            assertThat(record.getMessage(), not(containsString("unexpected exception")));
+        }
+    }
+
+    @Test
+    void exactHttp2PrefaceIdentifiesConnection(WebServer server) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", server.port())) {
+            socket.setSoTimeout(5_000);
+            socket.getOutputStream().write(Http2Util.prefaceData().readBytes());
+            socket.getOutputStream().flush();
+
+            byte[] frameHeaderBytes = socket.getInputStream().readNBytes(Http2FrameHeader.LENGTH);
+            assertThat(frameHeaderBytes.length, is(Http2FrameHeader.LENGTH));
+            Http2FrameHeader frameHeader = Http2FrameHeader.create(BufferData.create(frameHeaderBytes));
+            assertThat(frameHeader.type(), is(Http2FrameType.SETTINGS));
+        }
+    }
+
+    private static final class TestLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Level originalLevel;
+        private final boolean originalUseParentHandlers;
+        private final CountDownLatch recordReceived = new CountDownLatch(1);
+        private volatile LogRecord record;
+
+        private TestLogHandler(Logger logger) {
+            this.logger = logger;
+            this.originalLevel = logger.getLevel();
+            this.originalUseParentHandlers = logger.getUseParentHandlers();
+            setLevel(Level.ALL);
+            logger.addHandler(this);
+            logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getThrown() instanceof DataReader.InsufficientDataAvailableException) {
+                this.record = record;
+                recordReceived.countDown();
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            logger.setLevel(originalLevel);
+            logger.setUseParentHandlers(originalUseParentHandlers);
+        }
+
+        private LogRecord await(Duration timeout) throws InterruptedException {
+            return recordReceived.await(timeout.toMillis(), TimeUnit.MILLISECONDS) ? record : null;
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ConnectionHandler.java
@@ -48,6 +48,7 @@ import io.helidon.common.socket.NioSocket;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.socket.PlainSocket;
 import io.helidon.common.socket.SocketWriter;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.socket.TlsNioSocket;
 import io.helidon.common.socket.TlsSocket;
 import io.helidon.common.task.InterruptableTask;
@@ -353,6 +354,12 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
         } catch (CloseConnectionException e) {
             // end of request stream - safe to close the connection, as it was requested by our client
             helidonSocket.log(LOGGER, TRACE, "connection close requested", e);
+        } catch (DataReader.InsufficientDataAvailableException | SocketWriterException e) {
+            // the connection ended while reading or writing data
+            helidonSocket.log(LOGGER, TRACE, "server I/O issue", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            helidonSocket.log(LOGGER, TRACE, "connection interrupted", e);
         } catch (UncheckedIOException e) {
             if (e.getCause() instanceof SocketException) {
                 // socket exception - the socket failed, probably killed by OS, proxy or client
@@ -525,7 +532,7 @@ class ConnectionHandler implements InterruptableTask<Void>, ConnectionContext {
                 int expectedBytes = candidate.bytesToIdentifyConnection();
 
                 ServerConnectionSelector.Support supports;
-                if (expectedBytes == 0 || expectedBytes < currentBuffer.available()) {
+                if (expectedBytes == 0 || expectedBytes <= currentBuffer.available()) {
                     supports = candidate.supports(currentBuffer);
                 } else {
                     // we need more data, let's keep this provider for now

--- a/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/http1/Http1Connection.java
@@ -172,7 +172,6 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
         this.myThread = Thread.currentThread();
         try {
             ProxyProtocolData proxyProtocolData = ctx.proxyProtocolData().orElse(null);
-
             while (canRun) {
                 currentlyReadingPrologue = true;
                 HttpPrologue prologue = http1prologue.readPrologue();
@@ -298,6 +297,8 @@ public class Http1Connection implements ServerConnection, InterruptableTask<Void
                     throw tooManyConcurrentRequests(prologue, headers);
                 }
             }
+        } catch (DataReader.InsufficientDataAvailableException e) {
+            throw new CloseConnectionException("Connection closed by client", e);
         } catch (CloseConnectionException e) {
             throw e;
         } catch (BadRequestException e) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ConnectionHandlerTest.java
@@ -15,9 +15,12 @@
  */
 package io.helidon.webserver;
 
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -26,10 +29,14 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.concurrency.limits.Limit;
 import io.helidon.common.concurrency.limits.LimitAlgorithm;
+import io.helidon.common.socket.SocketWriterException;
 import io.helidon.common.tls.Tls;
+import io.helidon.webserver.spi.ServerConnection;
+import io.helidon.webserver.spi.ServerConnectionSelector;
 
 import org.junit.jupiter.api.Test;
 
@@ -82,29 +89,130 @@ class ConnectionHandlerTest {
         }
     }
 
+    @Test
+    void socketWriterFailureIsTrace() throws Exception {
+        assertConnectionFailureLevel(new SocketWriterException(), Level.FINER);
+    }
+
+    @Test
+    void connectionInterruptionIsTrace() throws Exception {
+        assertConnectionFailureLevel(new InterruptedException("test interruption"), Level.FINER);
+    }
+
+    @Test
+    void unexpectedConnectionFailureRemainsWarning() throws Exception {
+        assertConnectionFailureLevel(new IllegalStateException("unexpected"), Level.WARNING);
+    }
+
+    private static void assertConnectionFailureLevel(Exception failure, Level expectedLevel) throws Exception {
+        ListenerConfig listenerConfig = mock(ListenerConfig.class);
+        when(listenerConfig.useNio()).thenReturn(true);
+        ListenerContext listenerContext = mock(ListenerContext.class);
+        when(listenerContext.config()).thenReturn(listenerConfig);
+        SocketChannel socket = mock(SocketChannel.class);
+        when(socket.getRemoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 12345));
+        when(socket.getLocalAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 80));
+        ListenerConfig virtualHostConfig = mock(ListenerConfig.class);
+        when(virtualHostConfig.sni()).thenReturn(SniConfig.create());
+        when(virtualHostConfig.virtualHosts()).thenReturn(List.of());
+        Tls tls = mock(Tls.class);
+        VirtualHostRegistry virtualHosts = VirtualHostRegistry.create("server", virtualHostConfig, tls);
+        ConnectionProviders connectionProviders =
+                ConnectionProviders.create(List.of(new TestConnectionSelector(failure)));
+        ConnectionHandler handler = new ConnectionHandler(listenerContext,
+                                                          mock(LimitAlgorithm.Token.class),
+                                                          mock(Limit.class),
+                                                          connectionProviders,
+                                                          socket,
+                                                          "server",
+                                                          Router.empty(),
+                                                          tls,
+                                                          virtualHosts,
+                                                          _ -> { });
+
+        try (TestLogHandler logHandler = TestLogHandler.install(failure)) {
+            Thread thread = Thread.ofVirtual().start(handler::run);
+            LogRecord record = logHandler.await();
+            thread.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(thread.isAlive(), is(false));
+            assertThat(record.getThrown(), sameInstance(failure));
+            assertThat(record.getLevel(), is(expectedLevel));
+        }
+    }
+
+    private record TestConnectionSelector(Exception failure) implements ServerConnectionSelector {
+        @Override
+        public int bytesToIdentifyConnection() {
+            return 0;
+        }
+
+        @Override
+        public Support supports(BufferData data) {
+            return Support.SUPPORTED;
+        }
+
+        @Override
+        public Set<String> supportedApplicationProtocols() {
+            return Set.of();
+        }
+
+        @Override
+        public ServerConnection connection(ConnectionContext ctx) {
+            return new ServerConnection() {
+                @Override
+                public void handle(Limit limit) throws InterruptedException {
+                    if (failure instanceof RuntimeException runtimeException) {
+                        throw runtimeException;
+                    }
+                    throw (InterruptedException) failure;
+                }
+
+                @Override
+                public Duration idleTime() {
+                    return Duration.ZERO;
+                }
+
+                @Override
+                public void close(boolean interrupt) {
+                }
+            };
+        }
+    }
+
     private static final class TestLogHandler extends Handler implements AutoCloseable {
         private final Logger logger;
         private final Level previousLevel;
+        private final boolean previousUseParentHandlers;
+        private final Throwable failure;
         private final CountDownLatch latch = new CountDownLatch(1);
         private final AtomicReference<LogRecord> record = new AtomicReference<>();
 
-        private TestLogHandler(Logger logger) {
+        private TestLogHandler(Logger logger, Throwable failure) {
             this.logger = logger;
             this.previousLevel = logger.getLevel();
+            this.previousUseParentHandlers = logger.getUseParentHandlers();
+            this.failure = failure;
             setLevel(Level.ALL);
         }
 
         static TestLogHandler install() {
+            return install(null);
+        }
+
+        static TestLogHandler install(Throwable failure) {
             Logger logger = Logger.getLogger(ConnectionHandler.class.getName());
-            TestLogHandler handler = new TestLogHandler(logger);
+            TestLogHandler handler = new TestLogHandler(logger, failure);
             logger.setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
             logger.addHandler(handler);
             return handler;
         }
 
         @Override
         public void publish(LogRecord record) {
-            if (this.record.compareAndSet(null, record)) {
+            if ((failure == null || record.getThrown() == failure)
+                    && this.record.compareAndSet(null, record)) {
                 latch.countDown();
             }
         }
@@ -117,6 +225,7 @@ class ConnectionHandlerTest {
         public void close() {
             logger.removeHandler(this);
             logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
         }
 
         private LogRecord await() throws InterruptedException {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/http1/Http1ConnectionTest.java
@@ -253,6 +253,21 @@ class Http1ConnectionTest {
         }
     }
 
+    @Test
+    void peerCloseWhileReadingHeadersClosesConnection() {
+        AtomicReference<byte[]> input =
+                new AtomicReference<>("GET / HTTP/1.1\r\nHost:".getBytes(StandardCharsets.UTF_8));
+        Http1Connection connection = createConnection(DataReader.create(() -> input.getAndSet(null)),
+                                                      mock(DataWriter.class),
+                                                      DirectHandlers.create(),
+                                                      Router.empty());
+
+        CloseConnectionException exception = assertThrows(CloseConnectionException.class,
+                                                          () -> connection.handle(FixedLimit.create()));
+
+        assertThat(exception.getCause(), instanceOf(DataReader.InsufficientDataAvailableException.class));
+    }
+
     private static Http1Connection createConnection(DataWriter dataWriter) {
         return createConnection(mock(DataReader.class), dataWriter, DirectHandlers.create(), Router.empty());
     }


### PR DESCRIPTION
Carry forward #12541 to main.

Handle peer EOF, socket writer failures, and connection interruption as expected connection termination so these paths are logged at trace instead of warning.

Also select fixed-length protocols once their advertised byte count is available and normalize truncated HTTP/1 headers and HTTP/2 prefaces to connection closure.
