### PR TITLE
27.x: Change from using legacy maven archetype to helidon cli

### DIFF
--- a/docs/guides/config.md
+++ b/docs/guides/config.md
@@ -54,19 +54,18 @@ documentation.
 
 ### Create a Sample Helidon Project
 
-Use the Helidon Maven archetype to create a simple project that can be used
+Use the Helidon CLI to create a simple project that can be used
 for the examples in this guide.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 The project will be built and run from the helidon-quickstart-se directory:

--- a/docs/guides/crac.md
+++ b/docs/guides/crac.md
@@ -44,19 +44,18 @@ sdk install java 23.0.1.crac-zulu
 
 ## Generate the Project
 
-Generate the project using the Helidon Quickstart Maven archetype.
+Generate the project using the Helidon CLI.
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
-The archetype generates a Maven project in your current directory (for example,
+The CLI generates a Maven project in your current directory (for example,
 `helidon-quickstart-se`). Change into this directory and build.
 
 ```shell [Terminal]

--- a/docs/guides/dbclient.md
+++ b/docs/guides/dbclient.md
@@ -148,21 +148,20 @@ following settings should be set by default:
 Password must stay empty. Click **Connect**, the browser displays a web page.
 The database is correctly set and running.
 
-### Create a Sample Helidon Project Using Maven Archetype
+### Create a Sample Helidon Project Using the Helidon CLI
 
-Generate the project sources using the Helidon Maven archetype. The result is
+Generate the project sources using the Helidon CLI. The result is
 a simple project that can be used for the examples in this guide.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 A new directory named `helidon-quickstart-se` is created.

--- a/docs/guides/health.md
+++ b/docs/guides/health.md
@@ -43,19 +43,18 @@ export JAVA_HOME=/usr/lib/jvm/jdk-26
 
 ### Create a Sample Helidon Project
 
-Generate the project sources using the Helidon Maven archetype. The result is
+Generate the project sources using the Helidon CLI. The result is
 a simple project that can be used for the examples in this guide.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 ### Using the Built-In Health Checks

--- a/docs/guides/jlink.md
+++ b/docs/guides/jlink.md
@@ -74,19 +74,18 @@ ls $JAVA_HOME/jmods
 
 ## Generate the Project
 
-Generate the project using the Helidon Quickstart Maven archetype.
+Generate the project using the Helidon CLI.
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
-The archetype generates a Maven project in your current directory (for example,
+The CLI generates a Maven project in your current directory (for example,
 `helidon-quickstart-se`). Change into this directory and build.
 
 ```shell [Terminal]

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -42,19 +42,18 @@ export JAVA_HOME=/usr/lib/jvm/jdk-26
 
 ### Create a Sample Helidon Project
 
-Use the Helidon Maven archetype to create a simple project that can be used
+Use the Helidon CLI to create a simple project that can be used
 for the examples in this guide.
 
-Run the Maven archetype
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 ### Using the Built-In Meters

--- a/docs/guides/native-image.md
+++ b/docs/guides/native-image.md
@@ -70,19 +70,18 @@ $GRAALVM_HOME/bin/native-image --version
 
 ## Generate the Project
 
-Generate the project using the Helidon Quickstart Maven archetype.
+Generate the project using the Helidon CLI.
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
-The archetype generates a Maven project in your current directory (for example,
+The CLI generates a Maven project in your current directory (for example,
 `helidon-quickstart-se`). Change into this directory and build.
 
 ```shell [Terminal]

--- a/docs/guides/oidc.md
+++ b/docs/guides/oidc.md
@@ -236,21 +236,19 @@ open a new tab to set up Helidon.
 
 ## Setup Helidon
 
-Use the Helidon Maven archetype to create a simple project. It will be used
-as an example to show how to set up Helidon. Replace `27.0.0-SNAPSHOT` by the
-latest helidon version. It will download the quickstart project into the current
-directory.
+Use the Helidon CLI to create a simple project. It will be used as an example
+to show how to set up Helidon. The CLI creates the quickstart project in the
+current directory.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 The project will be built and run from the helidon-quickstart-se directory:

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -74,19 +74,18 @@ viewed using the Jaeger UI.
 
 ### Create a Sample Helidon Project
 
-Use the Helidon Maven archetype to create a simple project that can be used
+Use the Helidon CLI to create a simple project that can be used
 for the examples in this guide.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 The project will be built and run from the helidon-quickstart-se directory:
@@ -314,16 +313,15 @@ do the following steps, similar to what you did at the start of this guide:
 
 ### Create the Second Service
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se-2 \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se-2 \
+    --package io.helidon.examples.quickstart.se
 ```
 
 The project is in the helidon-quickstart-se-2 directory:

--- a/docs/guides/webclient.md
+++ b/docs/guides/webclient.md
@@ -72,19 +72,18 @@ Introduction](../modules/webclient.md).
 
 #### Create a sample Helidon project
 
-Generate the project sources using the Helidon Maven archetype. The result is
+Generate the project sources using the Helidon CLI. The result is
 a simple project that can be used for the examples in this guide.
 
-Run the Maven archetype:
+Run the Helidon CLI:
 
 ```shell [Terminal]
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion=27.0.0-SNAPSHOT \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
+helidon init --batch \
+    --flavor SE \
+    --archetype quickstart \
+    --groupid io.helidon.examples \
+    --artifactid helidon-quickstart-se \
+    --package io.helidon.examples.quickstart.se
 ```
 
 You should now have a directory called `helidon-quickstart-se`.


### PR DESCRIPTION
### Description

### Documentation

Changes documentation to use the helidon cli and not the maven archetype to create projects.

Related to #11347

