### PR TITLE
Enforce HTTP/2 HEAD and 304 response content semantics (27.x)

### DIFF
--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2CallChainBase.java
@@ -121,7 +121,9 @@ abstract class Http2CallChainBase implements WebClientService.TransportChain {
 
     static Http2Headers readHeaders(Http2ClientStream stream, Duration readTimeout) {
         try {
-            return readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
+            Http2Headers headers = readTimeout == null ? stream.readHeaders() : stream.readHeaders(readTimeout);
+            stream.finishNoContent();
+            return headers;
         } catch (Http2Exception e) {
             resetAndClose(stream, e);
             throw e;

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -924,6 +924,9 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
      * @param endOfStream trailers must always close the remote side
      */
     private void trailersLocked(Http2Headers headers, boolean endOfStream) {
+        if (currentHeaders.status() == Status.NOT_MODIFIED_304) {
+            throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Received trailers on a 304 response");
+        }
         Http2StreamState nextState =
                 Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, false, endOfStream, true);
         if (endOfStream && (nextState == Http2StreamState.CLOSED || state == Http2StreamState.HALF_CLOSED_LOCAL)) {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -28,6 +28,7 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
+import io.helidon.http.Method;
 import io.helidon.http.Status;
 import io.helidon.http.WritableHeaders;
 import io.helidon.http.http2.Http2ErrorCode;
@@ -84,7 +85,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private volatile RuntimeException connectionFailure;
     // accessed from stream thread an connection thread
     private volatile StreamFlowControl flowControl;
+    // Wire completion is independent of whether the response semantics permit content.
     private boolean hasEntity;
+    private boolean headRequest;
+    private boolean responseNoContent;
     private boolean continue100Received;
     private volatile boolean inboundEndQueued;
     private volatile boolean locallyReset;
@@ -296,15 +300,15 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     }
 
     /**
-     * Determines if an entity is expected. Set to {@code false} when an EOS flag
-     * is received.
+     * Determines whether the response can expose an entity. HEAD and 304 responses
+     * have no entity even when empty DATA frames are needed to end the stream.
      *
      * @return {@code true} if entity expected, {@code false} otherwise.
      */
     public boolean hasEntity() {
         inboundStateLock.lock();
         try {
-            return hasEntity;
+            return hasEntity && !responseNoContent;
         } finally {
             inboundStateLock.unlock();
         }
@@ -420,6 +424,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         if (inboundEndQueued || currentReadState != ReadState.DATA) {
             throw invalidInboundDataState(currentReadState);
         }
+        if (responseNoContent && dataContentLength(frameData) != 0) {
+            failResponseContent();
+            return false;
+        }
         if (!endOfStream) {
             return true;
         }
@@ -477,6 +485,22 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
 
     BufferData read(int i) {
         return read();
+    }
+
+    void finishNoContent() {
+        if (!responseNoContent) {
+            return;
+        }
+        // Bodyless responses still have to receive END_STREAM before they can be closed.
+        while (expectsEntityData()) {
+            readOne(timeout);
+        }
+        inboundStateLock.lock();
+        try {
+            throwIfInboundFailed();
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     /**
@@ -544,6 +568,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         inboundStateLock.lock();
         try {
             updateState(Http2StreamState.checkAndGetState(this.state, Http2FrameType.HEADERS, true, endOfStream, true));
+            this.headRequest = http2Headers.method() == Method.HEAD;
             this.readState = readState.check(http2Headers.httpHeaders().containsToken(HeaderValues.EXPECT_100)
                                                      ? ReadState.CONTINUE_100_HEADERS
                                                      : ReadState.HEADERS);
@@ -853,6 +878,7 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         readState = readState.check(endOfStream ? ReadState.END : ReadState.DATA);
         this.currentHeaders = headers;
         this.continue100Received = false;
+        this.responseNoContent = headRequest || headers.status() == Status.NOT_MODIFIED_304;
         this.hasEntity = !endOfStream;
     }
 
@@ -922,6 +948,17 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         reset(failure.code());
     }
 
+    private static int dataContentLength(Http2FrameData frameData) {
+        int length = frameData.data().available();
+        if (frameData.header().flags(Http2FrameTypes.DATA).padded()) {
+            if (length == 0 || frameData.data().get(0) >= length) {
+                throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid DATA padding");
+            }
+            length -= frameData.data().get(0) + 1;
+        }
+        return length;
+    }
+
     private static void validateRegularHeaders(Headers headers) {
         for (var header : headers) {
             try {
@@ -972,6 +1009,23 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private Http2Exception invalidInboundDataState(ReadState currentReadState) {
         return new Http2Exception(Http2ErrorCode.PROTOCOL,
                                   "Received DATA frame in invalid response read state " + currentReadState);
+    }
+
+    private void failResponseContent() {
+        var failure = new Http2Exception(Http2ErrorCode.PROTOCOL, "Received content on a HEAD or 304 response");
+        inboundStateLock.lock();
+        try {
+            inboundFailure = failure;
+            try {
+                reset(Http2ErrorCode.PROTOCOL);
+            } finally {
+                buffer.fail(failure);
+                close();
+                inboundStateChanged.signalAll();
+            }
+        } finally {
+            inboundStateLock.unlock();
+        }
     }
 
     enum ReadState {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -1019,11 +1019,12 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
         inboundStateLock.lock();
         try {
             inboundFailure = failure;
+            int discardedDataLength = buffer.failAndDiscard(failure);
             try {
                 reset(Http2ErrorCode.PROTOCOL);
             } finally {
-                buffer.fail(failure);
                 close();
+                connection.flowControl().incrementInboundConnectionWindowSize(discardedDataLength);
                 inboundStateChanged.signalAll();
             }
         } finally {

--- a/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
+++ b/webclient/http2/src/main/java/io/helidon/webclient/http2/Http2ClientStream.java
@@ -951,10 +951,10 @@ public class Http2ClientStream implements Http2Stream, ReleasableResource {
     private static int dataContentLength(Http2FrameData frameData) {
         int length = frameData.data().available();
         if (frameData.header().flags(Http2FrameTypes.DATA).padded()) {
-            if (length == 0 || frameData.data().get(0) >= length) {
+            if (length == 0 || (frameData.data().get(0) & 0xFF) >= length) {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL, "Invalid DATA padding");
             }
-            length -= frameData.data().get(0) + 1;
+            length -= (frameData.data().get(0) & 0xFF) + 1;
         }
         return length;
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1562,11 +1562,23 @@ class Http2ClientConnectionTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"HEAD, 200, false, false", "HEAD, 200, true, false", "HEAD, 426, false, false", "HEAD, 426, true, false",
-                "GET, 304, false, false", "GET, 304, true, false",
-                "HEAD, 200, false, true", "HEAD, 200, true, true", "HEAD, 426, false, true", "HEAD, 426, true, true",
-                "GET, 304, false, true", "GET, 304, true, true"})
-    void forbiddenResponseContentResetsOnlyItsStream(String methodName, int statusCode, boolean endOfStream, boolean padded)
+    @CsvSource({"HEAD, 200, false, false, false", "HEAD, 200, true, false, false",
+                "HEAD, 426, false, false, false", "HEAD, 426, true, false, false",
+                "GET, 304, false, false, false", "GET, 304, true, false, false",
+                "HEAD, 200, false, true, false", "HEAD, 200, true, true, false",
+                "HEAD, 426, false, true, false", "HEAD, 426, true, true, false",
+                "GET, 304, false, true, false", "GET, 304, true, true, false",
+                "HEAD, 200, false, false, true", "HEAD, 200, true, false, true",
+                "HEAD, 426, false, false, true", "HEAD, 426, true, false, true",
+                "GET, 304, false, false, true", "GET, 304, true, false, true",
+                "HEAD, 200, false, true, true", "HEAD, 200, true, true, true",
+                "HEAD, 426, false, true, true", "HEAD, 426, true, true, true",
+                "GET, 304, false, true, true", "GET, 304, true, true, true"})
+    void forbiddenResponseContentResetsOnlyItsStream(String methodName,
+                                                    int statusCode,
+                                                    boolean endOfStream,
+                                                    boolean padded,
+                                                    boolean consumePriorData)
             throws Exception {
         Method method = Method.create(methodName);
         Status status = Status.create(statusCode);
@@ -1587,19 +1599,24 @@ class Http2ClientConnectionTest {
                     .status(status);
             test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
             assertThat(malformedStream.readHeaders().status(), is(status));
+            Http2FrameData queuedData = paddedDataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, false, 255);
+            assertThat(connection.handle(queuedData.header(), queuedData.data()), is(true));
+            if (consumePriorData) {
+                // Credit already returned by consumption must not be returned again when the stream fails.
+                malformedStream.readOne(TEST_WAIT_TIMEOUT);
+            }
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
             Http2FrameData firstData = padded
                     ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
                     : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream);
-            int discardedLength = firstData.header().length();
-            if (endOfStream) {
-                test.offerInbound(firstData);
-            } else {
+            int discardedLength = (consumePriorData ? 0 : queuedData.header().length()) + firstData.header().length();
+            // Process the rejection before response construction can consume the earlier queued padding.
+            assertThat(connection.handle(firstData.header(), firstData.data()), is(true));
+            if (!endOfStream) {
                 // DATA already in flight after the reset still consumes connection credit, including padding.
                 Http2FrameData lateData = paddedDataFrame(malformedStream.streamId(), forbiddenContent, false, 255);
                 discardedLength += lateData.header().length();
-                test.offerInbound(firstData,
-                                  lateData,
+                test.offerInbound(lateData,
                                   dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, true));
             }
             test.offerInbound(encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1429,7 +1429,7 @@ class Http2ClientConnectionTest {
                 "HEAD, 200, padded-buffer, 127", "HEAD, 426, padded-buffer, 127", "GET, 304, padded-buffer, 127",
                 "HEAD, 200, padded-buffer, 128", "HEAD, 426, padded-buffer, 128", "GET, 304, padded-buffer, 128",
                 "HEAD, 200, padded-buffer, 255", "HEAD, 426, padded-buffer, 255", "GET, 304, padded-buffer, 255",
-                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0", "GET, 304, trailers, 0"})
+                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0"})
     void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName,
                                                                  int statusCode,
                                                                  String termination,
@@ -1500,6 +1500,63 @@ class Http2ClientConnectionTest {
             assertThat(nextStream, notNullValue());
             nextStream.close();
             stream.close();
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"GET, false", "GET, true", "HEAD, false", "HEAD, true"})
+    void notModifiedTrailersResetOnlyTheirStream(String methodName, boolean emptyData) throws Exception {
+        Method method = Method.create(methodName);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(2));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream malformedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+            malformedStream.writeHeaders(requestHeaders().method(method), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(Status.NOT_MODIFIED_304);
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
+            assertThat(malformedStream.readHeaders().status(), is(Status.NOT_MODIFIED_304));
+            if (emptyData) {
+                test.offerInbound(dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, false));
+            }
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), encodedTrailers(), inboundTable, huffman, true),
+                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            Http2Exception failure = assertThrows(Http2Exception.class, () -> chain.readResponse(request, malformedStream));
+            assertThat(failure.code(), is(Http2ErrorCode.PROTOCOL));
+
+            Http2FrameData reset = test.awaitWrittenFrame(Http2FrameType.RST_STREAM);
+            assertThat(reset.header().streamId(), is(malformedStream.streamId()));
+            assertThat(Http2RstStream.create(reset.data()).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertThat(siblingStream.readHeaders().status(), is(Status.OK_200));
+            BufferData data = siblingStream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(recoveredStream, notNullValue());
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+            recoveredStream.close();
+            siblingStream.close();
+            malformedStream.close();
             connection.close();
         }
     }

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -39,6 +39,7 @@ import io.helidon.common.buffers.DataReader;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.socket.SocketContext;
 import io.helidon.common.tls.Tls;
+import io.helidon.http.ClientResponseHeaders;
 import io.helidon.http.HeaderNames;
 import io.helidon.http.HeaderValues;
 import io.helidon.http.Headers;
@@ -59,6 +60,7 @@ import io.helidon.http.http2.Http2HuffmanEncoder;
 import io.helidon.http.http2.Http2RstStream;
 import io.helidon.http.http2.Http2Setting;
 import io.helidon.http.http2.Http2Settings;
+import io.helidon.http.http2.Http2Util;
 import io.helidon.http.http2.Http2WindowUpdate;
 import io.helidon.http.http2.WindowSize;
 import io.helidon.webclient.api.ClientConnection;
@@ -69,14 +71,19 @@ import io.helidon.webclient.api.Proxy;
 import io.helidon.webclient.api.ResolvedClientTarget;
 import io.helidon.webclient.api.TcpClientConnection;
 import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.api.WebClientServiceRequest;
+import io.helidon.webclient.api.WebClientServiceResponse;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -145,6 +152,21 @@ class Http2ClientConnectionTest {
                                                                                              : 0),
                                                           streamId);
         return new Http2FrameData(header, BufferData.create(bytes));
+    }
+
+    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream) {
+        int padding = 3;
+        byte[] paddedBytes = new byte[1 + bytes.length + padding];
+        paddedBytes[0] = (byte) padding;
+        System.arraycopy(bytes, 0, paddedBytes, 1, bytes.length);
+        Http2FrameHeader header = Http2FrameHeader.create(paddedBytes.length,
+                                                          Http2FrameTypes.DATA,
+                                                          Http2Flag.DataFlags.create(Http2Flag.PADDED
+                                                                                             | (endOfStream
+                                                                                                     ? Http2Flag.END_OF_STREAM
+                                                                                                     : 0)),
+                                                          streamId);
+        return new Http2FrameData(header, BufferData.create(paddedBytes));
     }
 
     private static Http2FrameData windowUpdateFrame(int streamId) {
@@ -1398,6 +1420,139 @@ class Http2ClientConnectionTest {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource({"HEAD, 200, headers", "HEAD, 426, headers", "GET, 304, headers",
+                "HEAD, 200, data", "HEAD, 426, data", "GET, 304, data",
+                "HEAD, 200, padded", "HEAD, 426, padded", "GET, 304, padded",
+                "HEAD, 200, trailers", "HEAD, 426, trailers", "GET, 304, trailers"})
+    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName, int statusCode, String termination) {
+        Method method = Method.create(methodName);
+        Status status = Status.create(statusCode);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(1));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream stream = connection.createStream(STREAM_CONFIG);
+            stream.writeHeaders(requestHeaders().method(method), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(status);
+            boolean headersEndStream = termination.equals("headers");
+            test.offerInbound(encodedHeaderFrame(stream.streamId(), headers, inboundTable, huffman, headersEndStream));
+            assertThat(stream.readHeaders().status(), is(status));
+
+            if (!headersEndStream) {
+                // Response semantics alone do not release the peer's concurrent-stream slot.
+                assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+                switch (termination) {
+                case "data" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], true));
+                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true));
+                case "trailers" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], false),
+                                                     encodedHeaderFrame(stream.streamId(),
+                                                                        encodedTrailers(),
+                                                                        inboundTable,
+                                                                        huffman,
+                                                                        true));
+                default -> throw new IllegalArgumentException("Unknown response termination: " + termination);
+                }
+            }
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            WebClientServiceResponse response = chain.readResponse(request, stream);
+            assertThat(response.status(), is(status));
+            assertThat(response.headers().get(HeaderNames.CONTENT_LENGTH).get(), is("123"));
+            assertThat(response.inputStream().isPresent(), is(false));
+
+            WebClientServiceResponse outputStreamResponse =
+                    Http2CallChainBase.createServiceResponse(request,
+                                                             test.clientConfig,
+                                                             stream,
+                                                             new CompletableFuture<>(),
+                                                             status,
+                                                             ClientResponseHeaders.create(headers.httpHeaders()));
+            assertThat(outputStreamResponse.headers().get(HeaderNames.CONTENT_LENGTH).get(), is("123"));
+            assertThat(outputStreamResponse.inputStream().isPresent(), is(false));
+
+            Http2ClientStream nextStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(nextStream, notNullValue());
+            nextStream.close();
+            stream.close();
+            connection.close();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"HEAD, 200, false, false", "HEAD, 200, true, false", "HEAD, 426, false, false", "HEAD, 426, true, false",
+                "GET, 304, false, false", "GET, 304, true, false",
+                "HEAD, 200, false, true", "HEAD, 200, true, true", "HEAD, 426, false, true", "HEAD, 426, true, true",
+                "GET, 304, false, true", "GET, 304, true, true"})
+    void forbiddenResponseContentResetsOnlyItsStream(String methodName, int statusCode, boolean endOfStream, boolean padded)
+            throws Exception {
+        Method method = Method.create(methodName);
+        Status status = Status.create(statusCode);
+        try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
+            test.offerInbound(settingsFrame(2));
+            Http2ClientConnection connection = test.createConnection(false);
+            Http2ClientStream malformedStream = connection.createStream(STREAM_CONFIG);
+            Http2ClientStream siblingStream = connection.createStream(STREAM_CONFIG);
+            malformedStream.writeHeaders(requestHeaders().method(method), true);
+            siblingStream.writeHeaders(requestHeaders(), true);
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+
+            Http2Headers.DynamicTable inboundTable =
+                    Http2Headers.DynamicTable.create(Http2Setting.HEADER_TABLE_SIZE.defaultValue());
+            Http2HuffmanEncoder huffman = Http2HuffmanEncoder.create();
+            Http2Headers headers = Http2Headers.create(WritableHeaders.create()
+                                                             .set(HeaderNames.CONTENT_LENGTH, "123"))
+                    .status(status);
+            test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
+            assertThat(malformedStream.readHeaders().status(), is(status));
+            byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
+            test.offerInbound(padded
+                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream)
+                                      : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
+                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+                              dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
+
+            WebClientServiceRequest request = mock(WebClientServiceRequest.class);
+            when(request.method()).thenReturn(method);
+            Http2CallEntityChain chain = new Http2CallEntityChain(test.client,
+                                                                  mock(Http2ClientRequestImpl.class),
+                                                                  new CompletableFuture<>(),
+                                                                  new CompletableFuture<>(),
+                                                                  BufferData.EMPTY_BYTES);
+            Http2Exception failure = assertThrows(Http2Exception.class, () -> chain.readResponse(request, malformedStream));
+            assertThat(failure.code(), is(Http2ErrorCode.PROTOCOL));
+
+            Http2FrameData reset = test.awaitWrittenFrame(Http2FrameType.RST_STREAM);
+            assertThat(reset.header().streamId(), is(malformedStream.streamId()));
+            assertThat(Http2RstStream.create(reset.data()).errorCode(), is(Http2ErrorCode.PROTOCOL));
+            assertThat(siblingStream.readHeaders().status(), is(Status.OK_200));
+            BufferData data = siblingStream.read();
+            byte[] entity = new byte[data.available()];
+            data.read(entity);
+            assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
+            assertThat(recoveredStream, notNullValue());
+            assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
+            recoveredStream.close();
+            siblingStream.close();
+            malformedStream.close();
+            connection.close();
+        }
+    }
+
     @Test
     void initialZeroMaxConcurrentStreamsClosesUnusableConnection() {
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
@@ -2281,6 +2436,7 @@ class Http2ClientConnectionTest {
 
         private final ExecutorService connectionExecutor = Executors.newSingleThreadExecutor();
         private final LinkedBlockingQueue<byte[]> inboundFrames = new LinkedBlockingQueue<>();
+        private final LinkedBlockingQueue<BufferData> writtenFrames = new LinkedBlockingQueue<>();
         // The client preface is the first writeNow call; the initial SETTINGS ACK is the second.
         private final CountDownLatch initialWriteNowCallsCompleted = new CountDownLatch(2);
         private final AtomicBoolean failWrites = new AtomicBoolean();
@@ -2322,6 +2478,7 @@ class Http2ClientConnectionTest {
             doAnswer(invocation -> {
                 maybeFailWrites();
                 maybeBlockWriteNow();
+                writtenFrames.add(invocation.<BufferData>getArgument(0).copy());
                 initialWriteNowCallsCompleted.countDown();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));
@@ -2367,6 +2524,26 @@ class Http2ClientConnectionTest {
 
         private void closeInbound() {
             inboundFrames.add(END_INBOUND);
+        }
+
+        private Http2FrameData awaitWrittenFrame(Http2FrameType expectedType) throws InterruptedException {
+            long deadline = System.nanoTime() + TEST_WAIT_TIMEOUT.toNanos();
+            while (true) {
+                BufferData data = writtenFrames.poll(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
+                assertThat("Expected an outbound " + expectedType + " frame", data, notNullValue());
+                if (data.available() == Http2Util.PREFACE_LENGTH) {
+                    byte[] bytes = new byte[Http2Util.PREFACE_LENGTH];
+                    data.read(bytes);
+                    data.rewind();
+                    if (Http2Util.isPreface(bytes)) {
+                        continue;
+                    }
+                }
+                Http2FrameHeader header = Http2FrameHeader.create(data);
+                if (header.type() == expectedType) {
+                    return new Http2FrameData(header, data);
+                }
+            }
         }
 
         private void assertConnectionClosed() {

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -154,8 +154,7 @@ class Http2ClientConnectionTest {
         return new Http2FrameData(header, BufferData.create(bytes));
     }
 
-    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream) {
-        int padding = 3;
+    private static Http2FrameData paddedDataFrame(int streamId, byte[] bytes, boolean endOfStream, int padding) {
         byte[] paddedBytes = new byte[1 + bytes.length + padding];
         paddedBytes[0] = (byte) padding;
         System.arraycopy(bytes, 0, paddedBytes, 1, bytes.length);
@@ -1421,11 +1420,20 @@ class Http2ClientConnectionTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"HEAD, 200, headers", "HEAD, 426, headers", "GET, 304, headers",
-                "HEAD, 200, data", "HEAD, 426, data", "GET, 304, data",
-                "HEAD, 200, padded", "HEAD, 426, padded", "GET, 304, padded",
-                "HEAD, 200, trailers", "HEAD, 426, trailers", "GET, 304, trailers"})
-    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName, int statusCode, String termination) {
+    @CsvSource({"HEAD, 200, headers, 0", "HEAD, 426, headers, 0", "GET, 304, headers, 0",
+                "HEAD, 200, data, 0", "HEAD, 426, data, 0", "GET, 304, data, 0",
+                "HEAD, 200, padded, 3", "HEAD, 426, padded, 3", "GET, 304, padded, 3",
+                "HEAD, 200, padded, 127", "HEAD, 426, padded, 127", "GET, 304, padded, 127",
+                "HEAD, 200, padded, 128", "HEAD, 426, padded, 128", "GET, 304, padded, 128",
+                "HEAD, 200, padded, 255", "HEAD, 426, padded, 255", "GET, 304, padded, 255",
+                "HEAD, 200, padded-buffer, 127", "HEAD, 426, padded-buffer, 127", "GET, 304, padded-buffer, 127",
+                "HEAD, 200, padded-buffer, 128", "HEAD, 426, padded-buffer, 128", "GET, 304, padded-buffer, 128",
+                "HEAD, 200, padded-buffer, 255", "HEAD, 426, padded-buffer, 255", "GET, 304, padded-buffer, 255",
+                "HEAD, 200, trailers, 0", "HEAD, 426, trailers, 0", "GET, 304, trailers, 0"})
+    void responseWithoutContentPreservesMetadataAndReleasesStream(String methodName,
+                                                                 int statusCode,
+                                                                 String termination,
+                                                                 int padding) {
         Method method = Method.create(methodName);
         Status status = Status.create(statusCode);
         try (MockedConnectionTestContext test = new MockedConnectionTestContext()) {
@@ -1450,7 +1458,12 @@ class Http2ClientConnectionTest {
                 assertThat(connection.tryStream(STREAM_CONFIG), nullValue());
                 switch (termination) {
                 case "data" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], true));
-                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true));
+                case "padded" -> test.offerInbound(paddedDataFrame(stream.streamId(), new byte[0], true, padding));
+                case "padded-buffer" -> {
+                    // Mutable buffers expose signed bytes, unlike the reader's read-only buffers.
+                    Http2FrameData frame = paddedDataFrame(stream.streamId(), new byte[0], true, padding);
+                    assertThat(connection.handle(frame.header(), frame.data()), is(true));
+                }
                 case "trailers" -> test.offerInbound(dataFrame(stream.streamId(), new byte[0], false),
                                                      encodedHeaderFrame(stream.streamId(),
                                                                         encodedTrailers(),
@@ -1519,7 +1532,7 @@ class Http2ClientConnectionTest {
             assertThat(malformedStream.readHeaders().status(), is(status));
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
             test.offerInbound(padded
-                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream)
+                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
                                       : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
                               encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
                               dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -1531,10 +1531,21 @@ class Http2ClientConnectionTest {
             test.offerInbound(encodedHeaderFrame(malformedStream.streamId(), headers, inboundTable, huffman));
             assertThat(malformedStream.readHeaders().status(), is(status));
             byte[] forbiddenContent = "forbidden".getBytes(StandardCharsets.UTF_8);
-            test.offerInbound(padded
-                                      ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
-                                      : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream),
-                              encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
+            Http2FrameData firstData = padded
+                    ? paddedDataFrame(malformedStream.streamId(), forbiddenContent, endOfStream, 3)
+                    : dataFrame(malformedStream.streamId(), forbiddenContent, endOfStream);
+            int discardedLength = firstData.header().length();
+            if (endOfStream) {
+                test.offerInbound(firstData);
+            } else {
+                // DATA already in flight after the reset still consumes connection credit, including padding.
+                Http2FrameData lateData = paddedDataFrame(malformedStream.streamId(), forbiddenContent, false, 255);
+                discardedLength += lateData.header().length();
+                test.offerInbound(firstData,
+                                  lateData,
+                                  dataFrame(malformedStream.streamId(), BufferData.EMPTY_BYTES, true));
+            }
+            test.offerInbound(encodedHeaderFrame(siblingStream.streamId(), encodedResponseHeaders(false), inboundTable, huffman),
                               dataFrame(siblingStream.streamId(), "sibling".getBytes(StandardCharsets.UTF_8), false));
 
             WebClientServiceRequest request = mock(WebClientServiceRequest.class);
@@ -1555,6 +1566,18 @@ class Http2ClientConnectionTest {
             byte[] entity = new byte[data.available()];
             data.read(entity);
             assertThat(new String(entity, StandardCharsets.UTF_8), is("sibling"));
+
+            int connectionCredit = 0;
+            for (BufferData written : test.writtenFrames) {
+                Http2FrameHeader header = Http2FrameHeader.create(written);
+                assertThat("Only credit updates may follow the malformed-stream reset",
+                           header.type(), is(Http2FrameType.WINDOW_UPDATE));
+                if (header.streamId() == 0) {
+                    connectionCredit += Http2WindowUpdate.create(written).windowSizeIncrement();
+                }
+            }
+            assertThat("Discarded DATA and the consumed sibling body must restore exact connection credit",
+                       connectionCredit, is(discardedLength + entity.length));
 
             Http2ClientStream recoveredStream = connection.tryStream(STREAM_CONFIG);
             assertThat(recoveredStream, notNullValue());

--- a/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
+++ b/webclient/http2/src/test/java/io/helidon/webclient/http2/Http2ClientConnectionTest.java
@@ -2514,7 +2514,12 @@ class Http2ClientConnectionTest {
             doAnswer(invocation -> {
                 maybeFailWrites();
                 maybeBlockWriteNow();
-                writtenFrames.add(invocation.<BufferData>getArgument(0).copy());
+                BufferData frame = invocation.getArgument(0);
+                byte[] bytes = new byte[frame.available()];
+                for (int i = 0; i < bytes.length; i++) {
+                    bytes[i] = (byte) frame.get(i);
+                }
+                writtenFrames.add(BufferData.create(bytes));
                 initialWriteNowCallsCompleted.countDown();
                 return null;
             }).when(dataWriter).writeNow(any(BufferData.class));

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTest.java
@@ -75,7 +75,7 @@ class RoutingTest extends RoutingTestBase {
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
                 // shortcut methods with no path pattern
-                .get((req, res) -> res.send("get_catchall"))
+                .get((req, res) -> res.send(GET_CATCHALL_RESPONSE))
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RoutingTestBase.java
@@ -45,6 +45,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 // Use by both RoutingTest and RulesTest to share the same test methods
 abstract class RoutingTestBase {
+    static final String GET_CATCHALL_RESPONSE = "get_catchall";
+
     private static final Header MULTI_HANDLER = HeaderValues.createCached(
             HeaderNames.create("X-Multi-Handler"), "true");
     private static final String HEAD_ROUTE_HEADER = "X-Head-Route";
@@ -67,7 +69,7 @@ abstract class RoutingTestBase {
 
     static void sendHead(ServerResponse res, String responseMessage) {
         res.headers().set(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage));
-        res.headers().contentLength(responseMessage.getBytes(StandardCharsets.UTF_8).length);
+        res.headers().contentLength(GET_CATCHALL_RESPONSE.getBytes(StandardCharsets.UTF_8).length);
         res.send();
     }
 
@@ -125,7 +127,7 @@ abstract class RoutingTestBase {
                                  boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
@@ -137,7 +139,7 @@ abstract class RoutingTestBase {
                                                    boolean hasResponseEntity) {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
@@ -161,7 +163,7 @@ abstract class RoutingTestBase {
         try (Http1ClientResponse response = request.apply(path).request()) {
             assertThat(response.status(), is(Status.OK_200));
             assertThat(response.headers(), hasHeader(MULTI_HANDLER));
-            assertResponseEntity(response, responseMessage, hasResponseEntity);
+            assertResponseEntity(response, path, responseMessage, hasResponseEntity);
         }
     }
 
@@ -176,6 +178,7 @@ abstract class RoutingTestBase {
     }
 
     private static void assertResponseEntity(Http1ClientResponse response,
+                                             String path,
                                              String responseMessage,
                                              boolean hasResponseEntity) {
         if (hasResponseEntity) {
@@ -184,6 +187,11 @@ abstract class RoutingTestBase {
             assertThat(response.headers(),
                        hasHeader(HeaderValues.createCached(HeaderNames.create(HEAD_ROUTE_HEADER), responseMessage)));
             assertThrows(IllegalStateException.class, () -> response.as(String.class));
+            try (Http1ClientResponse getResponse = client.get(path).request()) {
+                assertThat(getResponse.status(), is(Status.OK_200));
+                byte[] getContent = getResponse.as(byte[].class);
+                assertThat(response.headers().contentLength().orElse(-1), is((long) getContent.length));
+            }
         }
     }
 

--- a/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
+++ b/webserver/tests/webserver/src/test/java/io/helidon/webserver/tests/RulesTest.java
@@ -72,7 +72,7 @@ class RulesTest extends RoutingTestBase {
                 .trace("/trace_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("trace_multi"))
                 .patch("/patch_multi", RoutingTestBase::multiHandler, (req, res) -> res.send("patch_multi"))
                 // shortcut methods with no path pattern
-                .get((req, res) -> res.send("get_catchall"))
+                .get((req, res) -> res.send(GET_CATCHALL_RESPONSE))
                 .post((req, res) -> res.send("post_catchall"))
                 .put((req, res) -> res.send("put_catchall"))
                 .delete((req, res) -> res.send("delete_catchall"))


### PR DESCRIPTION
Resolves #12546

Carry forward HTTP/2 response handling from #12532. HEAD and 304 responses preserve their metadata without exposing an entity. Empty DATA and allowed HEAD trailers are consumed through END_STREAM; forbidden content and 304 trailers fail with PROTOCOL_ERROR while preserving sibling streams and connection credit. Align HEAD routing test metadata with the corresponding GET responses.
