### PR TITLE
Preserve HTTP/1 response entities with Upgrade headers (27.x)

### DIFF
--- a/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
+++ b/webclient/http1/src/main/java/io/helidon/webclient/http1/Http1CallChainBase.java
@@ -523,12 +523,6 @@ abstract class Http1CallChainBase implements WebClientService.TransportChain {
         if (responseHeaders.contains(HeaderValues.CONTENT_LENGTH_ZERO)) {
             return false;
         }
-        if ((
-                responseHeaders.contains(HeaderNames.UPGRADE)
-                        && !responseHeaders.containsToken(HeaderValues.TRANSFER_ENCODING_CHUNKED))) {
-            // this is an upgrade response and there is no entity
-            return false;
-        }
         // if we decide to support HTTP/1.0, we may have an entity without any headers
         // in HTTP/1.1, we should have a content encoding
         return true;

--- a/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
+++ b/webclient/http1/src/test/java/io/helidon/webclient/http1/Http1ClientTest.java
@@ -1054,6 +1054,37 @@ class Http1ClientTest {
         assertThat(response.headers(), hasHeader(REQ_EXPECT_100_HEADER_NAME));
     }
 
+    @ParameterizedTest(name = "HEAD response: {0}")
+    @ValueSource(booleans = {false, true})
+    void testUpgradeRequiredEntityDoesNotContaminateConnection(boolean head) throws Exception {
+        try (UpgradeRequiredServer server = UpgradeRequiredServer.start(head)) {
+            Http1Client testClient = Http1Client.builder()
+                    .baseUri(server.uri())
+                    .readTimeout(Duration.ofSeconds(5))
+                    .build();
+            try {
+                try (Http1ClientResponse response = testClient.method(head ? Method.HEAD : Method.GET)
+                        .uri("/upgrade")
+                        .request()) {
+                    assertThat(response.status(), is(Status.UPGRADE_REQUIRED_426));
+                    if (head) {
+                        assertThat(response.entity().hasEntity(), is(false));
+                    } else {
+                        assertThat(response.entity().inputStream().readAllBytes(),
+                                   is("upgrade".getBytes(StandardCharsets.UTF_8)));
+                    }
+                }
+                try (Http1ClientResponse response = testClient.get("/next").request()) {
+                    assertThat(response.status(), is(Status.OK_200));
+                    assertThat(response.entity().inputStream().readAllBytes(), is("ok".getBytes(StandardCharsets.UTF_8)));
+                }
+                server.awaitCompletion();
+            } finally {
+                testClient.closeResource();
+            }
+        }
+    }
+
     // validates that HEAD is not allowed with entity payload
     @Test
     void testHeadMethod() {
@@ -2005,6 +2036,75 @@ class Http1ClientTest {
                     + "\r\n").getBytes(StandardCharsets.US_ASCII));
             while (response.hasRemaining()) {
                 socket.write(response);
+            }
+        }
+    }
+
+    private record UpgradeRequiredServer(ServerSocket server,
+                                         CompletableFuture<Void> completion) implements AutoCloseable {
+        private static final byte[] UPGRADE_HEADERS = ("HTTP/1.1 426 Upgrade Required\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Upgrade: h2c\r\n"
+                + "Content-Length: 7\r\n"
+                + "\r\n").getBytes(StandardCharsets.US_ASCII);
+        private static final byte[] NEXT_RESPONSE = ("HTTP/1.1 200 OK\r\n"
+                + "Content-Length: 2\r\n"
+                + "\r\n"
+                + "ok").getBytes(StandardCharsets.US_ASCII);
+
+        static UpgradeRequiredServer start(boolean head) throws IOException {
+            ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            server.setSoTimeout(5_000);
+            CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+                try (Socket socket = server.accept()) {
+                    socket.setSoTimeout(5_000);
+                    InputStream inputStream = socket.getInputStream();
+                    OutputStream outputStream = socket.getOutputStream();
+                    readHeaders(inputStream);
+                    outputStream.write(UPGRADE_HEADERS);
+                    if (!head) {
+                        outputStream.write("upgrade".getBytes(StandardCharsets.US_ASCII));
+                    }
+                    outputStream.flush();
+                    readHeaders(inputStream);
+                    outputStream.write(NEXT_RESPONSE);
+                    outputStream.flush();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            return new UpgradeRequiredServer(server, completion);
+        }
+
+        String uri() {
+            return "http://127.0.0.1:" + server.getLocalPort();
+        }
+
+        void awaitCompletion() throws Exception {
+            completion.get(5, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public void close() {
+            try {
+                server.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private static void readHeaders(InputStream inputStream) throws IOException {
+            int matched = 0;
+            while (matched < 4) {
+                int next = inputStream.read();
+                if (next == -1) {
+                    throw new IllegalStateException("HTTP/1 request headers were not complete");
+                }
+                matched = switch (matched) {
+                case 0, 2 -> next == '\r' ? matched + 1 : 0;
+                case 1, 3 -> next == '\n' ? matched + 1 : next == '\r' ? 1 : 0;
+                default -> throw new IllegalStateException("Unexpected header parser state");
+                };
             }
         }
     }


### PR DESCRIPTION
Resolves #12544

Preserves the body of ordinary HTTP/1 responses that include Upgrade and adds persistent-connection coverage for GET and HEAD. Carries forward the Upgrade-response correction from #12532 to main.
