### PR TITLE
Fix array formatting in generated builder toString methods

### DIFF
--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/FactoryOption.java
@@ -422,6 +422,7 @@ final class FactoryOption {
         Option.Builder.build() // build method
          */
         if (actualType.equals(OBJECT)
+                || actualType.array()
                 || actualType.unboxed().primitive()
                 || actualType.generic()) {
             // cannot build these for sure

--- a/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
+++ b/builder/codegen/src/main/java/io/helidon/builder/codegen/GenerateAbstractBuilder.java
@@ -1498,25 +1498,36 @@ final class GenerateAbstractBuilder {
                 .name("toString")
                 .returnType(TypeName.create(String.class))
                 .addAnnotation(Annotations.OVERRIDE)
-                .addContent("return \"" + typeName);
+                .addContent("return ");
 
         List<OptionHandler> toStringFields = options.stream()
                 .filter(it -> it.option().includeInToString() && (isBuilder || !it.option().builderOptionOnly()))
                 .toList();
 
         if (toStringFields.isEmpty()) {
-            method.addContentLine("{};\"");
+            method.addContentLiteral(typeName + "{};")
+                    .addContentLine();
         } else {
-            method.addContentLine("{\"")
+            method.addContentLiteral(typeName + "{")
+                    .addContentLine()
                     .increaseContentPadding()
-                    .increaseContentPadding()
-                    .addContentLine(toStringFields.stream()
-                                            .map(it -> GenerateAbstractBuilder.toStringBody(it, isBuilder))
-                                            .collect(Collectors.joining(" + \",\"\n")));
+                    .increaseContentPadding();
+            Iterator<OptionHandler> fieldIterator = toStringFields.iterator();
+            while (fieldIterator.hasNext()) {
+                toStringBody(method, fieldIterator.next(), isBuilder);
+                if (fieldIterator.hasNext()) {
+                    method.addContent(" + ")
+                            .addContentLiteral(",");
+                }
+                method.addContentLine();
+            }
             if (hasSuper) {
-                method.addContentLine("+ \"};\"");
+                method.addContent("+ ")
+                        .addContentLiteral("};")
+                        .addContentLine();
             } else {
-                method.addContent("+ \"}\"");
+                method.addContent("+ ")
+                        .addContentLiteral("}");
             }
         }
         if (hasSuper) {
@@ -1526,7 +1537,7 @@ final class GenerateAbstractBuilder {
         classBuilder.addMethod(method);
     }
 
-    private static String toStringBody(OptionHandler it, boolean isBuilder) {
+    private static void toStringBody(Method.Builder method, OptionHandler it, boolean isBuilder) {
         var option = it.option();
         var typeName = it.typeHandler().type();
 
@@ -1534,19 +1545,32 @@ final class GenerateAbstractBuilder {
                 .equals(Types.CHAR_ARRAY);
 
         String name = option.name();
+        method.addContent("+ ")
+                .addContentLiteral(name + "=")
+                .addContent(" + ");
         if (secret) {
             if (typeName.primitive() && !typeName.array()) {
-                return "+ \"" + name + "=****\"";
+                method.addContentLiteral("****");
+            } else if (!isBuilder && option.declaredType().isOptional()) {
+                // builder stores fields without optional wrapper
+                method.addContent("(" + name + ".isPresent() ? ")
+                        .addContentLiteral("****")
+                        .addContent(" : ")
+                        .addContentLiteral("null")
+                        .addContent(")");
+            } else {
+                method.addContent("(" + name + " == null ? ")
+                        .addContentLiteral("null")
+                        .addContent(" : ")
+                        .addContentLiteral("****")
+                        .addContent(")");
             }
-            // builder stores fields without optional wrapper
-            if (!isBuilder && option.declaredType().isOptional()) {
-                return "+ \"" + name + "=\" + (" + name + ".isPresent() ? \"****\" : "
-                        + "\"null\")";
-            }
-            return "+ \"" + name + "=\" + (" + name + " == null ? \"null\" : "
-                    + "\"****\")";
+        } else if (option.declaredType().array()) {
+            method.addContent(Arrays.class)
+                    .addContent(".toString(" + name + ")");
+        } else {
+            method.addContent(name);
         }
-        return "+ \"" + name + "=\" + " + name;
     }
 
     private static void implMethods(InnerClass.Builder classBuilder,

--- a/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/tostring/ArrayValuesBlueprint.java
+++ b/builder/tests/builder/src/main/java/io/helidon/builder/test/testsubjects/tostring/ArrayValuesBlueprint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.test.testsubjects.tostring;
+
+import java.util.Optional;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+@Prototype.Blueprint
+interface ArrayValuesBlueprint {
+    byte[] data();
+
+    @Option.Confidential
+    byte[] secretData();
+
+    char[] secretChars();
+
+    Optional<char[]> optionalSecretChars();
+}

--- a/builder/tests/builder/src/test/java/io/helidon/builder/test/ToStringTest.java
+++ b/builder/tests/builder/src/test/java/io/helidon/builder/test/ToStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates.
+ * Copyright (c) 2024, 2026 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,52 @@
 
 package io.helidon.builder.test;
 
+import io.helidon.builder.test.testsubjects.tostring.ArrayValues;
 import io.helidon.builder.test.testsubjects.tostring.Secret;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class ToStringTest {
+    @Test
+    void testToStringWithArrays() {
+        var builder = ArrayValues.builder()
+                .data(new byte[] {1, 2, 3})
+                .secretData(new byte[] {4, 5, 6})
+                .secretChars("secret".toCharArray())
+                .optionalSecretChars("optional-secret".toCharArray());
+        var value = builder.build();
+
+        assertThat(builder.toString(),
+                   is("ArrayValuesBuilder{data=[1, 2, 3],secretData=****,secretChars=****,optionalSecretChars=****}"));
+        assertThat(value.toString(),
+                   is("ArrayValues{data=[1, 2, 3],secretData=****,secretChars=****,optionalSecretChars=****}"));
+    }
+
+    @Test
+    void testToStringWithEmptyArrays() {
+        var builder = ArrayValues.builder()
+                .data(new byte[0])
+                .secretData(new byte[0])
+                .secretChars(new char[0]);
+        var value = builder.build();
+
+        assertThat(builder.toString(),
+                   is("ArrayValuesBuilder{data=[],secretData=****,secretChars=****,optionalSecretChars=null}"));
+        assertThat(value.toString(),
+                   is("ArrayValues{data=[],secretData=****,secretChars=****,optionalSecretChars=null}"));
+    }
+
+    @Test
+    void testToStringWithUnsetArrays() {
+        assertThat(ArrayValues.builder().toString(),
+                   is("ArrayValuesBuilder{data=null,secretData=null,secretChars=null,optionalSecretChars=null}"));
+    }
+
     @Test
     void testToStringWithConfidential() {
         var builder = Secret.builder()

--- a/builder/tests/codegen/pom.xml
+++ b/builder/tests/codegen/pom.xml
@@ -85,9 +85,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/ToStringTest.java
+++ b/builder/tests/codegen/src/test/java/io/helidon/builder/codegen/ToStringTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.builder.codegen;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Stream;
+
+import io.helidon.builder.api.Prototype;
+import io.helidon.codegen.apt.AptProcessor;
+import io.helidon.codegen.testing.TestCompiler;
+import io.helidon.common.Builder;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.helidon.codegen.testing.CodegenMatchers.matches;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ToStringTest {
+    static Stream<Arguments> arrayCases() {
+        return Stream.of(Arguments.of("byte", "Arrays.toString(data)"),
+                         Arguments.of("short", "Arrays.toString(data)"),
+                         Arguments.of("int", "Arrays.toString(data)"),
+                         Arguments.of("long", "Arrays.toString(data)"),
+                         Arguments.of("float", "Arrays.toString(data)"),
+                         Arguments.of("double", "Arrays.toString(data)"),
+                         Arguments.of("boolean", "Arrays.toString(data)"),
+                         Arguments.of("char", "(data == null ? \"null\" : \"****\")"),
+                         Arguments.of("String", "Arrays.toString(data)"),
+                         Arguments.of("Object", "Arrays.toString(data)"));
+    }
+
+    @ParameterizedTest(name = "{0}[]")
+    @MethodSource("arrayCases")
+    void testGeneratedSource(String type, String expectedExpression) throws IOException {
+        var result = TestCompiler.builder()
+                .currentRelease()
+                .addClasspath(List.of(Prototype.class, Builder.class))
+                .addProcessor(AptProcessor::new)
+                .addSource("PayloadBlueprint.java", """
+                        package example;
+
+                        import io.helidon.builder.api.Prototype;
+
+                        @Prototype.Blueprint
+                        interface PayloadBlueprint {
+                            %s[] data();
+                        }
+
+                        """.formatted(type))
+                .build()
+                .compile();
+        assertThat(result.diagnostics().toString(), result.success(), is(true));
+
+        var generatedSource = result.sourceOutput().resolve("example/Payload.java");
+        assertThat(Files.exists(generatedSource), is(true));
+        assertThat(Files.readString(generatedSource), matches("""
+                //...
+                        public String toString() {
+                            return "PayloadBuilder{"
+                                    + "data=" + %s
+                                    + "}";
+                        }
+                //...
+                            public String toString() {
+                                return "Payload{"
+                                        + "data=" + %s
+                                        + "}";
+                            }
+                //...
+                """.formatted(expectedExpression, expectedExpression)));
+    }
+}


### PR DESCRIPTION
### Description

Fixes #12551

Format array properties with `Arrays.toString` in generated builders and prototype implementations, preserving confidential and character-array masking. Use addContentLiteral for generated string literals and skip builder factory discovery for array types.

Add regression tests for populated, empty, and unset arrays, including integration tests that compile blueprints for all primitive array types and reference arrays and verify their generated output.

### Documentation

No changes
